### PR TITLE
Adding simple LaTeX template framework.

### DIFF
--- a/ieee/IEEEabrv.bib
+++ b/ieee/IEEEabrv.bib
@@ -1,0 +1,447 @@
+
+IEEEabrv.bib
+V1.12 (2007/01/11)
+Copyright (c) 2002-2007 by Michael Shell
+See: http://www.michaelshell.org/
+for current contact information.
+
+BibTeX bibliography string definitions of the ABBREVIATED titles of
+IEEE journals and magazines and online publications.
+
+This file is designed for bibliography styles that require 
+abbreviated titles and is not for use in bibliographies that
+require full-length titles.
+
+Support sites:
+http://www.michaelshell.org/tex/ieeetran/
+http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+and/or
+http://www.ieee.org/
+
+Special thanks to Laura Hyslop and ken Rawson of IEEE for their help
+in obtaining the information needed to compile this file. Also,
+Volker Kuhlmann and Moritz Borgmann kindly provided some corrections
+and additions.
+
+*************************************************************************
+Legal Notice:
+This code is offered as-is without any warranty either expressed or
+implied; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE! 
+User assumes all risk.
+In no event shall IEEE or any contributor to this code be liable for
+any damages or losses, including, but not limited to, incidental,
+consequential, or any other damages, resulting from the use or misuse
+of any information contained here.
+
+All comments are the opinions of their respective authors and are not
+necessarily endorsed by the IEEE.
+
+This work is distributed under the LaTeX Project Public License (LPPL)
+( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+distributed and modified. A copy of the LPPL, version 1.3, is included
+in the base LaTeX documentation of all distributions of LaTeX released
+2003/12/01 or later.
+Retain all contribution notices and credits.
+** Modified files should be clearly indicated as such, including  **
+** renaming them and changing author support contact information. **
+
+File list of work: IEEEabrv.bib, IEEEfull.bib, IEEEexample.bib,
+                   IEEEtran.bst, IEEEtranS.bst, IEEEtranSA.bst,
+                   IEEEtranN.bst, IEEEtranSN.bst, IEEEtran_bst_HOWTO.pdf
+*************************************************************************
+
+
+USAGE:
+
+\bibliographystyle{mybstfile}
+\bibliography{IEEEabrv,mybibfile}
+
+where the IEEE titles in the .bib database entries use the strings
+defined here. e.g.,
+
+
+   journal = IEEE_J_AC,
+
+
+to yield "{IEEE} Trans. Automat. Contr."
+
+
+IEEE uses abbreviated journal titles in their bibliographies -
+this file is suitable for work that is to be submitted to the IEEE.
+
+
+For work that requires full-length titles, you should use the full
+titles provided in the companion file, IEEEfull.bib.
+
+
+** NOTES **
+
+ 1. Journals have been grouped according to subject in order to make it
+    easier to locate and extract the definitions for related journals - 
+    as most works use references that are confined to a single topic.
+    Magazines are listed in straight alphabetical order.
+
+ 2. String names are closely based on IEEE's own internal acronyms.
+ 
+ 3. Abbreviations follow IEEE's style.
+
+ 4. Older, out-of-print IEEE titles are included (but not including titles
+    dating prior to IEEE's formation from the IRE and AIEE in 1963).
+
+ 5. The following NEW/current journal definitions have been disabled because
+    their abbreviations have not yet been verified:
+    
+    STRING{IEEE_J_CBB        = "{IEEE/ACM} Trans. Comput. Biology Bioinformatics"}
+    STRING{IEEE_J_CJECE      = "Canadian J. Elect. Comput. Eng."}
+    STRING{IEEE_J_DSC        = "{IEEE} Trans. Dependable Secure Comput."}
+    STRING{IEEE_O_DSO        = "{IEEE} Distrib. Syst. Online"}
+    
+ 6. The following OLD journal definitions have been disabled because
+    their abbreviations have not yet been found/verified:
+
+    STRING{IEEE_J_BCTV       = "{IEEE} Trans. Broadcast Television Receivers"}
+    STRING{IEEE_J_EWS        = "{IEEE} Trans. Eng. Writing Speech"}
+
+If you know what the proper abbreviation is for a string in #5 or #6 above,
+email me and I will correct them in the next release.
+
+
+
+
+
+IEEE Journals 
+
+
+
+aerospace and military
+@STRING{IEEE_J_AES        = "{IEEE} Trans. Aerosp. Electron. Syst."}
+@STRING{IEEE_J_ANE        = "{IEEE} Trans. Aerosp. Navig. Electron."}
+@STRING{IEEE_J_ANNE       = "{IEEE} Trans. Aeronaut. Navig. Electron."}
+@STRING{IEEE_J_AS         = "{IEEE} Trans. Aerosp."}
+@STRING{IEEE_J_AIRE       = "{IEEE} Trans. Airborne Electron."}
+@STRING{IEEE_J_MIL        = "{IEEE} Trans. Mil. Electron."}
+
+
+
+autos, transportation and vehicles (non-aerospace)
+@STRING{IEEE_J_ITS        = "{IEEE} Trans. Intell. Transp. Syst."}
+@STRING{IEEE_J_VT         = "{IEEE} Trans. Veh. Technol."}
+@STRING{IEEE_J_VC         = "{IEEE} Trans. Veh. Commun."}
+
+
+
+circuits, signals, systems, audio and controls
+@STRING{IEEE_J_SPL        = "{IEEE} Signal Process. Lett."}
+@STRING{IEEE_J_ASSP       = "{IEEE} Trans. Acoust., Speech, Signal Process."}
+@STRING{IEEE_J_AU         = "{IEEE} Trans. Audio"}
+@STRING{IEEE_J_AUEA       = "{IEEE} Trans. Audio Electroacoust."}
+@STRING{IEEE_J_AC         = "{IEEE} Trans. Autom. Control"}
+@STRING{IEEE_J_CAS        = "{IEEE} Trans. Circuits Syst."}
+@STRING{IEEE_J_CASVT      = "{IEEE} Trans. Circuits Syst. Video Technol."}
+@STRING{IEEE_J_CASI       = "{IEEE} Trans. Circuits Syst. {I}"}
+@STRING{IEEE_J_CASII      = "{IEEE} Trans. Circuits Syst. {II}"}
+in 2004 CASI and CASII renamed part title to CASI_RP and CASII_EB, respectively.
+@STRING{IEEE_J_CASI_RP    = "{IEEE} Trans. Circuits Syst. {I}"}
+@STRING{IEEE_J_CASII_EB   = "{IEEE} Trans. Circuits Syst. {II}"}
+@STRING{IEEE_J_CT         = "{IEEE} Trans. Circuit Theory"}
+@STRING{IEEE_J_CST        = "{IEEE} Trans. Control Syst. Technol."}
+@STRING{IEEE_J_SP         = "{IEEE} Trans. Signal Process."}
+@STRING{IEEE_J_SU         = "{IEEE} Trans. Sonics Ultrason."}
+@STRING{IEEE_J_SAP        = "{IEEE} Trans. Speech Audio Process."}
+@STRING{IEEE_J_UE         = "{IEEE} Trans. Ultrason. Eng."}
+@STRING{IEEE_J_UFFC       = "{IEEE} Trans. Ultrason., Ferroelectr., Freq. Control"}
+
+
+
+communications
+@STRING{IEEE_J_COML       = "{IEEE} Commun. Lett."}
+@STRING{IEEE_J_JSAC       = "{IEEE} J. Sel. Areas Commun."}
+@STRING{IEEE_J_COM        = "{IEEE} Trans. Commun."}
+@STRING{IEEE_J_COMT       = "{IEEE} Trans. Commun. Technol."}
+@STRING{IEEE_J_WCOM       = "{IEEE} Trans. Wireless Commun."}
+
+
+
+components, packaging and manufacturing
+@STRING{IEEE_J_ADVP       = "{IEEE} Trans. Adv. Packag."}
+@STRING{IEEE_J_CHMT       = "{IEEE} Trans. Compon., Hybrids, Manuf. Technol."}
+@STRING{IEEE_J_CPMTA      = "{IEEE} Trans. Compon., Packag., Manuf. Technol. {A}"}
+@STRING{IEEE_J_CPMTB      = "{IEEE} Trans. Compon., Packag., Manuf. Technol. {B}"}
+@STRING{IEEE_J_CPMTC      = "{IEEE} Trans. Compon., Packag., Manuf. Technol. {C}"}
+@STRING{IEEE_J_CAPT       = "{IEEE} Trans. Compon. Packag. Technol."}
+@STRING{IEEE_J_CAPTS      = "{IEEE} Trans. Compon. Packag. Technol."}
+@STRING{IEEE_J_CPART      = "{IEEE} Trans. Compon. Parts"}
+@STRING{IEEE_J_EPM        = "{IEEE} Trans. Electron. Packag. Manuf."}
+@STRING{IEEE_J_MFT        = "{IEEE} Trans. Manuf. Technol."}
+@STRING{IEEE_J_PHP        = "{IEEE} Trans. Parts, Hybrids, Packag."}
+@STRING{IEEE_J_PMP        = "{IEEE} Trans. Parts, Mater., Packag."}
+
+
+
+CAD
+@STRING{IEEE_J_TCAD       = "{IEEE} J. Technol. Comput. Aided Design"}
+@STRING{IEEE_J_CAD        = "{IEEE} Trans. Comput.-Aided Design Integr. Circuits Syst."}
+
+
+
+coding, data, information, knowledge
+@STRING{IEEE_J_IT         = "{IEEE} Trans. Inf. Theory"}
+@STRING{IEEE_J_KDE        = "{IEEE} Trans. Knowl. Data Eng."}
+
+
+
+computers, computation, networking and software
+@STRING{IEEE_J_C          = "{IEEE} Trans. Comput."}
+@STRING{IEEE_J_CAL        = "{IEEE} Comput. Archit. Lett."}
+disabled till definition is verified
+STRING{IEEE_J_DSC         = "{IEEE} Trans. Dependable Secure Comput."}
+@STRING{IEEE_J_ECOMP      = "{IEEE} Trans. Electron. Comput."}
+@STRING{IEEE_J_EVC        = "{IEEE} Trans. Evol. Comput."}
+@STRING{IEEE_J_FUZZ       = "{IEEE} Trans. Fuzzy Syst."}
+@STRING{IEEE_J_IFS        = "{IEEE} Trans. Inf. Forensics Security"}
+@STRING{IEEE_J_MC         = "{IEEE} Trans. Mobile Comput."}
+@STRING{IEEE_J_NET        = "{IEEE/ACM} Trans. Netw."}
+@STRING{IEEE_J_NN         = "{IEEE} Trans. Neural Netw."}
+@STRING{IEEE_J_PDS        = "{IEEE} Trans. Parallel Distrib. Syst."}
+@STRING{IEEE_J_SE         = "{IEEE} Trans. Softw. Eng."}
+
+
+
+computer graphics, imaging, and multimedia
+@STRING{IEEE_J_JDT        = "{IEEE/OSA} J. Display Technol."}
+@STRING{IEEE_J_IP         = "{IEEE} Trans. Image Process."}
+@STRING{IEEE_J_MM         = "{IEEE} Trans. Multimedia"}
+@STRING{IEEE_J_VCG        = "{IEEE} Trans. Vis. Comput. Graphics"}
+
+
+
+cybernetics, ergonomics, robots, man-machine, and automation
+@STRING{IEEE_J_ASE        = "{IEEE} Trans. Autom. Sci. Eng."}
+@STRING{IEEE_J_JRA        = "{IEEE} J. Robot. Autom."}
+@STRING{IEEE_J_HFE        = "{IEEE} Trans. Hum. Factors Electron."}
+@STRING{IEEE_J_MMS        = "{IEEE} Trans. Man-Mach. Syst."}
+@STRING{IEEE_J_PAMI       = "{IEEE} Trans. Pattern Anal. Mach. Intell."}
+in 1989 JRA became RA
+in August 2004, RA split into ASE and RO
+@STRING{IEEE_J_RA         = "{IEEE} Trans. Robot. Autom."}
+@STRING{IEEE_J_RO         = "{IEEE} Trans. Robot."}
+@STRING{IEEE_J_SMC        = "{IEEE} Trans. Syst., Man, Cybern."}
+@STRING{IEEE_J_SMCA       = "{IEEE} Trans. Syst., Man, Cybern. {A}"}
+@STRING{IEEE_J_SMCB       = "{IEEE} Trans. Syst., Man, Cybern. {B}"}
+@STRING{IEEE_J_SMCC       = "{IEEE} Trans. Syst., Man, Cybern. {C}"}
+@STRING{IEEE_J_SSC        = "{IEEE} Trans. Syst. Sci. Cybern."}
+
+
+
+earth, wind, fire and water
+@STRING{IEEE_J_GE         = "{IEEE} Trans. Geosci. Electron."}
+@STRING{IEEE_J_GRS        = "{IEEE} Trans. Geosci. Remote Sens."}
+@STRING{IEEE_J_GRSL       = "{IEEE} Geosci. Remote Sens. Lett."}
+@STRING{IEEE_J_OE         = "{IEEE} J. Ocean. Eng."}
+
+
+
+education, engineering, history, IEEE, professional
+disabled till definition is verified
+STRING{IEEE_J_CJECE       = "Canadian J. Elect. Comput. Eng."}
+@STRING{IEEE_J_PROC       = "Proc. {IEEE}"}
+@STRING{IEEE_J_EDU        = "{IEEE} Trans. Educ."}
+@STRING{IEEE_J_EM         = "{IEEE} Trans. Eng. Manag."}
+disabled till definition is verified
+STRING{IEEE_J_EWS         = "{IEEE} Trans. Eng. Writing Speech"}
+@STRING{IEEE_J_PC         = "{IEEE} Trans. Prof. Commun."}
+
+
+
+electromagnetics, antennas, EMI, magnetics and microwave
+@STRING{IEEE_J_AWPL       = "{IEEE} Antennas Wireless Propag. Lett."}
+@STRING{IEEE_J_MGWL       = "{IEEE} Microw. Guided Wave Lett."}
+IEEE seems to want "Compon." here, not "Comp."
+@STRING{IEEE_J_MWCL       = "{IEEE} Microw. Wireless Compon. Lett."}
+@STRING{IEEE_J_AP         = "{IEEE} Trans. Antennas Propag."}
+@STRING{IEEE_J_EMC        = "{IEEE} Trans. Electromagn. Compat."}
+@STRING{IEEE_J_MAG        = "{IEEE} Trans. Magn."}
+@STRING{IEEE_J_MTT        = "{IEEE} Trans. Microw. Theory Tech."}
+@STRING{IEEE_J_RFI        = "{IEEE} Trans. Radio Freq. Interference"}
+@STRING{IEEE_J_TJMJ       = "{IEEE} Transl. J. Magn. Jpn."}
+
+
+
+energy and power
+@STRING{IEEE_J_EC         = "{IEEE} Trans. Energy Convers."}
+@STRING{IEEE_J_PEL        = "{IEEE} Power Electron. Lett."}
+@STRING{IEEE_J_PWRAS      = "{IEEE} Trans. Power App. Syst."}
+@STRING{IEEE_J_PWRD       = "{IEEE} Trans. Power Del."}
+@STRING{IEEE_J_PWRE       = "{IEEE} Trans. Power Electron."}
+@STRING{IEEE_J_PWRS       = "{IEEE} Trans. Power Syst."}
+
+
+
+industrial, commercial and consumer
+@STRING{IEEE_J_APPIND     = "{IEEE} Trans. Appl. Ind."}
+@STRING{IEEE_J_BC         = "{IEEE} Trans. Broadcast."}
+disabled till definition is verified
+STRING{IEEE_J_BCTV        = "{IEEE} Trans. Broadcast Television Receivers"}
+@STRING{IEEE_J_CE         = "{IEEE} Trans. Consum. Electron."}
+@STRING{IEEE_J_IE         = "{IEEE} Trans. Ind. Electron."}
+@STRING{IEEE_J_IECI       = "{IEEE} Trans. Ind. Electron. Contr. Instrum."}
+@STRING{IEEE_J_IA         = "{IEEE} Trans. Ind. Appl."}
+@STRING{IEEE_J_IGA        = "{IEEE} Trans. Ind. Gen. Appl."}
+@STRING{IEEE_J_IINF       = "{IEEE} Trans. Ind. Informat."}
+@STRING{IEEE_J_PSE        = "{IEEE} J. Product Safety Eng."}
+
+
+
+instrumentation and measurement
+@STRING{IEEE_J_IM         = "{IEEE} Trans. Instrum. Meas."}
+
+
+
+insulation and materials
+@STRING{IEEE_J_JEM        = "{IEEE/TMS} J. Electron. Mater."}
+@STRING{IEEE_J_DEI        = "{IEEE} Trans. Dielectr. Electr. Insul."}
+@STRING{IEEE_J_EI         = "{IEEE} Trans. Electr. Insul."}
+
+
+
+mechanical
+@STRING{IEEE_J_MECH       = "{IEEE/ASME} Trans. Mechatronics"}
+@STRING{IEEE_J_MEMS       = "J. Microelectromech. Syst."}
+
+
+
+medical and biological
+@STRING{IEEE_J_BME        = "{IEEE} Trans. Biomed. Eng."}
+Note: The B-ME journal later dropped the hyphen and became the BME.
+@STRING{IEEE_J_B-ME       = "{IEEE} Trans. Bio-Med. Eng."}
+@STRING{IEEE_J_BMELC      = "{IEEE} Trans. Bio-Med. Electron."}
+disabled till definition is verified
+STRING{IEEE_J_CBB         = "{IEEE/ACM} Trans. Comput. Biology Bioinformatics"}
+@STRING{IEEE_J_ITBM       = "{IEEE} Trans. Inf. Technol. Biomed."}
+@STRING{IEEE_J_ME         = "{IEEE} Trans. Med. Electron."}
+@STRING{IEEE_J_MI         = "{IEEE} Trans. Med. Imag."}
+@STRING{IEEE_J_NB         = "{IEEE} Trans. Nanobiosci."}
+@STRING{IEEE_J_NSRE       = "{IEEE} Trans. Neural Syst. Rehabil. Eng."}
+@STRING{IEEE_J_RE         = "{IEEE} Trans. Rehabil. Eng."}
+
+
+
+ optics, lightwave and photonics
+@STRING{IEEE_J_PTL        = "{IEEE} Photon. Technol. Lett."}
+@STRING{IEEE_J_JLT        = "J. Lightw. Technol."}
+
+
+
+physics, electrons, nanotechnology, nuclear and quantum electronics
+@STRING{IEEE_J_EDL        = "{IEEE} Electron Device Lett."}
+@STRING{IEEE_J_JQE        = "{IEEE} J. Quantum Electron."}
+@STRING{IEEE_J_JSTQE      = "{IEEE} J. Sel. Topics Quantum Electron."}
+@STRING{IEEE_J_ED         = "{IEEE} Trans. Electron Devices"}
+@STRING{IEEE_J_NANO       = "{IEEE} Trans. Nanotechnol."}
+@STRING{IEEE_J_NS         = "{IEEE} Trans. Nucl. Sci."}
+@STRING{IEEE_J_PS         = "{IEEE} Trans. Plasma Sci."}
+
+
+
+reliability
+IEEE seems to want "Mat." here, not "Mater."
+@STRING{IEEE_J_DMR        = "{IEEE} Trans. Device Mater. Rel."}
+@STRING{IEEE_J_R          = "{IEEE} Trans. Rel."}
+
+
+
+semiconductors, superconductors, electrochemical and solid state
+@STRING{IEEE_J_ESSL       = "{IEEE/ECS} Electrochem. Solid-State Lett."}
+@STRING{IEEE_J_JSSC       = "{IEEE} J. Solid-State Circuits"}
+@STRING{IEEE_J_ASC        = "{IEEE} Trans. Appl. Supercond."}
+@STRING{IEEE_J_SM         = "{IEEE} Trans. Semicond. Manuf."}
+
+
+
+sensors
+@STRING{IEEE_J_SENSOR     = "{IEEE} Sensors J."}
+
+
+
+VLSI
+@STRING{IEEE_J_VLSI       = "{IEEE} Trans. {VLSI} Syst."}
+
+
+
+
+
+
+IEEE Magazines 
+
+
+
+@STRING{IEEE_M_AES        = "{IEEE} Aerosp. Electron. Syst. Mag."}
+@STRING{IEEE_M_HIST       = "{IEEE} Ann. Hist. Comput."}
+@STRING{IEEE_M_AP         = "{IEEE} Antennas Propag. Mag."}
+@STRING{IEEE_M_ASSP       = "{IEEE} {ASSP} Mag."}
+@STRING{IEEE_M_CD         = "{IEEE} Circuits Devices Mag."}
+@STRING{IEEE_M_CAS        = "{IEEE} Circuits Syst. Mag."}
+@STRING{IEEE_M_COM        = "{IEEE} Commun. Mag."}
+@STRING{IEEE_M_COMSOC     = "{IEEE} Commun. Soc. Mag."}
+@STRING{IEEE_M_CIM        = "{IEEE} Comput. Intell. Mag."}
+CSEM changed to CSE in 1999
+@STRING{IEEE_M_CSE        = "{IEEE} Comput. Sci. Eng."}
+@STRING{IEEE_M_CSEM       = "{IEEE} Comput. Sci. Eng. Mag."}
+@STRING{IEEE_M_C          = "{IEEE} Computer"}
+@STRING{IEEE_M_CAP        = "{IEEE} Comput. Appl. Power"}
+@STRING{IEEE_M_CGA        = "{IEEE} Comput. Graph. Appl."}
+@STRING{IEEE_M_CONC       = "{IEEE} Concurrency"}
+@STRING{IEEE_M_CS         = "{IEEE} Control Syst. Mag."}
+@STRING{IEEE_M_DTC        = "{IEEE} Des. Test. Comput."}
+@STRING{IEEE_M_EI         = "{IEEE} Electr. Insul. Mag."}
+@STRING{IEEE_M_ETR        = "{IEEE} ElectroTechnol. Rev."}
+@STRING{IEEE_M_EMB        = "{IEEE} Eng. Med. Biol. Mag."}
+@STRING{IEEE_M_EMR        = "{IEEE} Eng. Manag. Rev."}
+@STRING{IEEE_M_EXP        = "{IEEE} Expert"}
+@STRING{IEEE_M_IA         = "{IEEE} Ind. Appl. Mag."}
+@STRING{IEEE_M_IM         = "{IEEE} Instrum. Meas. Mag."}
+@STRING{IEEE_M_IS         = "{IEEE} Intell. Syst."}
+@STRING{IEEE_M_IC         = "{IEEE} Internet Comput."}
+@STRING{IEEE_M_ITP        = "{IEEE} {IT} Prof."}
+@STRING{IEEE_M_MICRO      = "{IEEE} Micro"}
+@STRING{IEEE_M_MW         = "{IEEE} Microw. Mag."}
+@STRING{IEEE_M_MM         = "{IEEE} Multimedia"}
+@STRING{IEEE_M_NET        = "{IEEE} Netw."}
+IEEE's editorial manual lists "Pers. Commun.", 
+but "Personal Commun. Mag." seems to be what is used in the journals
+@STRING{IEEE_M_PCOM       = "{IEEE} Personal Commun. Mag."}
+@STRING{IEEE_M_POT        = "{IEEE} Potentials"}
+CAP and PER merged to form PE in 2003
+@STRING{IEEE_M_PE         = "{IEEE} Power Energy Mag."}
+@STRING{IEEE_M_PER        = "{IEEE} Power Eng. Rev."}
+@STRING{IEEE_M_PVC        = "{IEEE} Pervasive Comput."}
+@STRING{IEEE_M_RA         = "{IEEE} Robot. Autom. Mag."}
+@STRING{IEEE_M_SAP        = "{IEEE} Security Privacy"}
+@STRING{IEEE_M_SP         = "{IEEE} Signal Process. Mag."}
+@STRING{IEEE_M_S          = "{IEEE} Softw."}
+@STRING{IEEE_M_SPECT      = "{IEEE} Spectr."}
+@STRING{IEEE_M_TS         = "{IEEE} Technol. Soc. Mag."}
+@STRING{IEEE_M_VT         = "{IEEE} Veh. Technol. Mag."}
+@STRING{IEEE_M_WC         = "{IEEE} Wireless Commun. Mag."}
+@STRING{IEEE_M_TODAY      = "Today's Engineer"}
+
+
+
+
+
+
+IEEE Online Publications 
+
+
+
+@STRING{IEEE_O_CSTO        = "{IEEE} Commun. Surveys Tuts."}
+disabled till definition is verified
+STRING{IEEE_O_DSO          = "{IEEE} Distrib. Syst. Online"}
+
+
+
+
+
+--
+EOF

--- a/ieee/IEEEannot.bst
+++ b/ieee/IEEEannot.bst
@@ -1,0 +1,2626 @@
+%%
+%% IEEEannot.bst
+%% BibTeX Bibliography Style file
+%% Sorting version of IEEEtran.bst
+%% *** Not for use with work to be submitted to the IEEE ***
+%% Version 1.11 (2003/04/02)
+%% 
+%% Copyright (c) 2003 Michael Shell
+%%
+%% Modified by Titus Barik (titus@barik.net) to support annotated
+%% bibliographies in IEEE citation format. Renamed to IEEEannot.bst. 
+%% The latest version of IEEEannot can always be downloaded at:
+%%
+%%		http://www.barik.net/sw/ieee/
+%%
+%% This version of IEEEannot is: 2004-15-02
+%% 
+%% Original starting code base and algorithms obtained from the output of
+%% Patrick W. Daly's makebst package as well as from prior versions of
+%% IEEE BibTeX styles:
+%% 
+%% 1. Howard Trickey and Oren Patashnik's ieeetr.bst  (1985/1988)
+%% 2. Silvano Balemi and Richard H. Roy's IEEEbib.bst (1993)
+%% 
+%% Added sorting code is from plain.bst.
+%% 
+%% See:
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/supported/IEEEtran/
+%% for latest version and current contact information.
+%% 
+%% For use with BibTeX version 0.99a or later
+%%
+%% This is a numerical citation style.
+%% 
+%%**********************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE!
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% This code is distributed under the Perl Artistic License 
+%% ( http://language.perl.com/misc/Artistic.html ) 
+%% and may be freely used, distributed and modified - subject to the
+%% constraints therein.
+%% Retain all contribution notices, credits and disclaimers.
+%% 
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%**********************************************************************
+%
+%
+% Changelog:
+% 
+% 1.10 (2002/09/27) Initial release
+%
+% 1.11 (2003/04/02)
+%  1. Fixed bug with URLs containing underscores when using url.sty. Thanks
+%     to Ming Kin Lai for reporting this.
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% DEFAULTS FOR THE CONTROLS OF THE BST STYLE %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% These are the defaults for the user adjustable controls. The values used
+% here can be overridden by the user via IEEEtranBSTCTL entry type.
+
+% NOTE: The recommended LaTeX command to invoke a control entry type is:
+% 
+%\makeatletter
+%\def\bstctlcite#1{\@bsphack
+%  \@for\@citeb:=#1\do{%
+%    \edef\@citeb{\expandafter\@firstofone\@citeb}%
+%    \if@filesw\immediate\write\@auxout{\string\citation{\@citeb}}\fi}%
+%  \@esphack}
+%\makeatother
+%
+% It is called at the start of the document, before the first \cite, like:
+% \bstctlcite{IEEEexample:BSTcontrol}
+%
+% IEEEtran.cls V1.6 and later does provide this command.
+
+
+
+% #0 turns off the display of the number for articles.
+% #1 enables
+FUNCTION {default.is.use.number.for.article} { #1 }
+
+
+% #0 turns off the display of the paper and type fields in @inproceedings.
+% #1 enables
+FUNCTION {default.is.use.paper} { #1 }
+
+
+% #0 turns off the forced use of "et al."
+% #1 enables
+FUNCTION {default.is.forced.et.al} { #0 }
+
+% The maximum number of names that can be present beyond which an "et al."
+% usage is forced. Be sure that num.names.shown.with.forced.et.al (below)
+% is not greater than this value!
+% Note: There are many instances of references in IEEE journals which have
+% a very large number of authors as well as instances in which "et al." is
+% used profusely.
+FUNCTION {default.max.num.names.before.forced.et.al} { #10 }
+
+% The number of names that will be shown with a forced "et al.".
+% Must be less than or equal to max.num.names.before.forced.et.al
+FUNCTION {default.num.names.shown.with.forced.et.al} { #1 }
+
+
+% #0 turns off the alternate interword spacing for entries with URLs.
+% #1 enables
+FUNCTION {default.is.use.alt.interword.spacing} { #1 }
+
+% If alternate interword spacing for entries with URLs is enabled, this is
+% the interword spacing stretch factor that will be used. For example, the
+% default "4" here means that the interword spacing in entries with URLs can
+% stretch to four times normal. Does not have to be an integer. Note that
+% the value specified here can be overridden by the user in their LaTeX
+% code via a command such as: 
+% "\providecommand\BIBentryALTinterwordstretchfactor{1.5}" in addition to
+% that via the IEEEtranBSTCTL entry type.
+FUNCTION {default.ALTinterwordstretchfactor} { "4" }
+
+
+% #0 turns off the "dashification" of repeated (i.e., identical to those
+% of the previous entry) names. IEEE normally does this.
+% #1 enables
+FUNCTION {default.is.dash.repeated.names} { #1 }
+
+
+% The default name format control string.
+FUNCTION {default.name.format.string}{ "{f.~}{vv~}{ll}{, jj}" }
+
+
+% The default LaTeX font command for the names.
+FUNCTION {default.name.latex.cmd}{ "" }
+
+
+% Other controls that cannot be accessed via IEEEtranBSTCTL entry type.
+
+% #0 turns off the terminal startup banner/completed message so as to
+% operate more quietly.
+% #1 enables
+FUNCTION {is.print.banners.to.terminal} { #1 }
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% FILE VERSION AND BANNER %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION{bst.file.version} { "1.11" }
+FUNCTION{bst.file.date} { "2003/04/02" }
+FUNCTION{bst.file.website} { "http://www.ctan.org/tex-archive/macros/latex/contrib/supported/IEEEtran/" }
+
+FUNCTION {banner.message}
+{ is.print.banners.to.terminal
+     { "-- IEEEtranS.bst version" " " * bst.file.version *
+       " (" * bst.file.date * ") " * "by Michael Shell." *
+       top$
+       "-- " bst.file.website *
+       top$
+       "-- See the " quote$ * "IEEEtran_bst_HOWTO.pdf" * quote$ * " manual for usage information." *
+       top$
+       "** Sorting version - not for use with work to be submitted to the IEEE."
+       top$
+     }
+     { skip$ }
+   if$
+}
+
+FUNCTION {completed.message}
+{ is.print.banners.to.terminal
+     { ""
+       top$
+       "Done."
+       top$
+     }
+     { skip$ }
+   if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% STRING CONSTANTS %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {bbl.and}{ "and" }
+FUNCTION {bbl.etal}{ "et~al." }
+FUNCTION {bbl.editors}{ "eds." }
+FUNCTION {bbl.editor}{ "ed." }
+FUNCTION {bbl.edition}{ "ed." }
+FUNCTION {bbl.volume}{ "vol." }
+FUNCTION {bbl.of}{ "of" }
+FUNCTION {bbl.number}{ "no." }
+FUNCTION {bbl.in}{ "in" }
+FUNCTION {bbl.pages}{ "pp." }
+FUNCTION {bbl.page}{ "p." }
+FUNCTION {bbl.chapter}{ "ch." }
+FUNCTION {bbl.paper}{ "paper" }
+FUNCTION {bbl.part}{ "pt." }
+FUNCTION {bbl.patent}{ "Patent" }
+FUNCTION {bbl.patentUS}{ "U.S." }
+FUNCTION {bbl.revision}{ "Rev." }
+FUNCTION {bbl.series}{ "ser." }
+FUNCTION {bbl.standard}{ "Std." }
+FUNCTION {bbl.techrep}{ "Tech. Rep." }
+FUNCTION {bbl.mthesis}{ "Master's thesis" }
+FUNCTION {bbl.phdthesis}{ "Ph.D. dissertation" }
+FUNCTION {bbl.urlprefix}{ "[Online]. Available:" }
+FUNCTION {bbl.st}{ "st" }
+FUNCTION {bbl.nd}{ "nd" }
+FUNCTION {bbl.rd}{ "rd" }
+FUNCTION {bbl.th}{ "th" }
+
+
+% This is the LaTeX spacer that is used when a larger than normal space
+% is called for (such as just before the address:publisher).
+FUNCTION {large.space} { "\hskip 1em plus 0.5em minus 0.4em\relax " }
+
+% The LaTeX code for dashes that are used to represent repeated names.
+% Note: Some older IEEE journals used something like
+% "\rule{0.275in}{0.5pt}\," which is fairly thick and runs right along
+% the baseline. However, IEEE now uses a thinner, above baseline,
+% six dash long sequence.
+FUNCTION {repeated.name.dashes} { "------" }
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% PREDEFINED STRING MACROS %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+MACRO {jan} {"Jan."}
+MACRO {feb} {"Feb."}
+MACRO {mar} {"Mar."}
+MACRO {apr} {"Apr."}
+MACRO {may} {"May"}
+MACRO {jun} {"June"}
+MACRO {jul} {"July"}
+MACRO {aug} {"Aug."}
+MACRO {sep} {"Sept."}
+MACRO {oct} {"Oct."}
+MACRO {nov} {"Nov."}
+MACRO {dec} {"Dec."}
+
+
+
+%%%%%%%%%%%%%%%%%%
+%% ENTRY FIELDS %%
+%%%%%%%%%%%%%%%%%%
+
+ENTRY
+  { 
+  	address
+	annote
+    assignee
+    author
+    booktitle
+    chapter
+    day
+    dayfiled
+    edition
+    editor
+    howpublished
+    institution
+    intype
+    journal
+    key
+    language
+    month
+    monthfiled
+    nationality
+    note
+    number
+    organization
+    pages
+    paper
+    publisher
+    school
+    series
+    revision
+    title
+    type
+    url
+    volume
+    year
+    yearfiled
+    CTLuse_article_number
+    CTLuse_paper
+    CTLuse_forced_etal
+    CTLmax_names_forced_etal
+    CTLnames_show_etal
+    CTLuse_alt_spacing
+    CTLalt_stretch_factor
+    CTLdash_repeated_names
+    CTLname_format_string
+    CTLname_latex_cmd
+  }
+  {}
+  { label }
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%
+%% INTEGER VARIABLES %%
+%%%%%%%%%%%%%%%%%%%%%%%
+
+INTEGERS { prev.status.punct this.status.punct punct.std
+           punct.no punct.comma punct.period 
+           prev.status.space this.status.space space.std
+           space.no space.normal space.large
+           prev.status.quote this.status.quote quote.std
+           quote.no quote.close
+           prev.status.nline this.status.nline nline.std
+           nline.no nline.newblock 
+           status.cap cap.std
+           cap.no cap.yes}
+
+INTEGERS { longest.label.width multiresult nameptr namesleft number.label numnames }
+
+INTEGERS { is.use.number.for.article
+           is.use.paper
+           is.forced.et.al
+           max.num.names.before.forced.et.al
+           num.names.shown.with.forced.et.al
+           is.use.alt.interword.spacing
+           is.dash.repeated.names}
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% STRING VARIABLES %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+STRINGS { bibinfo
+          longest.label
+          oldname
+          s
+          t
+          ALTinterwordstretchfactor
+          name.format.string
+          name.latex.cmd}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+%% LOW LEVEL FUNCTIONS %%
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {initialize.controls}
+{ default.is.use.number.for.article 'is.use.number.for.article :=
+  default.is.use.paper 'is.use.paper :=
+  default.is.forced.et.al 'is.forced.et.al :=
+  default.max.num.names.before.forced.et.al 'max.num.names.before.forced.et.al :=
+  default.num.names.shown.with.forced.et.al 'num.names.shown.with.forced.et.al :=
+  default.is.use.alt.interword.spacing 'is.use.alt.interword.spacing :=
+  default.is.dash.repeated.names 'is.dash.repeated.names :=
+  default.ALTinterwordstretchfactor 'ALTinterwordstretchfactor :=
+  default.name.format.string 'name.format.string :=
+  default.name.latex.cmd 'name.latex.cmd :=
+}
+
+
+% This IEEEtran.bst features a very powerful and flexible mechanism for
+% controlling the capitalization, punctuation, spacing, quotation, and
+% newlines of the formatted entry fields. (Note: IEEEtran.bst does not need
+% or use the newline/newblock feature, but it has been implemented for
+% possible future use.) The output states of IEEEtran.bst consist of
+% multiple independent attributes and, as such, can be thought of as being
+% vectors, rather than the simple scalar values ("before.all", 
+% "mid.sentence", etc.) used in most other .bst files.
+% 
+% The more flexible and complex design used here was motivated in part by
+% IEEE's rather unusual bibliography style. For example, IEEE ends the
+% previous field item with a period and large space prior to the publisher
+% address; the @electronic entry types use periods as inter-item punctuation
+% rather than the commas used by the other entry types; and URLs are never
+% followed by periods even though they are the last item in the entry.
+% Although it is possible to accommodate these features with the conventional
+% output state system, the seemingly endless exceptions make for convoluted,
+% unreliable and difficult to maintain code.
+%
+% IEEEtran.bst's output state system can be easily understood via a simple
+% illustration of two most recently formatted entry fields (on the stack):
+%
+%               CURRENT_ITEM
+%               "PREVIOUS_ITEM
+%
+% which, in this example, is to eventually appear in the bibliography as:
+% 
+%               "PREVIOUS_ITEM," CURRENT_ITEM
+%
+% It is the job of the output routine to take the previous item off of the
+% stack (while leaving the current item at the top of the stack), apply its
+% trailing punctuation (including closing quote marks) and spacing, and then
+% to write the result to BibTeX's output buffer:
+% 
+%               "PREVIOUS_ITEM," 
+% 
+% Punctuation (and spacing) between items is often determined by both of the
+% items rather than just the first one. The presence of quotation marks
+% further complicates the situation because, in standard English, trailing
+% punctuation marks are supposed to be contained within the quotes.
+% 
+% IEEEtran.bst maintains two output state (aka "status") vectors which
+% correspond to the previous and current (aka "this") items. Each vector
+% consists of several independent attributes which track punctuation,
+% spacing, quotation, and newlines. Capitalization status is handled by a
+% separate scalar because the format routines, not the output routine,
+% handle capitalization and, therefore, there is no need to maintain the
+% capitalization attribute for both the "previous" and "this" items.
+% 
+% When a format routine adds a new item, it copies the current output status
+% vector to the previous output status vector and (usually) resets the
+% current (this) output status vector to a "standard status" vector. Using a
+% "standard status" vector in this way allows us to redefine what we mean by
+% "standard status" at the start of each entry handler and reuse the same
+% format routines under the various inter-item separation schemes. For
+% example, the standard status vector for the @book entry type may use
+% commas for item separators, while the @electronic type may use periods,
+% yet both entry handlers exploit many of the exact same format routines.
+% 
+% Because format routines have write access to the output status vector of
+% the previous item, they can override the punctuation choices of the
+% previous format routine! Therefore, it becomes trivial to implement rules
+% such as "Always use a period and a large space before the publisher." By
+% pushing the generation of the closing quote mark to the output routine, we
+% avoid all the problems caused by having to close a quote before having all
+% the information required to determine what the punctuation should be.
+%
+% The IEEEtran.bst output state system can easily be expanded if needed.
+% For instance, it is easy to add a "space.tie" attribute value if the
+% bibliography rules mandate that two items have to be joined with an
+% unbreakable space. 
+
+% Titus Barik Annotation Addition
+
+% annotation addition
+FUNCTION {format.annotate}
+{ annote empty$
+	{ "" }
+	{ " \begin{quotation}\noindent "
+		annote
+		* " \end{quotation} " *
+	}
+	if$
+}
+
+
+FUNCTION {initialize.status.constants}
+{ #0 'punct.no :=
+  #1 'punct.comma :=
+  #2 'punct.period :=
+  #0 'space.no := 
+  #1 'space.normal :=
+  #2 'space.large :=
+  #0 'quote.no :=
+  #1 'quote.close :=
+  #0 'cap.no :=
+  #1 'cap.yes :=
+  #0 'nline.no :=
+  #1 'nline.newblock :=
+}
+
+FUNCTION {std.status.using.comma}
+{ punct.comma 'punct.std :=
+  space.normal 'space.std :=
+  quote.no 'quote.std :=
+  nline.no 'nline.std :=
+  cap.no 'cap.std :=
+}
+
+FUNCTION {std.status.using.period}
+{ punct.period 'punct.std :=
+  space.normal 'space.std :=
+  quote.no 'quote.std :=
+  nline.no 'nline.std :=
+  cap.yes 'cap.std :=
+}
+
+FUNCTION {initialize.prev.this.status}
+{ punct.no 'prev.status.punct :=
+  space.no 'prev.status.space :=
+  quote.no 'prev.status.quote :=
+  nline.no 'prev.status.nline :=
+  punct.no 'this.status.punct :=
+  space.no 'this.status.space :=
+  quote.no 'this.status.quote :=
+  nline.no 'this.status.nline :=
+  cap.yes 'status.cap :=
+}
+
+FUNCTION {this.status.std}
+{ punct.std 'this.status.punct :=
+  space.std 'this.status.space :=
+  quote.std 'this.status.quote :=
+  nline.std 'this.status.nline :=
+}
+
+FUNCTION {cap.status.std}{ cap.std 'status.cap := }
+
+FUNCTION {this.to.prev.status}
+{ this.status.punct 'prev.status.punct :=
+  this.status.space 'prev.status.space :=
+  this.status.quote 'prev.status.quote :=
+  this.status.nline 'prev.status.nline :=
+}
+
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+
+FUNCTION {and}
+{   { skip$ }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {or}
+{   { pop$ #1 }
+    { skip$ }
+  if$
+}
+
+
+% convert the strings "yes" or "no" to #1 or #0 respectively
+FUNCTION {yes.no.to.int}
+{ "l" change.case$ duplicate$
+    "yes" =
+    { pop$  #1 }
+    { duplicate$ "no" =
+        { pop$ #0 }
+        { "unknown boolean " quote$ * swap$ * quote$ *
+          " in " * cite$ * warning$
+          #0
+        }
+      if$
+    }
+  if$
+}
+
+
+% pushes true if the single char string on the stack is in the
+% range of "0" to "9"
+FUNCTION {is.num}
+{ chr.to.int$
+  duplicate$ "0" chr.to.int$ < not
+  swap$ "9" chr.to.int$ > not and
+}
+
+% multiplies the integer on the stack by a factor of 10
+FUNCTION {bump.int.mag}
+{ #0 'multiresult :=
+    { duplicate$ #0 > }
+    { #1 -
+      multiresult #10 +
+      'multiresult :=
+    }
+  while$
+pop$
+multiresult
+}
+
+% converts a single character string on the stack to an integer
+FUNCTION {char.to.integer}
+{ duplicate$ 
+  is.num
+    { chr.to.int$ "0" chr.to.int$ - }
+    {"noninteger character " quote$ * swap$ * quote$ *
+          " in integer field of " * cite$ * warning$
+    #0
+    }
+  if$
+}
+
+% converts a string on the stack to an integer
+FUNCTION {string.to.integer}
+{ duplicate$ text.length$ 'namesleft :=
+  #1 'nameptr :=
+  #0 'numnames :=
+    { nameptr namesleft > not }
+    { duplicate$ nameptr #1 substring$
+      char.to.integer numnames bump.int.mag +
+      'numnames :=
+      nameptr #1 +
+      'nameptr :=
+    }
+  while$
+pop$
+numnames
+}
+
+
+
+
+% The output routines write out the *next* to the top (previous) item on the
+% stack, adding punctuation and such as needed. Since IEEEtran.bst maintains
+% the output status for the top two items on the stack, these output
+% routines have to consider the previous output status (which corresponds to
+% the item that is being output). Full independent control of punctuation,
+% closing quote marks, spacing, and newblock is provided.
+% 
+% "output.nonnull" does not check for the presence of a previous empty
+% item.
+% 
+% "output" does check for the presence of a previous empty item and will
+% remove an empty item rather than outputing it.
+% 
+% "output.warn" is like "output", but will issue a warning if it detects
+% an empty item.
+
+FUNCTION {output.nonnull}
+{ swap$
+  prev.status.punct punct.comma =
+     { "," * }
+     { skip$ }
+   if$
+  prev.status.punct punct.period =
+     { add.period$ }
+     { skip$ }
+   if$ 
+  prev.status.quote quote.close =
+     { "''" * }
+     { skip$ }
+   if$
+  prev.status.space space.normal =
+     { " " * }
+     { skip$ }
+   if$
+  prev.status.space space.large =
+     { large.space * }
+     { skip$ }
+   if$
+  write$
+  prev.status.nline nline.newblock =
+     { newline$ "\newblock " write$ }
+     { skip$ }
+   if$
+}
+
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+
+FUNCTION {output.warn}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+
+% "fin.entry" is the output routine that handles the last item of the entry
+% (which will be on the top of the stack when "fin.entry" is called).
+
+FUNCTION {fin.entry}
+{ this.status.punct punct.no =
+     { skip$ }
+     { add.period$ }
+   if$
+   this.status.quote quote.close =
+     { "''" * }
+     { skip$ }
+   if$
+write$
+newline$
+}
+
+
+FUNCTION {is.last.char.not.punct}
+{ duplicate$
+   "}" * add.period$
+   #-1 #1 substring$ "." =
+}
+
+FUNCTION {is.multiple.pages}
+{ 't :=
+  #0 'multiresult :=
+    { multiresult not
+      t empty$ not
+      and
+    }
+    { t #1 #1 substring$
+      duplicate$ "-" =
+      swap$ duplicate$ "," =
+      swap$ "+" =
+      or or
+        { #1 'multiresult := }
+        { t #2 global.max$ substring$ 't := }
+      if$
+    }
+  while$
+ 
+  multiresult
+}
+
+FUNCTION {capitalize}{ "u" change.case$ "t" change.case$ }
+
+FUNCTION {emphasize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+
+FUNCTION {do.name.latex.cmd}
+{ name.latex.cmd
+  empty$
+    { skip$ }
+    { name.latex.cmd "{" * swap$ * "}" * }
+  if$
+}
+
+% IEEEtran.bst uses its own \BIBforeignlanguage command which directly
+% invokes the TeX hyphenation patterns without the need of the Babel
+% package. Babel does a lot more than switch hyphenation patterns and
+% its loading can cause unintended effects in many class files (such as
+% IEEEtran.cls).
+FUNCTION {select.language}
+{ duplicate$ empty$ 'pop$
+    { language empty$ 'skip$
+        { "\BIBforeignlanguage{" language * "}{" * swap$ * "}" * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tie.or.space.prefix}
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$
+}
+
+FUNCTION {get.bbl.editor}
+{ editor num.names$ #1 > 'bbl.editors 'bbl.editor if$ }
+
+FUNCTION {space.word}{ " " swap$ * " " * }
+
+
+% Field Conditioners, Converters, Checkers and External Interfaces
+
+FUNCTION {empty.field.to.null.string}
+{ duplicate$ empty$
+    { pop$ "" }
+    { skip$ }
+  if$
+}
+
+FUNCTION {either.or.check}
+{ empty$
+    { pop$ }
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+
+FUNCTION {empty.entry.warn}
+{ author empty$ title empty$ howpublished empty$
+  month empty$ year empty$ note empty$ url empty$
+  and and and and and and
+    { "all relevant fields are empty in " cite$ * warning$ }
+    'skip$
+  if$
+}
+
+
+% The bibinfo system provides a way for the electronic parsing/acquisition
+% of a bibliography's contents as is done by ReVTeX. For example, a field
+% could be entered into the bibliography as:
+% \bibinfo{volume}{2}
+% Only the "2" would show up in the document, but the LaTeX \bibinfo command
+% could do additional things with the information. IEEEtran.bst does provide
+% a \bibinfo command via "\providecommand{\bibinfo}[2]{#2}". However, it is
+% currently not used as the bogus bibinfo functions defined here output the
+% entry values directly without the \bibinfo wrapper. The bibinfo functions
+% themselves (and the calls to them) are retained for possible future use.
+% 
+% bibinfo.check avoids acting on missing fields while bibinfo.warn will
+% issue a warning message if a missing field is detected. Prior to calling
+% the bibinfo functions, the user should push the field value and then its
+% name string, in that order.
+
+FUNCTION {bibinfo.check}
+{ swap$ duplicate$ missing$
+    { pop$ pop$ "" }
+    { duplicate$ empty$
+        { swap$ pop$ }
+        { swap$ pop$ }
+      if$
+    }
+  if$
+}
+
+FUNCTION {bibinfo.warn}
+{ swap$ duplicate$ missing$
+    { swap$ "missing " swap$ * " in " * cite$ * warning$ pop$ "" }
+    { duplicate$ empty$
+        { swap$ "empty " swap$ * " in " * cite$ * warning$ }
+        { swap$ pop$ }
+      if$
+    }
+  if$
+}
+
+
+% IEEE separates large numbers with more than 4 digits into groups of
+% three. IEEE uses a small space to separate these number groups. 
+% Typical applications include patent and page numbers.
+
+% number of consecutive digits required to trigger the group separation.
+FUNCTION {large.number.trigger}{ #5 }
+
+% For numbers longer than the trigger, this is the blocksize of the groups.
+% The blocksize must be less than the trigger threshold, and 2 * blocksize
+% must be greater than the trigger threshold (can't do more than one
+% separation on the initial trigger).
+FUNCTION {large.number.blocksize}{ #3 }
+
+% What is actually inserted between the number groups.
+FUNCTION {large.number.separator}{ "\," }
+
+% So as to save on integer variables by reusing existing ones, numnames
+% holds the current number of consecutive digits read and nameptr holds
+% the number that will trigger an inserted space.
+FUNCTION {large.number.separate}
+{ 't :=
+  ""
+  #0 'numnames :=
+  large.number.trigger 'nameptr :=
+  { t empty$ not }
+  { t #-1 #1 substring$ is.num
+      { numnames #1 + 'numnames := }
+      { #0 'numnames := 
+        large.number.trigger 'nameptr :=
+      }
+    if$
+    t #-1 #1 substring$ swap$ *
+    t #-2 global.max$ substring$ 't :=
+    numnames nameptr =
+      { duplicate$ #1 nameptr large.number.blocksize - substring$ swap$
+        nameptr large.number.blocksize - #1 + global.max$ substring$
+        large.number.separator swap$ * *
+        nameptr large.number.blocksize - 'numnames :=
+        large.number.blocksize #1 + 'nameptr :=
+      }
+      { skip$ }
+    if$
+  }
+  while$
+}
+
+% Converts all single dashes "-" to double dashes "--".
+FUNCTION {n.dashify}
+{ large.number.separate
+  't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { t #1 #2 substring$ "--" = not
+            { "--" *
+              t #2 global.max$ substring$ 't :=
+            }
+            {   { t #1 #1 substring$ "-" = }
+                { "-" *
+                  t #2 global.max$ substring$ 't :=
+                }
+              while$
+            }
+          if$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+
+% This function detects entries with names that are identical to that of
+% the previous entry and replaces the repeated names with dashes (if the
+% "is.dash.repeated.names" user control is nonzero).
+FUNCTION {name.or.dash}
+{ 's :=
+   oldname empty$
+     { s 'oldname := s }
+     { s oldname =
+         { is.dash.repeated.names
+              { repeated.name.dashes }
+              { s 'oldname := s }
+            if$
+         }
+         { s 'oldname := s }
+       if$
+     }
+   if$
+}
+
+% Converts the number string on the top of the stack to
+% "numerical ordinal form" (e.g., "7" to "7th"). There is
+% no artificial limit to the upper bound of the numbers as the
+% least significant digit always determines the ordinal form.
+FUNCTION {num.to.ordinal}
+{ duplicate$ #-1 #1 substring$ "1" =
+     { bbl.st * }
+     { duplicate$ #-1 #1 substring$ "2" =
+         { bbl.nd * }
+         { duplicate$ #-1 #1 substring$ "3" =
+             { bbl.rd * }
+             { bbl.th * }
+           if$
+         }
+       if$
+     }
+   if$
+}
+
+% If the string on the top of the stack begins with a number,
+% (e.g., 11th) then replace the string with the leading number
+% it contains. Otherwise retain the string as-is. s holds the
+% extracted number, t holds the part of the string that remains
+% to be scanned.
+FUNCTION {extract.num}
+{ duplicate$ 't :=
+  "" 's :=
+  { t empty$ not }
+  { t #1 #1 substring$
+    t #2 global.max$ substring$ 't :=
+    duplicate$ is.num
+      { s swap$ * 's := }
+      { pop$ "" 't := }
+    if$
+  }
+  while$
+  s empty$
+    'skip$
+    { pop$ s }
+  if$
+}
+
+% Converts the word number string on the top of the stack to
+% Arabic string form. Will be successful up to "tenth".
+FUNCTION {word.to.num}
+{ duplicate$ "l" change.case$ 's :=
+  s "first" =
+    { pop$ "1" }
+    { skip$ }
+  if$
+  s "second" =
+    { pop$ "2" }
+    { skip$ }
+  if$
+  s "third" =
+    { pop$ "3" }
+    { skip$ }
+  if$
+  s "fourth" =
+    { pop$ "4" }
+    { skip$ }
+  if$
+  s "fifth" =
+    { pop$ "5" }
+    { skip$ }
+  if$
+  s "sixth" =
+    { pop$ "6" }
+    { skip$ }
+  if$
+  s "seventh" =
+    { pop$ "7" }
+    { skip$ }
+  if$
+  s "eighth" =
+    { pop$ "8" }
+    { skip$ }
+  if$
+  s "ninth" =
+    { pop$ "9" }
+    { skip$ }
+  if$
+  s "tenth" =
+    { pop$ "10" }
+    { skip$ }
+  if$
+}
+
+
+% Converts the string on the top of the stack to numerical
+% ordinal (e.g., "11th") form.
+FUNCTION {convert.edition}
+{ duplicate$ empty$ 'skip$
+    { duplicate$ #1 #1 substring$ is.num
+        { extract.num
+          num.to.ordinal
+        }
+        { word.to.num
+          duplicate$ #1 #1 substring$ is.num
+            { num.to.ordinal }
+            { "edition ordinal word " quote$ * edition * quote$ *
+              " may be too high (or improper) for conversion" * " in " * cite$ * warning$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% LATEX BIBLIOGRAPHY CODE %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {start.entry}
+{ newline$
+  "\bibitem{" write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  initialize.prev.this.status
+}
+
+% Here we write out all the LaTeX code that we will need. The most involved
+% code sequences are those that control the alternate interword spacing and
+% foreign language hyphenation patterns. The heavy use of \providecommand
+% gives users a way to override the defaults. Special thanks to Javier Bezos,
+% Johannes Braams, Robin Fairburns, Heiko Oberdiek, Donald Arseneau and all
+% the other gurus on comp.text.tex for their help and advice on the topic of
+% \selectlanguage, Babel and BibTeX.
+FUNCTION {begin.bib}
+{ preamble$ empty$ 'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{"  longest.label  * "}" *
+  write$ newline$
+  "\providecommand{\url}[1]{#1}"
+  write$ newline$
+  "\csname url@rmstyle\endcsname"
+  write$ newline$
+  "\providecommand{\newblock}{\relax}"
+  write$ newline$
+  "\providecommand{\bibinfo}[2]{#2}"
+  write$ newline$
+  "\providecommand\BIBentrySTDinterwordspacing{\spaceskip=0pt\relax}"
+  write$ newline$
+  "\providecommand\BIBentryALTinterwordstretchfactor{"
+  ALTinterwordstretchfactor * "}" *
+  write$ newline$
+  "\providecommand\BIBentryALTinterwordspacing{\spaceskip=\fontdimen2\font plus "
+  write$ newline$
+  "\BIBentryALTinterwordstretchfactor\fontdimen3\font minus \fontdimen4\font\relax}"
+  write$ newline$
+  "\providecommand\BIBforeignlanguage[2]{{%"
+  write$ newline$
+  "\expandafter\ifx\csname l@#1\endcsname\relax"
+  write$ newline$
+  "\typeout{** WARNING: IEEEtran.bst: No hyphenation pattern has been}%"
+  write$ newline$
+  "\typeout{** loaded for the language `#1'. Using the pattern for}%"
+  write$ newline$
+  "\typeout{** the default language instead.}%"
+  write$ newline$
+  "\else"
+  write$ newline$
+  "\language=\csname l@#1\endcsname"
+  write$ newline$
+  "\fi"
+  write$ newline$
+  "#2}}"
+  write$ newline$
+}
+
+FUNCTION {end.bib}
+{ newline$ "\end{thebibliography}" write$ newline$ }
+
+FUNCTION {if.url.alt.interword.spacing}
+{ is.use.alt.interword.spacing 
+     {url empty$ 'skip$ {"\BIBentryALTinterwordspacing" write$ newline$} if$}
+     { skip$ }
+   if$
+}
+
+FUNCTION {if.url.std.interword.spacing}
+{ is.use.alt.interword.spacing 
+     {url empty$ 'skip$ {"\BIBentrySTDinterwordspacing" write$ newline$} if$}
+     { skip$ }
+   if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%
+%% LONGEST LABEL PASS %%
+%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {initialize.longest.label}
+{ "" 'longest.label :=
+  #1 'number.label :=
+  #0 'longest.label.width :=
+}
+
+FUNCTION {longest.label.pass}
+{ number.label int.to.str$ 'label :=
+  number.label #1 + 'number.label :=
+  label width$ longest.label.width >
+    { label 'longest.label :=
+      label width$ 'longest.label.width :=
+    }
+    'skip$
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%
+%% FORMAT HANDLERS %%
+%%%%%%%%%%%%%%%%%%%%%
+
+%% Lower Level Formats (used by higher level formats)
+
+FUNCTION {format.address.org.or.pub.date}
+{ 't :=
+  ""
+  year empty$
+    { "empty year in " cite$ * warning$ }
+    { skip$ }
+  if$
+  address empty$ t empty$ and
+  year empty$ and month empty$ and
+    { skip$ }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      address "address" bibinfo.check *
+      t empty$
+        { skip$ }
+        { punct.period 'prev.status.punct :=
+          space.large 'prev.status.space :=
+          address empty$
+            { skip$ }
+            { ": " * }
+          if$
+          t *
+        }
+      if$
+      year empty$ month empty$ and
+        { skip$ }
+        { t empty$ address empty$ and
+            { skip$ }
+            { ", " * }
+          if$
+          month empty$
+            { year empty$
+                { skip$ }
+                { year "year" bibinfo.check * }
+              if$
+            }
+            { month "month" bibinfo.check *
+              year empty$
+                 { skip$ }
+                 { " " * year "year" bibinfo.check * }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+
+FUNCTION {format.names}
+{ 'bibinfo :=
+  duplicate$ empty$ 'skip$ {
+  this.to.prev.status
+  this.status.std
+  's :=
+  "" 't :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      name.format.string
+      format.name$
+      bibinfo bibinfo.check
+      't :=
+      nameptr #1 >
+        { nameptr num.names.shown.with.forced.et.al #1 + =
+          numnames max.num.names.before.forced.et.al >
+          is.forced.et.al and and
+            { "others" 't :=
+              #1 'namesleft :=
+            }
+            { skip$ }
+          if$
+          namesleft #1 >
+            { ", " * t do.name.latex.cmd * }
+            {
+              numnames #2 >
+                { "," * }
+                'skip$
+              if$
+              s nameptr "{ll}" format.name$ duplicate$ "others" =
+                { 't := }
+                { pop$ }
+              if$
+              t "others" =
+                {
+                  " " * bbl.etal emphasize *
+                }
+                {
+                  bbl.and
+                  space.word * t do.name.latex.cmd *
+                }
+              if$
+            }
+          if$
+        }
+        { t do.name.latex.cmd }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+  cap.status.std
+  } if$
+}
+
+
+
+
+%% Higher Level Formats
+
+%% addresses/locations
+
+FUNCTION {format.address}
+{ address duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% author/editor names
+
+FUNCTION {format.authors}{ author "author" format.names }
+
+FUNCTION {format.editors}
+{ editor "editor" format.names duplicate$ empty$ 'skip$
+    { ", " *
+      get.bbl.editor
+      capitalize
+      *
+    }
+  if$
+}
+
+
+
+%% date
+
+FUNCTION {format.date}
+{
+  month "month" bibinfo.check duplicate$ empty$
+  year  "year" bibinfo.check duplicate$ empty$
+    { swap$ 'skip$
+        { this.to.prev.status
+          this.status.std
+          cap.status.std
+         "there's a month but no year in " cite$ * warning$ }
+      if$
+      *
+    }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      swap$ 'skip$
+        {
+          swap$
+          " " * swap$
+        }
+      if$
+      *
+    }
+  if$
+}
+
+FUNCTION {format.date.electronic}
+{ month "month" bibinfo.check duplicate$ empty$
+  year  "year" bibinfo.check duplicate$ empty$
+    { swap$ 
+        { pop$ }
+        { "there's a month but no year in " cite$ * warning$
+        pop$ ")" * "(" swap$ *
+        this.to.prev.status
+        punct.no 'this.status.punct :=
+        space.normal 'this.status.space :=
+        quote.no 'this.status.quote :=
+        cap.yes  'status.cap :=
+        }
+      if$
+    }
+    { swap$ 
+        { swap$ pop$ ")" * "(" swap$ * }
+        { "(" swap$ * ", " * swap$ * ")" * }
+      if$
+    this.to.prev.status
+    punct.no 'this.status.punct :=
+    space.normal 'this.status.space :=
+    quote.no 'this.status.quote :=
+    cap.yes  'status.cap :=
+    }
+  if$
+}
+
+
+
+%% edition/title
+
+% Note: IEEE considers the edition to be closely associated with
+% the title of a book. So, in IEEEtran.bst the edition is normally handled 
+% within the formatting of the title. The format.edition function is 
+% retained here for possible future use.
+FUNCTION {format.edition}
+{ edition duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      convert.edition
+      status.cap
+        { "t" }
+        { "l" }
+      if$ change.case$
+      "edition" bibinfo.check
+      "~" * bbl.edition *
+      cap.status.std
+    }
+  if$
+}
+
+% This is used to format the booktitle of a conference proceedings.
+% Here we use the "intype" field to provide the user a way to 
+% override the word "in" (e.g., with things like "presented at")
+% Use of intype stops the emphasis of the booktitle to indicate that
+% we no longer mean the written conference proceedings, but the
+% conference itself.
+FUNCTION {format.in.booktitle}
+{ booktitle "booktitle" bibinfo.check duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      select.language
+      intype missing$
+        { emphasize
+          bbl.in " " *
+        }
+        { intype " " * }
+      if$
+      swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+% This is used to format the booktitle of collection.
+% Here the "intype" field is not supported, but "edition" is.
+FUNCTION {format.in.booktitle.edition}
+{ booktitle "booktitle" bibinfo.check duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      select.language
+      emphasize
+      edition empty$ 'skip$
+        { ", " *
+          edition
+          convert.edition
+          "l" change.case$
+          * "~" * bbl.edition *
+        }
+      if$
+      bbl.in " " * swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.article.title}
+{ title duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      "t" change.case$
+    }
+  if$
+  "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    { quote.close 'this.status.quote :=
+      is.last.char.not.punct
+        { punct.std 'this.status.punct := }
+        { punct.no 'this.status.punct := }
+      if$
+      select.language
+      "``" swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.article.title.electronic}
+{ title duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      "t" change.case$ 
+    }
+  if$
+  "title" bibinfo.check
+  duplicate$ empty$ 
+    { skip$ } 
+    { select.language }
+  if$
+}
+
+FUNCTION {format.book.title.edition}
+{ title "title" bibinfo.check
+  duplicate$ empty$
+    { "empty title in " cite$ * warning$ }
+    { this.to.prev.status
+      this.status.std
+      select.language
+      emphasize
+      edition empty$ 'skip$
+        { ", " *
+          edition
+          convert.edition
+          status.cap
+            { "t" }
+            { "l" }
+          if$
+          change.case$
+          * "~" * bbl.edition *
+        }
+      if$
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.book.title}
+{ title "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      select.language
+      emphasize
+    }
+  if$
+}
+
+
+
+%% journal
+
+FUNCTION {format.journal}
+{ journal duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      select.language
+      emphasize
+    }
+  if$
+}
+
+
+
+%% how published
+
+FUNCTION {format.howpublished}
+{ howpublished duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% institutions/organization/publishers/school
+
+FUNCTION {format.institution}
+{ institution duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.organization}
+{ organization duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.address.publisher.date}
+{ publisher "publisher" bibinfo.warn format.address.org.or.pub.date }
+
+FUNCTION {format.address.publisher.date.nowarn}
+{ publisher "publisher" bibinfo.check format.address.org.or.pub.date }
+
+FUNCTION {format.address.organization.date}
+{ organization "organization" bibinfo.check format.address.org.or.pub.date }
+
+FUNCTION {format.school}
+{ school duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% volume/number/series/chapter/pages
+
+FUNCTION {format.volume}
+{ volume empty.field.to.null.string
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      bbl.volume 
+      status.cap
+        { capitalize }
+        { skip$ }
+      if$
+      swap$ tie.or.space.prefix
+      "volume" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.number}
+{ number empty.field.to.null.string
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      status.cap
+         { bbl.number capitalize }
+         { bbl.number }
+       if$
+      swap$ tie.or.space.prefix
+      "number" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.number.if.use.for.article}
+{ is.use.number.for.article 
+     { format.number }
+     { "" }
+   if$
+}
+
+% IEEE does not seem to tie the series so closely with the volume
+% and number as is done in other bibliography styles. Instead the
+% series is treated somewhat like an extension of the title.
+FUNCTION {format.series}
+{ series empty$ 
+   { "" }
+   { this.to.prev.status
+     this.status.std
+     bbl.series " " *
+     series "series" bibinfo.check *
+     cap.status.std
+   }
+ if$
+}
+
+
+FUNCTION {format.chapter}
+{ chapter empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      type empty$
+        { bbl.chapter }
+        { type "l" change.case$
+          "type" bibinfo.check
+        }
+      if$
+      chapter tie.or.space.prefix
+      "chapter" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+% The intended use of format.paper is for paper numbers of inproceedings.
+% The paper type can be overridden via the type field.
+% We allow the type to be displayed even if the paper number is absent
+% for things like "postdeadline paper"
+FUNCTION {format.paper}
+{ is.use.paper
+     { paper empty$
+        { type empty$
+            { "" }
+            { this.to.prev.status
+              this.status.std
+              type "type" bibinfo.check
+              cap.status.std
+            }
+          if$
+        }
+        { this.to.prev.status
+          this.status.std
+          type empty$
+            { bbl.paper }
+            { type "type" bibinfo.check }
+          if$
+          " " * paper
+          "paper" bibinfo.check
+          *
+          cap.status.std
+        }
+      if$
+     }
+     { "" } 
+   if$
+}
+
+
+FUNCTION {format.pages}
+{ pages duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      duplicate$ is.multiple.pages
+        {
+          bbl.pages swap$
+          n.dashify
+        }
+        {
+          bbl.page swap$
+        }
+      if$
+      tie.or.space.prefix
+      "pages" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% technical report number
+
+FUNCTION {format.tech.report.number}
+{ number "number" bibinfo.check
+  type duplicate$ empty$
+    { pop$ 
+      this.to.prev.status
+      this.status.std
+      cap.status.std
+      bbl.techrep
+    }
+    { skip$ }
+  if$
+  "type" bibinfo.check 
+  swap$ duplicate$ empty$
+    { pop$ }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      tie.or.space.prefix * * }
+  if$
+}
+
+
+
+%% note
+
+FUNCTION {format.note}
+{ note empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      punct.period 'this.status.punct :=
+      note #1 #1 substring$
+      duplicate$ "{" =
+        { skip$ }
+        { status.cap
+          { "u" }
+          { "l" }
+        if$
+        change.case$
+        }
+      if$
+      note #2 global.max$ substring$ * "note" bibinfo.check
+      cap.yes  'status.cap :=
+    }
+  if$
+}
+
+
+
+%% patent
+
+FUNCTION {format.patent.date}
+{ this.to.prev.status
+  this.status.std
+  year empty$
+    { monthfiled duplicate$ empty$
+        { "monthfiled" bibinfo.check pop$ "" }
+        { "monthfiled" bibinfo.check }
+      if$
+      dayfiled duplicate$ empty$
+        { "dayfiled" bibinfo.check pop$ "" * }
+        { "dayfiled" bibinfo.check 
+          monthfiled empty$ 
+             { "dayfiled without a monthfiled in " cite$ * warning$
+               * 
+             }
+             { " " swap$ * * }
+           if$
+        }
+      if$
+      yearfiled empty$
+        { "no year or yearfiled in " cite$ * warning$ }
+        { yearfiled "yearfiled" bibinfo.check 
+          swap$
+          duplicate$ empty$
+             { pop$ }
+             { ", " * swap$ * }
+           if$
+        }
+      if$
+    }
+    { month duplicate$ empty$
+        { "month" bibinfo.check pop$ "" }
+        { "month" bibinfo.check }
+      if$
+      day duplicate$ empty$
+        { "day" bibinfo.check pop$ "" * }
+        { "day" bibinfo.check 
+          month empty$ 
+             { "day without a month in " cite$ * warning$
+               * 
+             }
+             { " " swap$ * * }
+           if$
+        }
+      if$
+      year "year" bibinfo.check 
+      swap$
+      duplicate$ empty$
+        { pop$ }
+        { ", " * swap$ * }
+      if$
+    }
+  if$
+  cap.status.std
+}
+
+FUNCTION {format.patent.nationality.type.number}
+{ this.to.prev.status
+  this.status.std
+  nationality duplicate$ empty$
+    { "nationality" bibinfo.warn pop$ "" }
+    { "nationality" bibinfo.check
+      duplicate$ "l" change.case$ "united states" =
+        { pop$ bbl.patentUS }
+        { skip$ }
+      if$
+      " " *
+    }
+  if$
+  type empty$
+    { bbl.patent "type" bibinfo.check }
+    { type "type" bibinfo.check }
+  if$  
+  *
+  number duplicate$ empty$
+    { "number" bibinfo.warn pop$ }
+    { "number" bibinfo.check
+      large.number.separate
+      swap$ " " * swap$ *
+    }
+  if$ 
+  cap.status.std
+}
+
+
+
+%% standard
+
+FUNCTION {format.organization.institution.standard.type.number}
+{ this.to.prev.status
+  this.status.std
+  organization duplicate$ empty$
+    { pop$ 
+      institution duplicate$ empty$
+        { "institution" bibinfo.warn }
+        { "institution" bibinfo.warn " " * }
+      if$
+    }
+    { "organization" bibinfo.warn " " * }
+  if$
+  type empty$
+    { bbl.standard "type" bibinfo.check }
+    { type "type" bibinfo.check }
+  if$  
+  *
+  number duplicate$ empty$
+    { "number" bibinfo.check pop$ }
+    { "number" bibinfo.check
+      large.number.separate
+      swap$ " " * swap$ *
+    }
+  if$ 
+  cap.status.std
+}
+
+FUNCTION {format.revision}
+{ revision empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      bbl.revision
+      revision tie.or.space.prefix
+      "revision" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+%% thesis
+
+FUNCTION {format.master.thesis.type}
+{ this.to.prev.status
+  this.status.std
+  type empty$
+    {
+      bbl.mthesis
+    }
+    { 
+      type "type" bibinfo.check
+    }
+  if$
+cap.status.std
+}
+
+FUNCTION {format.phd.thesis.type}
+{ this.to.prev.status
+  this.status.std
+  type empty$
+    {
+      bbl.phdthesis
+    }
+    { 
+      type "type" bibinfo.check
+    }
+  if$
+cap.status.std
+}
+
+
+
+%% URL
+
+FUNCTION {format.url}
+{ url empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      cap.yes 'status.cap :=
+      bbl.urlprefix " " * 
+      "\url{" * url * "}" *
+      punct.no 'this.status.punct :=
+      punct.period 'prev.status.punct :=
+      space.normal 'this.status.space :=
+      space.normal 'prev.status.space :=
+      quote.no 'this.status.quote :=
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%
+%% ENTRY HANDLERS %%
+%%%%%%%%%%%%%%%%%%%%
+
+
+% Note: In many journals, IEEE (or the authors) tend not to show the number
+% for articles, so the display of the number is controlled here by the
+% switch "is.use.number.for.article"
+FUNCTION {article}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.journal "journal" bibinfo.check "journal" output.warn
+  format.volume output
+  format.number.if.use.for.article output
+  format.pages output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {book}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  author empty$
+    { format.editors "author and editor" output.warn }
+    { format.authors output.nonnull }
+  if$
+  name.or.dash
+  format.book.title.edition output
+  format.series output
+  author empty$
+    { skip$ }
+    { format.editors output }
+  if$
+  format.address.publisher.date output
+  format.volume output
+  format.number output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {booklet}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {electronic}
+{ std.status.using.period
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.date.electronic output
+  format.article.title.electronic output
+  format.howpublished "howpublished" bibinfo.check output
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {inbook}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  author empty$
+    { format.editors "author and editor" output.warn }
+    { format.authors output.nonnull }
+  if$
+  name.or.dash
+  format.book.title.edition output
+  format.series output
+  format.address.publisher.date output
+  format.volume output
+  format.number output
+  format.chapter output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {incollection}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.in.booktitle.edition "booktitle" output.warn
+  format.series output
+  format.editors output
+  format.address.publisher.date.nowarn output
+  format.volume output
+  format.number output
+  format.chapter output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {inproceedings}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.in.booktitle "booktitle" output.warn
+  format.series output
+  format.editors output
+  format.volume output
+  format.number output
+  publisher empty$
+    { format.address.organization.date output }
+    { format.organization "organization" bibinfo.check output
+      format.address.publisher.date output
+    }
+  if$
+  format.paper output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {manual}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.book.title.edition "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {mastersthesis}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.master.thesis.type output.nonnull
+  format.school "school" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {misc}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title output
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.pages output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {patent}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title output
+  format.patent.nationality.type.number output
+  format.patent.date output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {periodical}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.editors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.series output
+  format.volume output
+  format.number output
+  format.organization "organization" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {phdthesis}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.phd.thesis.type output.nonnull
+  format.school "school" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {proceedings}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.editors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.series output
+  format.volume output
+  format.number output
+  publisher empty$
+    { format.address.organization.date output }
+    { format.organization "organization" bibinfo.check output
+      format.address.publisher.date output
+    }
+  if$
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {standard}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization.institution.standard.type.number output
+  format.revision output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {techreport}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.institution "institution" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.tech.report.number output.nonnull
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+FUNCTION {unpublished}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.date output
+  format.note "note" output.warn
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+% TB: added for annotation
+  format.annotate write$
+  newline$
+}
+
+
+% The special entry type which provides the user interface to the
+% BST controls
+FUNCTION {IEEEtranBSTCTL}
+{ is.print.banners.to.terminal
+    { "** IEEEtran BST control entry " quote$ * cite$ * quote$ * " detected." *
+      top$
+    }
+    { skip$ }
+  if$
+  CTLuse_article_number
+  empty$
+    { skip$ }
+    { CTLuse_article_number
+      yes.no.to.int
+      'is.use.number.for.article :=
+    }
+  if$
+  CTLuse_paper
+  empty$
+    { skip$ }
+    { CTLuse_paper
+      yes.no.to.int
+      'is.use.paper :=
+    }
+  if$
+  CTLuse_forced_etal
+  empty$
+    { skip$ }
+    { CTLuse_forced_etal
+      yes.no.to.int
+      'is.forced.et.al :=
+    }
+  if$
+  CTLmax_names_forced_etal
+  empty$
+    { skip$ }
+    { CTLmax_names_forced_etal
+      string.to.integer
+      'max.num.names.before.forced.et.al :=
+    }
+  if$
+  CTLnames_show_etal
+  empty$
+    { skip$ }
+    { CTLnames_show_etal
+      string.to.integer
+      'num.names.shown.with.forced.et.al :=
+    }
+  if$
+  CTLuse_alt_spacing
+  empty$
+    { skip$ }
+    { CTLuse_alt_spacing
+      yes.no.to.int
+      'is.use.alt.interword.spacing :=
+    }
+  if$
+  CTLalt_stretch_factor
+  empty$
+    { skip$ }
+    { CTLalt_stretch_factor
+      'ALTinterwordstretchfactor :=
+      "\renewcommand\BIBentryALTinterwordstretchfactor{"
+      ALTinterwordstretchfactor * "}" *
+      write$ newline$
+    }
+  if$
+  CTLdash_repeated_names
+  empty$
+    { skip$ }
+    { CTLdash_repeated_names
+      yes.no.to.int
+      'is.dash.repeated.names :=
+    }
+  if$
+  CTLname_format_string
+  empty$
+    { skip$ }
+    { CTLname_format_string
+      'name.format.string :=
+    }
+  if$
+  CTLname_latex_cmd
+  empty$
+    { skip$ }
+    { CTLname_latex_cmd
+      'name.latex.cmd :=
+    }
+  if$
+  
+  
+  num.names.shown.with.forced.et.al max.num.names.before.forced.et.al >
+    { "CTLnames_show_etal cannot be greater than CTLmax_names_forced_etal in " cite$ * warning$ 
+      max.num.names.before.forced.et.al 'num.names.shown.with.forced.et.al :=
+    }
+    { skip$ }
+  if$
+}
+
+
+%%%%%%%%%%%%%%%%%%%
+%% ENTRY ALIASES %%
+%%%%%%%%%%%%%%%%%%%
+FUNCTION {conference}{inproceedings}
+FUNCTION {online}{electronic}
+FUNCTION {internet}{electronic}
+FUNCTION {webpage}{electronic}
+FUNCTION {default.type}{misc}
+
+
+
+%%%%%%%%%%%%%%%%%%
+%% MAIN PROGRAM %%
+%%%%%%%%%%%%%%%%%%
+
+READ
+
+EXECUTE {initialize.controls}
+EXECUTE {initialize.status.constants}
+EXECUTE {banner.message}
+
+
+
+% BEGIN sort code based on that of plain.bst
+
+FUNCTION {sortify}
+{ purify$
+  "l" change.case$
+}
+
+INTEGERS { len }
+
+FUNCTION {chop.word}
+{ 's :=
+  'len :=
+  s #1 len substring$ =
+    { s len #1 + global.max$ substring$ }
+    { s }
+  if$
+}
+
+FUNCTION {sort.format.names}
+{ 's :=
+  #1 'nameptr :=
+  ""
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { nameptr #1 >
+        { "   " * }
+        { skip$ }
+      if$
+      s nameptr "{vv{ } }{ll{ }}{  ff{ }}{  jj{ }}" format.name$ 't :=
+      nameptr numnames = t "others" = and
+        { "et al" * }
+        { t sortify * }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {sort.format.title}
+{ 't :=
+  "A " #2
+    "An " #3
+      "The " #4 t chop.word
+    chop.word
+  chop.word
+  sortify
+  #1 global.max$ substring$
+}
+
+FUNCTION {author.sort}
+{ author empty$
+    { key empty$
+        { "to sort, need author or key in " cite$ * warning$ "" }
+        { key sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {author.editor.sort}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { "to sort, need author, editor, or key in " cite$ * warning$ "" }
+            { key sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {author.organization.sort}
+{ author empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need author, organization, or key in " cite$ * warning$ "" }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {editor.organization.sort}
+{ editor empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need editor, organization, or key in " cite$ * warning$ "" }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { editor sort.format.names }
+  if$
+}
+
+FUNCTION {author.organization.institution.sort}
+{ author empty$
+    { organization empty$
+        { institution empty$
+            { key empty$
+                { "to sort, need author, organization, institution or key in " cite$ * warning$ "" }
+                { key sortify }
+              if$
+            }
+            { "The " #4 institution chop.word sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+
+FUNCTION {presort}
+{ type$ "ieeetranbstctl" =
+    { key empty$
+        { "_" }
+        { key sortify }
+      if$
+    }
+    { type$ "book" =
+      type$ "inbook" =
+      or 
+        { author.editor.sort }
+        { type$ "proceedings" =
+          type$ "periodical" =
+          or
+            { editor.organization.sort }
+            { type$ "manual" =
+              type$ "electronic" =
+              type$ "misc" =
+              or or
+                { author.organization.sort }
+                { type$ "standard" =
+                   { author.organization.institution.sort }
+                   { author.sort }
+                 if$ 
+                }
+              if$
+            }
+          if$
+        }
+      if$
+      "    "
+      *
+      year empty.field.to.null.string sortify
+      *
+      "    "
+      *
+      title empty.field.to.null.string
+      sort.format.title
+      *
+    }
+  if$
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+
+ITERATE {presort}
+
+SORT
+
+% END sort code based on that of plain.bst
+
+
+
+EXECUTE {initialize.longest.label}
+ITERATE {longest.label.pass}
+
+EXECUTE {begin.bib}
+ITERATE {call.type$}
+EXECUTE {end.bib}
+
+EXECUTE{completed.message}
+
+
+%% That's all folks, mds.

--- a/ieee/IEEEexample.bib
+++ b/ieee/IEEEexample.bib
@@ -1,0 +1,1190 @@
+
+IEEEexample.bib 
+V1.12 (2007/01/11)
+Copyright (c) 2002-2007 by Michael Shell
+See: http://www.michaelshell.org/
+for current contact information.
+
+This is an example BibTeX database for the official IEEEtran.bst
+BibTeX style file.
+
+Some entries call strings that are defined in the IEEEabrv.bib file.
+Therefore, IEEEabrv.bib should be loaded prior to this file. 
+Usage: 
+
+\bibliographystyle{./IEEEtran}
+\bibliography{./IEEEabrv,./IEEEexample}
+
+
+Support sites:
+http://www.michaelshell.org/tex/ieeetran/
+http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+and/or
+http://www.ieee.org/
+
+*************************************************************************
+Legal Notice:
+This code is offered as-is without any warranty either expressed or
+implied; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE! 
+User assumes all risk.
+In no event shall IEEE or any contributor to this code be liable for
+any damages or losses, including, but not limited to, incidental,
+consequential, or any other damages, resulting from the use or misuse
+of any information contained here.
+
+All comments are the opinions of their respective authors and are not
+necessarily endorsed by the IEEE.
+
+This work is distributed under the LaTeX Project Public License (LPPL)
+( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+distributed and modified. A copy of the LPPL, version 1.3, is included
+in the base LaTeX documentation of all distributions of LaTeX released
+2003/12/01 or later.
+Retain all contribution notices and credits.
+** Modified files should be clearly indicated as such, including  **
+** renaming them and changing author support contact information. **
+
+File list of work: IEEEabrv.bib, IEEEfull.bib, IEEEexample.bib,
+                   IEEEtran.bst, IEEEtranS.bst, IEEEtranSA.bst,
+                   IEEEtranN.bst, IEEEtranSN.bst, IEEEtran_bst_HOWTO.pdf
+*************************************************************************
+
+
+Note that, because the example references were taken from actual IEEE
+publications, these examples do not always contain the full amount
+of information that may be desirable (for use with other BibTeX styles).
+In particular, full names (not abbreviated with initials) should be
+entered whenever possible as some (non-IEEE) bibliography styles use
+full names. IEEEtran.bst will automatically abbreviate when it encounters
+full names.
+ 
+ 
+ 
+ 
+references for the IEEEtran.bst documentation
+IEEEtran homepage
+@electronic{IEEEhowto:IEEEtranpage,
+  author        = "Michael Shell",
+  title         = "{IEEE}tran Homepage",
+  url           = "http://www.michaelshell.org/tex/ieeetran/",
+  year          = "2007"
+}
+
+
+the distribution site for IEEEtran.bst
+@electronic{IEEEexample:shellCTANpage,
+  author        = "Michael Shell",
+  title         = "{IEEE}tran Webpage on {CTAN}",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/",
+  year          = "2007"
+}
+
+
+the IEEE website
+sort key is needed for sorting styles
+@electronic{IEEEexample:IEEEwebsite,
+  title         = "The {IEEE} Website",
+  url           = "http://www.ieee.org/",
+  year          = "2007",
+  key           = "IEEE"
+}
+
+
+The BibTeX user's guide.
+The filename could have been put in the URL instead. But, there might
+be other interesting things for the user in the same directory - and
+the filename might change before the directory that contains it.
+@electronic{IEEEexample:bibtexuser,
+  author        = "Oren Patashnik",
+  title         = "{{\BibTeX}}ing",
+  howpublished  = "{btxdoc.pdf}",
+  url           = "http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/",
+  month         = feb,
+  year          = "1988"
+}
+
+
+The BibTeX style designer's guide.
+@electronic{IEEEexample:bibtexdesign,
+  author        = "Oren Patashnik",
+  title         = "Designing {{\BibTeX}} Styles",
+  howpublished  = "{btxhak.pdf}",
+  url           = "http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/",
+  month         = feb,
+  year          = "1988"
+}
+
+
+A comprehensive BibTeX tutorial.
+@electronic{IEEEexample:tamethebeast,
+  author        = "Nicolas Markey",
+  title         = "Tame the BeaST  ---  The B to X of {{\BibTeX}}",
+  url           = "http://tug.ctan.org/tex-archive/info/bibtex/tamethebeast/",
+  month         = oct,
+  year          = "2005"
+}
+
+
+The BibTeX Tips and FAQ guide.
+@electronic{IEEEexample:bibtexFAQ,
+  author        = "David Hoadley and Michael Shell",
+  title         = "{{\BibTeX}} Tips and {FAQ}",
+  howpublished  = "{btxFAQ.pdf}",
+  url           = "http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/",
+  month         = jan,
+  year          = "2007"
+}
+
+
+The TeX FAQ
+@electronic{IEEEexample:texfaq,
+  author        = "Robin Fairbairns",
+  title         = "The {{\TeX}} {FAQ}",
+  url           = "http://www.tex.ac.uk/cgi-bin/texfaq2html/",
+  month         = jan,
+  year          = "2007"
+}
+
+
+A BibTeX Guide via Examples.
+@electronic{IEEEexample:bibtexguide,
+  author        = "Ki-Joo Kim",
+  title         = "A {{\BibTeX}} Guide via Examples",
+  howpublished  = "{bibtex\_guide.pdf}",
+  url           = "http://www.geocities.com/kijoo2000/",
+  month         = apr,
+  year          = "2004"
+}
+
+
+TeX User Group Bibliography Archive
+@electronic{IEEEexample:beebe_archive,
+  author        = "Nelson H. F. Beebe",
+  title         = "{{\TeX}} User Group Bibliography Archive",
+  url           = "http://www.math.utah.edu:8080/pub/tex/bib/index-table.html",
+  month         = aug,
+  year          = "2006"
+}
+
+The natbib.sty package.
+@electronic{ctan:natbib,
+  author        = "Patrick W. Daly",
+  title         = "The natbib.sty package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/contrib/natbib/",
+  month         = sep,
+  year          = "2006"
+}
+
+The url.sty package.
+@electronic{IEEEexample:urlsty,
+  author        = "Donald Arseneau",
+  title         = "The url.sty Package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/contrib/misc/",
+  month         = jun,
+  year          = "2005",
+}
+
+
+The hyperref.sty package.
+@electronic{IEEEexample:hyperrefsty,
+  author        = "Sebastian Rahtz and Heiko Oberdiek",
+  title         = "The hyperref.sty Package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/contrib/hyperref/",
+  month         = nov,
+  year          = "2006",
+}
+
+
+The breakurl.sty package.
+@electronic{IEEEexample:breakurl,
+  author        = "Vilar Camara Neto",
+  title         = "The breakurl.sty Package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/contrib/breakurl/",
+  month         = aug,
+  year          = "2006",
+}
+
+
+The Babel package.
+@electronic{IEEEexample:babel,
+  author        = "Johannes Braams",
+  title         = "The Babel Package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/required/babel/",
+  month         = nov,
+  year          = "2005",
+}
+
+
+The multibib package.
+@electronic{IEEEexample:multibibsty,
+  author        = "Thorsten Hansen",
+  title         = "The multibib.sty package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/contrib/multibib/",
+  month         = jan,
+  year          = "2004"
+}
+
+
+The biblatex package.
+@electronic{IEEEexample:biblatex,
+  author        = "Philipp Lehman",
+  title         = "The biblatex package",
+  url           = "http://www.ctan.org/tex-archive/macros/latex/exptl/biblatex/",
+  month         = jan,
+  year          = "2007"
+}
+
+
+
+The three most common and typical types of references used in
+IEEE publications:
+
+an article in a journal
+Note the use of the IEEE_J_EDL string, defined in the IEEEabrv.bib file,
+for the journal name. IEEEtran.bst defines the BibTeX standard three
+letter month codes per IEEE style.
+From the June 2002 issue of "IEEE Transactions on Electron Devices",
+page 996, reference #16.
+@article{IEEEexample:article_typical,
+  author        = "S. Zhang and C. Zhu and J. K. O. Sin and P. K. T. Mok",
+  title         = "A Novel Ultrathin Elevated Channel Low-temperature 
+                   Poly-{Si} {TFT}",
+  journal       = IEEE_J_EDL,
+  volume        = "20",
+  month         = nov,
+  year          = "1999",
+  pages         = "569-571"
+}
+
+
+journal article using et al.
+The (five) authors are actually: F. Delorme, S. Slempkes, G. Alibert, 
+B. Rose, J. Brandon
+The month (July) was not given here.
+From the September 1998 issue of "IEEE Journal on Selected Areas in
+Communications", page 1257, reference #28.
+@article{IEEEexample:articleetal,
+  author        = "F. Delorme and others",
+  title         = "Butt-jointed {DBR} Laser With 15 {nm} Tunability Grown
+                   in Three {MOVPE} Steps",
+  journal       = "Electron. Lett.",
+  volume        = "31",
+  number        = "15",
+  year          = "1995",
+  pages         = "1244-1245"
+}
+
+
+a paper in a conference proceedings
+"conference" can be used as an alias for "inproceedings"
+From the June 2002 issue of "Journal of Microelectromechanical Systems",
+page 205, reference #16.
+@inproceedings{IEEEexample:conf_typical,
+  author        = "R. K. Gupta and S. D. Senturia",
+  title         = "Pull-in Time Dynamics as a Measure of Absolute Pressure",
+  booktitle     = "Proc. {IEEE} International Workshop on
+                   Microelectromechanical Systems ({MEMS}'97)",
+  address       = "Nagoya, Japan",
+  month         = jan,
+  year          = "1997",
+  pages         = "290-294"
+}
+
+
+a book
+From the May 2002 issue of "IEEE Transactions on Magnetics",
+page 1466, reference #4.
+@book{IEEEexample:book_typical,
+  author        = "B. D. Cullity",
+  title         = "Introduction to Magnetic Materials",
+  publisher     = "Addison-Wesley",
+  address       = "Reading, MA",
+  year          = "1972"
+}
+
+
+
+
+Other examples
+
+journal article with large page numbers, IEEE will divide numbers 5 digits
+or longer into groups of three with small spaces between them. Page ranges
+can be separated via either "-" or "--", IEEEtran.bst will automatically
+convert the separator dash(es) to "--".
+Authors and/or IEEE do not always provide/use the journal number, but it
+was used in this case. IEEEtran.bst can be configured to ignore journal
+numbers if desired.
+From the August 2000 issue of "IEEE Photonics Technology Letters",
+page 1039, reference #11.
+@article{IEEEexample:articlelargepages,
+  author        = "A. Castaldini and A. Cavallini and B. Fraboni
+                   and P. Fernandez and J. Piqueras",
+  title         = "Midgap Traps Related to Compensation Processes in
+                   {CdTe} Alloys",
+  journal       = "Phys. Rev. B.",
+  volume        = "56",
+  number        = "23",
+  year          = "1997",
+  pages         = "14897-14900"
+}
+
+
+journal article with dual months 
+use the BibTeX "#" concatenation operator
+From the March 2002 issue of "IEEE Transactions on Mechatronics",
+page 21, reference #8.
+@article{IEEEexample:articledualmonths,
+  author        = "Y. Okada and K. Dejima and T. Ohishi",
+  title         = "Analysis and Comparison of {PM} Synchronous Motor and
+                   Induction Motor Type Magnetic Bearings",
+  journal       = IEEE_J_IA,
+  volume        = "31",
+  month         = sep # "/" # oct,
+  year          = "1995",
+  pages         = "1047-1053"
+}
+
+
+journal article to be published as a misc entry type
+date information like month and year is optional 
+However, the article form like that below may be a better approach.
+From the May 2002 issue of "IEEE Journal of Selected Areas in 
+Communication", page 725, reference #3.
+@misc{IEEEexample:TBPmisc,
+  author        = "M. Coates and A. Hero and R. Nowak and B. Yu",
+  title         = "Internet Tomography",
+  howpublished  = IEEE_M_SP,
+  month         = may,
+  year          = "2002",
+  note          = "to be published"
+}
+
+
+journal article to be published as an article entry type
+year is required, so if absent, use the year field to hold
+the "submitted for publication" in order to avoid a warning for
+the missing year field.
+From the June 2002 issue of "IEEE Transactions on Information Theory",
+page 1461, reference #21.
+@article{IEEEexample:TBParticle,
+  author        = "N. Kahale and R. Urbanke",
+  title         = "On the Minimum Distance of Parallel and Serially
+                   Concatenated Codes",
+  journal       = IEEE_J_IT,
+  year          = "submitted for publication"
+}
+
+
+
+
+
+book with editor and no author
+From the June 2002 issue of "IEEE Transactions on Information Theory",
+page 1725, reference #1.
+@book{IEEEexample:bookwitheditor,
+  editor        = "J. C. Candy and G. C. Temes",
+  title         = "Oversampling Delta-Sigma Data Converters Theory,
+                   Design and Simulation",
+  publisher     = "{IEEE} Press.",
+  address       = "New York",
+  year          = "1992"
+}
+
+
+book with edition, author and editor
+Note that the standard BibTeX styles do not support book entries with both
+author and editor fields, but IEEEtran.bst does.
+The standard BibTeX way of specifying the edition is to use capitalized
+ordinal words such as "First", "Second", etc. Most .bst files can convert
+up to about "Fifth" into the format needed. IEEEtran.bst can convert up
+to "Tenth" to the "Arabic ordinal" form IEEE uses (e.g., "10th"). For
+editions over the tenth, it is best to use the "Arabic ordinal" form for
+IEEE related work (e.g., "101st")
+Note how "Jr." has to be entered.
+From the May 2002 issue of "Journal of Lightwave Technology", page 856,
+reference #17.
+@book{IEEEexample:book,
+  author        = "S. M. Metev and V. P. Veiko",
+  editor        = "Osgood, Jr., R. M.",
+  title         = "Laser Assisted Microtechnology",
+  edition       = "Second",
+  publisher     = "Springer-Verlag",
+  address       = "Berlin, Germany",
+  year          = "1998"
+}
+
+
+book with series and volume
+From the January 2000 issue of "IEEE Transactions on Communications",
+page 11, reference #31.
+@book{IEEEexample:bookwithseriesvolume,
+  editor        = "J. Breckling",
+  title         = "The Analysis of Directional Time Series: Applications to
+                   Wind Speed and Direction",
+  series        = "Lecture Notes in Statistics",
+  publisher     = "Springer",
+  address       = "Berlin, Germany",
+  year          = "1989",
+  volume        = "61"
+}
+
+
+inbook with chapter number. The pages field could also have been given.
+The chapter number could be changed to something else such as a section
+number via the type field: type = "sec.".
+From the May 2002 issue of "IEEE Transactions on Circuits and Systems---I: 
+Fundamental Applications and Theory", page 638, reference #22.
+@inbook{IEEEexample:inbook,
+  author        = "H. E. Rose",
+  title         = "A Course in Number Theory",
+  publisher     = "Oxford Univ. Press",
+  address       = "New York, NY",
+  year          = "1988",
+  chapter       = "3"
+}
+
+
+inbook with pages and note. The language field is not set to Russian
+because the title is presented here in its translated, English, form.
+From the May 2002 issue of "IEEE Transactions on Magnetics", page 1533,
+reference #5.
+@inbook{IEEEexample:inbookpagesnote,
+  author        = "B. K. Bul",
+  title         = "Theory Principles and Design of Magnetic Circuits",
+  publisher     = "Energia Press",
+  address       = "Moscow",
+  year          = "1964",
+  pages         = "464",
+  note          = "(in Russian)"
+}
+
+
+
+
+
+incollection with author and editor
+From the May 2002 issue of "Journal of Lightwave Technology",
+page 807, reference #7.
+@incollection{IEEEexample:incollection,
+  author        = "W. V. Sorin",
+  editor        = "D. Derickson",
+  title         = "Optical Reflectometry for Component Characterization",
+  booktitle     = "Fiber Optic Test and Measurement",
+  publisher     = "Prentice-Hall",
+  address       = "Englewood Cliffs, NJ",
+  year          = "1998"
+}
+
+
+incollection with series
+From the April 2000 issue of "IEEE Transactions on Communication",
+page 609, reference #3.
+@incollection{IEEEexample:incollectionwithseries,
+  author        = "J. B. Anderson and K. Tepe",
+  title         = "Properties of the Tailbiting {BCJR} Decoder",
+  booktitle     = "Codes, Systems and Graphical Models",
+  series        = "{IMA} Volumes in Mathematics and Its Applications",
+  publisher     = "Springer-Verlag",
+  address       = "New York",
+  year          = "2000"
+  
+}
+
+
+incollection with author, editor, chapter and pages
+From the January 2000 issue of "IEEE Transactions on Communications",
+page 16, reference #9.
+@incollection{IEEEexample:incollection_chpp,
+  author        = "P. Hedelin and P. Knagenhjelm and M. Skoglund",
+  editor        = "W. B. Kleijn and K. K. Paliwal",
+  title         = "Theory for Transmission of Vector Quantization Data",
+  booktitle     = "Speech Coding and Synthesis",
+  publisher     = "Elsevier Science",
+  address       = "Amsterdam, The Netherlands",
+  year          = "1995",
+  chapter       = "10",
+  pages         = "347-396"
+}
+
+
+incollection with a large number of authors, some authors/journals will
+use et al. for so many names. IEEEtran.bst can be configured to do this
+if desired, or "R. M. A. Dawson and others" can be used instead.
+Note that IEEE may not include the publisher for incollection entries -
+IEEEtran.bst will not issue a warning if the publisher is missing for
+incollections - but other .bst files often will.
+From the June 2002 issue of "IEEE Transactions on Electron Devices",
+page 996, reference #12.
+@incollection{IEEEexample:incollectionmanyauthors,
+  author        = "R. M. A. Dawson and Z. Shen and D. A. Furst and
+                   S. Connor and J. Hsu and M. G. Kane and R. G. Stewart and
+                   A. Ipri and C. N. King and P. J. Green and R. T. Flegal
+                   and S. Pearson and W. A. Barrow and E. Dickey and K. Ping
+                   and C. W. Tang and S. Van. Slyke and
+                   F. Chen and J. Shi and J. C. Sturm and M. H. Lu",
+  title         = "Design of an Improved Pixel for a Polysilicon 
+                   Active-Matrix Organic {LED} Display",
+  booktitle     = "{SID} Tech. Dig.",
+  volume        = "29",
+  year          = "1998",
+  pages         = "11-14"
+}
+
+
+
+
+
+A Motorola data book as a manual
+It is somewhat unusual to include the data book part number.
+in the title. It might be more correct to put this information
+in the howpublished field instead.
+From the December 2000 issue of "IEEE Transactions on Communications",
+page 1986, reference #10.
+@manual{IEEEexample:motmanual,
+  title         = "{FLEXChip} Signal Processor ({MC68175/D})",
+  organization  = "Motorola",
+  year          = "1996"
+}
+
+
+same reference, but using IEEEtran's howpublished extension
+@manual{IEEEexample:motmanualhowpub,
+  title         = "{FLEXChip} Signal Processor",
+  howpublished  = "{MC68175/D}",
+  organization  = "Motorola",
+  year          = "1996"
+}
+
+
+
+
+conference paper with an address and days. Some journals capitalize the
+letters in "Globecom", this one did not.
+From the May 2002 issue of "IEEE Transactions on Communications",
+page 697, reference #12.
+@inproceedings{IEEEexample:confwithadddays,
+  author        = "M. S. Yee and L. Hanzo",
+  title         = "Radial Basis Function Decision Feedback Equaliser
+                   Assisted Burst-by-burst Adaptive Modulation",
+  booktitle     = "Proc. {IEEE} Globecom '99",
+  address       = "Rio de Janeiro, Brazil",
+  month         = dec # " 5--9,",
+  year          = "1999",
+  pages         = "2183-2187"
+}
+
+
+conference paper with volume number. A conference proceedings with a vol
+number is a little uncommon, note that the vol number is placed
+before the address in the formatted bibliography entry
+From the April 2002 issue of "IEEE/ACM Transactions on Networking",
+page 181, reference #26.
+@inproceedings{IEEEexample:confwithvolume,
+  author        = "M. Yajnik and S. B. Moon and J. Kurose and D. Towsley",
+  title         = "Measurement and Modeling of the Temporal Dependence in
+                   Packet Loss",
+  booktitle     = "Proc. {IEEE} {INFOCOM}'99",
+  volume        = "1",
+  address       = "New York, NY",
+  month         = mar,
+  year          = "1999",
+  pages         = "345-352"
+}
+
+
+conference paper with a paper number, the type field can be used to
+override the word "paper", e.g., type = "postdeadline paper". A type
+can be given even without a paper  field.
+Also, IEEEtran.bst can be configured to ignore paper numbers and types.
+From the May 2002 issue of "Journal of Lightwave Technology",
+page 807, reference #4.
+@inproceedings{IEEEexample:confwithpaper,
+  author        = "M. Wegmuller and J. P. von der Weid and P. Oberson
+                   and N. Gisin",
+  title         = "High Resolution Fiber Distributed Measurements With
+                   Coherent {OFDR}",
+  booktitle     = "Proc. {ECOC}'00",
+  year          = "2000",
+  paper         = "11.3.4",
+  pages         = "109"
+}
+
+
+conference paper with a postdeadline type paper, the paper field is
+optional.
+From the August 2000 issue of "IEEE Photonics Technology Letters",
+page 1087, reference #12.
+@inproceedings{IEEEexample:confwithpapertype,
+  author        = "B. Mikkelsen and G. Raybon and R.-J. Essiambre and
+                   K. Dreyer and Y. Su. and L. E. Nelson and J. E. Johnson
+                   and G. Shtengel and A. Bond and D. G. Moodie and
+                   A. D. Ellis",
+  title         = "160 {Gbit/s} Single-channel Transmission Over 300 km 
+                   Nonzero-dispersion Fiber With Semiconductor Based
+                   Transmitter and Demultiplexer",
+  booktitle     = "Proc. {ECOC}'99",
+  year          = "1999",
+  paper         = "2-3",
+  type          = "postdeadline paper",
+  pages         = "28-29"
+}
+
+
+presented at a conference
+intype overrides the default "in" and causes the booktitle not to be
+emphasized (rendered in italics).
+From the February 2002 issue of "IEEE/ACM Transactions on Networking",
+page 163, reference #6.
+@inproceedings{IEEEexample:presentedatconf,
+  author        = "S. G. Finn and M. M{\'e}dard and R. A. Barry",
+  title         = "A Novel Approach to Automatic Protection Switching
+                   Using Trees",
+  intype        = "presented at the",
+  booktitle     = "Proc. Int. Conf. Commun.",
+  year          = "1997"
+}
+
+
+
+
+
+master's thesis, often the University name will be abbreviated and the
+state or country will be included in the address. The type field can
+used to override the default type "Master's thesis"
+From the June 2002 issue of "IEEE Transactions on Microelectromechanical
+Systems", page 186, reference #11.
+@mastersthesis{IEEEexample:masters,
+  author        = "Nin C. Loh",
+  title         = "High-Resolution Micromachined Interferometric
+                   Accelerometer",
+  school        = "Massachusetts Institute of Technology",
+  address       = "Cambridge",
+  year          = "1992"
+}
+
+
+master's thesis with a type field
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 391, reference #12.
+@mastersthesis{IEEEexample:masterstype,
+  author        = "A. Karnik",
+  title         = "Performance of {TCP} Congestion Control with Rate
+                   Feedback: {TCP/ABR} and Rate Adaptive {TCP/IP}",
+  school        = "Indian Institute of Science",
+  type          = "M. Eng. thesis",
+  address       = "Bangalore, India",
+  month         = jan,
+  year          = "1999"
+}
+
+
+
+
+
+Ph.D. dissertation with a URL field, the university is abbreviated
+From the October 2001 issue of "IEEE/ACM Transactions on Networking",
+page 590, reference #11.
+@phdthesis{IEEEexample:phdurl,
+  author        = "Q. Li",
+  title         = "Delay Characterization and Performance Control of
+                   Wide-area Networks",
+  school        = "Univ. of Delaware",
+  address       = "Newark",
+  month         = may,
+  year          = "2000",
+  url           = "http://www.ece.udel.edu/~qli"
+}
+
+
+
+
+
+technical report
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 490, reference #15.
+@techreport{IEEEexample:techrep,
+  author        = "R. Jain and K. K. Ramakrishnan and D. M. Chiu",
+  title         = "Congestion Avoidance in Computer Networks with a 
+                   Connectionless Network Layer",
+  institution   = "Digital Equipment Corporation",
+  address       = "MA",
+  number        = "DEC-TR-506",
+  month         = aug,
+  year          = "1987"
+}
+
+
+technical report with type
+for those times when "Tech. Rep." needs to be modified
+From the February 2001 issue of "IEEE/ACM Transactions on Networking",
+page 46, reference #8.
+@techreport{IEEEexample:techreptype,
+  author        = "J. Padhye and V. Firoiu and D. Towsley",
+  title         = "A Stochastic Model of {TCP} {R}eno Congestion Avoidance
+                   and Control",
+  institution   = "Univ. of Massachusetts",
+  address       = "Amherst, MA",
+  type          = "CMPSCI Tech. Rep.",
+  number        = "99-02",
+  year          = "1999"
+}
+
+
+technical report with type
+for those times when "Tech. Rep." needs to be modified
+This reference did not have an address.
+From the January 2000 issue of "IEEE Transactions on Communications",
+page 117, reference #6.
+@techreport{IEEEexample:techreptypeii,
+  author        = "D. Middleton and A. D. Spaulding",
+  title         = "A Tutorial Review of Elements of Weak Signal Detection
+                   in Non-{G}aussian {EMI} Environments",
+  institution   = "National Telecommunications and Information
+                   Administration ({NTIA}), U.S. Dept. of Commerce",
+  type          = "NTIA Report",
+  number        = "86-194",
+  month         = may,
+  year          = "1986"
+}
+
+
+
+
+
+an unpublished work
+for unpublished types, the note field is required. IEEE usually
+just uses the word "unpublished" for the note.
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 391, reference #16.
+@unpublished{IEEEexample:unpublished,
+  author        = "T. J. Ott and N. Aggarwal",
+  title         = "{TCP} over {ATM}: {ABR} or {UBR}",
+  note          = "Unpublished"
+}
+
+
+
+
+
+electronic with a howpublished information field 
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 391, reference #7.
+@electronic{IEEEexample:electronhowinfo,
+  author        = "V. Jacobson",
+  title         = "Modified {TCP} Congestion Avoidance Algorithm",
+  howpublished  = "end2end-interest mailing list",
+  url           = "ftp://ftp.isi.edu/end2end/end2end-interest-1990.mail",
+  month         = apr,
+  year          = "1990"
+}
+
+
+electronic with a howpublished information field 
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 418, reference #31.
+@electronic{IEEEexample:electronhowinfo2,
+  author        = "V. Valloppillil and K. W. Ross",
+  title         = "Cache Array Routing Protocol v1.1",
+  howpublished  = "Internet draft",
+  url           = "http://ds1.internic.net/internet-drafts/draft-vinod-carp-v1-03.txt",
+  year          = "1998"
+}
+
+
+electronic with an organization and address
+From the February 2002 issue of "IEEE/ACM Transactions on Networking",
+page 114, reference #15.
+@electronic{IEEEexample:electronorgadd,
+  author        = "D. H. Lorenz and A. Orda",
+  title         = "Optimal Partition of {QoS} Requirements on Unicast
+                   Paths and Multicast Trees",
+  organization  = "Dept. Elect. Eng., Technion",
+  address       = "Haifa, Israel",
+  url           = "ftp://ftp.technion.ac.il/pub/supported/ee/Network/lor.mopq98.ps",
+  month         = jul,
+  year          = "1998"
+}
+
+
+
+
+
+U.S. patent
+Use the type field to override the patent type. e.g.,
+type = "Patent Application"
+The address is that of the assignee. Note that IEEE does not
+display the assignee, the address, and only displays one date.
+(if year is not present, the filed dates are used.) However, this
+information should be entered as other BibTeX styles may use it.
+alternatively, nationality could be entered as "U.S." 
+From the April 2000 issue of "IEEE Transactions on Communications",
+page 542, reference #6.
+@patent{IEEEexample:uspat,
+  author        = "Ronald E. Sorace and Victor S. Reinhardt and
+                   Steven A. Vaughn",
+  assignee      = "Hughes Aircraft Company",
+  address       = "Los Angeles, CA",
+  title         = "High-Speed Digital-to-{RF} Converter",
+  nationality   = "United States",
+  number        = "5668842",
+  dayfiled      = "28",
+  monthfiled    = feb,
+  yearfiled     = "1995",
+  day           = "16",
+  month         = sep,
+  year          = "1997"
+}
+
+
+Japanese Patent
+From the April 2000 issue of "IEEE Transactions on Communications",
+page 556, reference #6.
+@patent{IEEEexample:jppat,
+  author        = "U. Hideki",
+  title         = "Quadrature Modulation Circuit",
+  nationality   = "Japanese",
+  number        = "152932/92",
+  day           = "20",
+  month         = may,
+  year          = "1992"
+}
+
+
+French Patent request, the language field must be entered in lower case
+as this is the option name Babel uses. The nationality field needs to be
+capitalized. Because this is a patent request, the date filed fields are
+used while the date fields are left empty/missing. In other countries,
+the words "Patent Application", etc. are used instead.
+From the April 2000 issue of "IEEE Transactions on Communications",
+page 556, reference #9.
+@patent{IEEEexample:frenchpatreq,
+  author        = "F. Kowalik and M. Isard",
+  title         = "Estimateur d'un D{\'e}faut de Fonctionnement 
+                   d'un Modulateur en Quadrature et {\'E}tage de Modulation
+                   l'Utilisant",
+  language      = "french",
+  nationality   = "French",
+  type          = "Patent Request",
+  number        = "9500261",
+  dayfiled      = "11",
+  monthfiled    = jan,
+  yearfiled     = "1995"
+}
+
+
+
+
+
+a periodical
+From the April 2001 issue of "IEEE/ACM Transactions on Networking",
+page 160, reference #1.
+sort key is needed for sorting styles
+@periodical{IEEEexample:periodical,
+  title         = IEEE_M_PCOM # ", Special Issue on Wireless {ATM}",
+  volume        = "3",
+  month         = aug,
+  year          = "1996",
+  key           = "IEEE"
+}
+
+
+
+
+
+standard, IEEE does not use the address for standards, but it is good
+to provide one for BibTeX styles that use it.
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 451, reference #2.
+@standard{IEEEexample:standard,
+  title         = "Wireless {LAN} Medium Access Control {(MAC)} and 
+                   Physical Layer {(PHY)} Specification",
+  organization  = "IEEE",
+  address       = "Piscataway, NJ",
+  number        = "802.11",
+  year          = "1997"
+}
+
+
+standard with type and revision, the type overrides the word standard
+(or std.). Here a standard number is not available and a revision number
+is used.
+From the August 2000 issue of "IEEE Photonics Technology Letters",
+page 1048, reference #13.
+@standard{IEEEexample:standardproposed,
+  title         = "Fiber Channel Physical Interface ({FC-PI})",
+  institution   = "NCITS",
+  address       = "Washington, DC",
+  type          = "Working Draft Proposed Standard",
+  revision      = "5.2",
+  year          = "1999"
+}
+
+
+standard draft as a misc with author
+From the May 2002 issue of "IEEE Journal of Selected Areas in
+Communication", page 725, reference #16.
+@misc{IEEEexample:draftasmisc,
+  author        = "I. Widjaja and A. Elwalid",
+  title         = "{MATE}: {MPLS} Adaptive Traffic Engineering",
+  howpublished  = "IETF Draft",
+  year          = "1999"
+}
+
+
+
+
+
+misc for a techreport like reference
+techreport is not perfectly suitable because this entry lacks
+an institution field
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 490, reference #22.
+@misc{IEEEexample:miscforum,
+  author        = "L. Roberts",
+  title         = "Enhanced Proportional Rate Control Algorithm {PRCA}",
+  howpublished  = "{ATM} Forum Contribution 94-0735R1",
+  month         = aug,
+  year          = "1994"
+}
+
+
+misc for a white paper
+From the August 2001 issue of "IEEE/ACM Transactions on Networking",
+page 478, reference #4 - Note that the reference there (improperly?)
+used the author field for "Cisco".
+@misc{IEEEexample:whitepaper,
+  title         = "Advanced {QoS} Services for the Intelligent Internet",
+  howpublished  = "White Paper",
+  organization  = "Cisco",
+  month         = may,
+  year          = "1997"
+}
+
+
+misc for a data sheet
+From the November 2000 issue of "IEEE Photonics Technology Letters",
+page 1551, reference #6.
+@misc{IEEEexample:datasheet,
+  title         = "{PDCA12-70} Data Sheet",
+  organization  = "Opto Speed SA",
+  address       = "Mezzovico, Switzerland"
+}
+
+
+
+
+
+Other unusual references
+
+a private communication as a misc entry type
+sometimes the designation "personal communication" is used instead
+From the June 2002 issue of "IEEE Transactions on Information Theory",
+page 1725, reference #16.
+@misc{IEEEexample:private,
+  author        = "S. Konyagin",
+  howpublished  = "private communication",
+  year          = "1998"
+}
+
+
+an internet request for comments (RFC) as a misc entry type
+It would also be nice to add a URL to these types of things.
+RFCs can also be handled as electronic references.
+From the April 2002 issue of "IEEE/ACM Transactions on Networking",
+page 181, reference #14.
+@misc{IEEEexample:miscrfc,
+  author        = "K. K. Ramakrishnan and S. Floyd",
+  title         = "A Proposal to Add Explicit Congestion
+                   Notification ({ECN}) to {IP}",
+  howpublished  = "RFC 2481",
+  month         = jan,
+  year          = "1999"
+}
+
+
+a software package as a manual
+From the June 2002 issue of "IEEE/ASME Journal of Microelectromechanical
+Systems", page 205, reference #20.
+Sometimes they put the version/release information in the title.
+@manual{IEEEexample:softmanual,
+  title         = "SaberDesigner Reference Manual",
+  organization  = "Analogy, Inc.",
+  address       = "Beaverton, OR",
+  year          = "1998",
+  note          = "Release 4.3"
+}
+
+
+a software package as an electronic reference
+From the February 2003 issue of  "IEEE/ACM Transactions on Networking",
+page 46, reference #24. If there is no author or organization, a sorting
+key is required for sorting styles. It might be a good idea to include
+month and year fields as well.
+@electronic{IEEEexample:softonline,
+  title         = "Ucb/lbnl/vint Network Simulator---ns (Version 2)",
+  url           = "http://www-mash.cs.berkeley.edu/ns/",
+  key           = "ns"
+}
+
+
+misc for a German regulation
+In German, the first letters of nouns are capitalized, so we do so here.
+From the June 2002 issue of "IEEE Journal in Selected Areas in
+Communication", page 892, reference #9.
+@misc{IEEEexample:miscgermanreg,
+  title         = "{M}essung von {S}t{\"o}rfeldern an {A}nlagen 
+                   und {L}eitungen der {T}elekommunikation im
+                   {F}requenzbereich 9 {kHz} bis 3 {GHz}",
+  language      = "german",
+  howpublished  = "{M}e{\ss}vorschrift {R}eg {TP} {MV} 05",
+  organization  = "Regulierungsbeh{\"o}rde f{\"u}r {T}elekommunikation und
+                   {P}ost ({R}eg {TP})"
+}
+
+
+
+Ways to handle things like CCSDS's Blue Books
+journal article with a URL. However, this is not a very good approach
+because the Blue Books are not really journals and the author field has
+to be abused.
+From the June 2002 issue of "IEEE Transactions on Information Theory",
+page 1461, reference #7.
+@article{IEEEexample:bluebookarticle,
+  author        = "{Consulative Committee for Space Data Systems (CCSDS)}",
+  title         = "Telemetry Channel Coding",
+  journal       = "Blue Book",
+  number        = "4",
+  year          = "1999",
+  url           = "http://www.ccsds.org/documents/pdf/CCSDS-101.0-B-4.pdf"
+}
+
+
+CCSDS's Blue Book handled as a book
+However, it is not a good idea to have to use the author field for
+an organization (done here because the book entry type requires an
+author field).
+@book{IEEEexample:bluebookbook,
+  author        = "{Consulative Committee for Space Data Systems (CCSDS)}",
+  title         = "Telemetry Channel Coding",
+  series        = "Blue Book",
+  number        = "4",
+  publisher     = "{CCSDS}",
+  address       = "Newport Beach, {CA}",
+  year          = "1999",
+  url           = "http://www.ccsds.org/documents/pdf/CCSDS-101.0-B-4.pdf"
+}
+
+
+CCSDS's Blue Book handled as a manual
+This is a much better approach, but uses the howpublished field.
+@manual{IEEEexample:bluebookmanual,
+  title         = "Telemetry Channel Coding",
+  howpublished  = "ser. Blue Book, No. 4",
+  organization  = "Consulative Committee for Space Data Systems (CCSDS)",
+  address       = "Newport Beach, CA",
+  year          = "1999",
+  url           = "http://www.ccsds.org/documents/pdf/CCSDS-101.0-B-4.pdf"
+}
+
+
+
+CCSDS's Blue Book handled as a standard
+Probably the best approach for this particular case because the work
+is standard related. Note that IEEE does not display the address for
+standards.
+@standard{IEEEexample:bluebookstandard,
+  title         = "Telemetry Channel Coding",
+  howpublished  = "ser. Blue Book, No. 4",
+  organization  = "Consulative Committee for Space Data Systems (CCSDS)",
+  address       = "Newport Beach, CA",
+  type          = "Recommendation for Space Data System Standard",
+  number        = "101.0-B-4",
+  month         = May,
+  year          = "1999",
+  url           = "http://www.ccsds.org/documents/pdf/CCSDS-101.0-B-4.pdf"
+}
+
+
+
+
+
+
+
+
+An example of a IEEEtran control entry which can change some IEEEtran.bst
+settings. An entry like this must be cited via \bstctlcite{} command
+before the first real \cite{}. The same entry key cannot be called twice
+(just like multiple \cite{} of the same entry key place only one entry
+in the bibliography.)
+The available control fields are:
+
+CTLuse_article_number
+"no" turns off the display of the number for articles.
+"yes" enables
+
+CTLuse_paper
+"no" turns off the display of the paper and type fields in inproceedings.
+"yes" enables
+
+CTLuse_forced_etal 
+"no" turns off the forced use of "et al."
+"yes" enables
+
+CTLmax_names_forced_etal
+The maximum number of names that can be present beyond which an "et al."
+usage is forced. Be sure that CTLnames_show_etal (below)
+is not greater than this value!
+
+CTLnames_show_etal
+The number of names that will be shown with a forced "et al.".
+Must be less than or equal to CTLmax_names_forced_etal
+
+CTLuse_alt_spacing 
+"no" turns off the alternate interword spacing for entries with URLs.
+"yes" enables
+
+CTLalt_stretch_factor
+If alternate interword spacing for entries with URLs is enabled, this is
+the interword spacing stretch factor that will be used. For example, the
+default "4" here means that the interword spacing in entries with URLs can
+stretch to four times normal. Does not have to be an integer.
+
+CTLdash_repeated_names
+"no" turns off the "dashification" of repeated (i.e., identical to those
+of the previous entry) names. IEEE normally does this.
+"yes" enables
+
+CTLname_format_string
+The name format control string as explained in the BibTeX style hacking
+guide.
+IEEE style "{f.~}{vv~}{ll}{, jj}" is the default,
+
+CTLname_latex_cmd
+A LaTeX command that each name will be fed to (e.g., "\textsc").
+Leave empty if no special font is desired for the names.
+The default is empty.
+
+CTLname_url_prefix
+The prefix text used before URLs.
+The default is "[Online]. Available:" A space will be inserted after this
+text. If this space is not wanted, just use \relax at the end of the
+prefix text.
+
+
+Those fields that are not to be changed can be left out.
+@IEEEtranBSTCTL{IEEEexample:BSTcontrol,
+  CTLuse_article_number     = "yes",
+  CTLuse_paper              = "yes",
+  CTLuse_forced_etal        = "no",
+  CTLmax_names_forced_etal  = "10",
+  CTLnames_show_etal        = "1",
+  CTLuse_alt_spacing        = "yes",
+  CTLalt_stretch_factor     = "4",
+  CTLdash_repeated_names    = "yes",
+  CTLname_format_string     = "{f.~}{vv~}{ll}{, jj}",
+  CTLname_latex_cmd         = "",
+  CTLname_url_prefix        = "[Online]. Available:"
+}
+
+

--- a/ieee/IEEEfull.bib
+++ b/ieee/IEEEfull.bib
@@ -1,0 +1,419 @@
+
+IEEEfull.bib
+V1.12 (2007/01/11)
+Copyright (c) 2002-2007 by Michael Shell
+See: http://www.michaelshell.org/
+for current contact information.
+
+BibTeX bibliography string definitions of the FULL titles of
+IEEE journals and magazines and online publications.
+
+This file is designed for bibliography styles that require 
+full-length titles and is not for use in bibliographies that
+abbreviate titles.
+
+Support sites:
+http://www.michaelshell.org/tex/ieeetran/
+http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+and/or
+http://www.ieee.org/
+
+Special thanks to Laura Hyslop and ken Rawson of IEEE for their help
+in obtaining the information needed to compile this file. Also,
+Volker Kuhlmann and Moritz Borgmann kindly provided some corrections
+and additions.
+
+*************************************************************************
+Legal Notice:
+This code is offered as-is without any warranty either expressed or
+implied; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE! 
+User assumes all risk.
+In no event shall IEEE or any contributor to this code be liable for
+any damages or losses, including, but not limited to, incidental,
+consequential, or any other damages, resulting from the use or misuse
+of any information contained here.
+
+All comments are the opinions of their respective authors and are not
+necessarily endorsed by the IEEE.
+
+This work is distributed under the LaTeX Project Public License (LPPL)
+( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+distributed and modified. A copy of the LPPL, version 1.3, is included
+in the base LaTeX documentation of all distributions of LaTeX released
+2003/12/01 or later.
+Retain all contribution notices and credits.
+** Modified files should be clearly indicated as such, including  **
+** renaming them and changing author support contact information. **
+
+File list of work: IEEEabrv.bib, IEEEfull.bib, IEEEexample.bib,
+                   IEEEtran.bst, IEEEtranS.bst, IEEEtranSA.bst,
+                   IEEEtranN.bst, IEEEtranSN.bst, IEEEtran_bst_HOWTO.pdf
+*************************************************************************
+
+
+USAGE:
+
+\bibliographystyle{mybstfile}
+\bibliography{IEEEfull,mybibfile}
+
+where the IEEE titles in the .bib database entries use the strings
+defined here. e.g.,
+
+
+   journal = IEEE_J_AC,
+
+
+to yield "{IEEE} Transactions on Automatic Control"
+
+
+WARNING: IEEE uses abbreviated journal titles in their bibliographies!
+Because this file provides the full titles, you should NOT use this file
+for work that is to be submitted to the IEEE.
+
+For IEEE work, you should use the abbreviated titles provided in the
+companion file, IEEEabrv.bib.
+
+
+** NOTES **
+
+ 1. Journals have been grouped according to subject in order to make it
+    easier to locate and extract the definitions for related journals - 
+    as most works use references that are confined to a single topic.
+    Magazines are listed in straight alphabetical order.
+
+ 2. String names are closely based on IEEE's own internal acronyms.
+
+ 3. Older, out-of-print IEEE titles are included (but not including titles
+    dating prior to IEEE's formation from the IRE and AIEE in 1963).
+
+
+
+
+
+
+IEEE Journals 
+
+
+
+aerospace and military
+@STRING{IEEE_J_AES        = "{IEEE} Transactions on Aerospace and Electronic Systems"}
+@STRING{IEEE_J_ANE        = "{IEEE} Transactions on Aerospace and Navigational Electronics"}
+@STRING{IEEE_J_ANNE       = "{IEEE} Transactions on Aeronautical and Navigational Electronics"}
+@STRING{IEEE_J_AS         = "{IEEE} Transactions on Aerospace"}
+@STRING{IEEE_J_AIRE       = "{IEEE} Transactions on Airborne Electronics"}
+@STRING{IEEE_J_MIL        = "{IEEE} Transactions on Military Electronics"}
+
+
+
+autos, transportation and vehicles (non-aerospace)
+@STRING{IEEE_J_ITS        = "{IEEE} Transactions on Intelligent Transportation Systems"}
+@STRING{IEEE_J_VT         = "{IEEE} Transactions on Vehicular Technology"}
+@STRING{IEEE_J_VC         = "{IEEE} Transactions on Vehicular Communications"}
+
+
+
+circuits, signals, systems, audio and controls
+@STRING{IEEE_J_SPL        = "{IEEE} Signal Processing Letters"}
+@STRING{IEEE_J_ASSP       = "{IEEE} Transactions on Acoustics, Speech, and Signal Processing"}
+@STRING{IEEE_J_AU         = "{IEEE} Transactions on Audio"}
+@STRING{IEEE_J_AUEA       = "{IEEE} Transactions on Audio and Electroacoustics"}
+@STRING{IEEE_J_AC         = "{IEEE} Transactions on Automatic Control"}
+@STRING{IEEE_J_CAS        = "{IEEE} Transactions on Circuits and Systems"}
+@STRING{IEEE_J_CASVT      = "{IEEE} Transactions on Circuits and Systems for Video Technology"}
+@STRING{IEEE_J_CASI       = "{IEEE} Transactions on Circuits and Systems---Part {I}: Fundamental Theory and Applications"}
+@STRING{IEEE_J_CASII      = "{IEEE} Transactions on Circuits and Systems---Part {II}: Analog and Digital Signal Processing"}
+in 2004 CASI and CASII renamed part title to CASI_RP and CASII_EB, respectively.
+@STRING{IEEE_J_CASI_RP    = "{IEEE} Transactions on Circuits and Systems---Part {I}: Regular Papers"}
+@STRING{IEEE_J_CASII_EB   = "{IEEE} Transactions on Circuits and Systems---Part {II}: Express Briefs"}
+@STRING{IEEE_J_CT         = "{IEEE} Transactions on Circuit Theory"}
+@STRING{IEEE_J_CST        = "{IEEE} Transactions on Control Systems Technology"}
+@STRING{IEEE_J_SP         = "{IEEE} Transactions on Signal Processing"}
+@STRING{IEEE_J_SU         = "{IEEE} Transactions on Sonics and Ultrasonics"}
+@STRING{IEEE_J_SAP        = "{IEEE} Transactions on Speech and Audio Processing"}
+@STRING{IEEE_J_UE         = "{IEEE} Transactions on Ultrasonics Engineering"}
+@STRING{IEEE_J_UFFC       = "{IEEE} Transactions on Ultrasonics, Ferroelectrics, and Frequency Control"}
+
+
+
+communications
+@STRING{IEEE_J_COML       = "{IEEE} Communications Letters"}
+@STRING{IEEE_J_JSAC       = "{IEEE} Journal on Selected Areas in Communications"}
+@STRING{IEEE_J_COM        = "{IEEE} Transactions on Communications"}
+@STRING{IEEE_J_COMT       = "{IEEE} Transactions on Communication Technology"}
+@STRING{IEEE_J_WCOM       = "{IEEE} Transactions on Wireless Communications"}
+
+
+
+components, packaging and manufacturing
+@STRING{IEEE_J_ADVP       = "{IEEE} Transactions on Advanced Packaging"}
+@STRING{IEEE_J_CHMT       = "{IEEE} Transactions on Components, Hybrids and Manufacturing Technology"}
+@STRING{IEEE_J_CPMTA      = "{IEEE} Transactions on Components, Packaging and Manufacturing Technology---Part {A}"}
+@STRING{IEEE_J_CPMTB      = "{IEEE} Transactions on Components, Packaging and Manufacturing Technology---Part {B}: Advanced Packaging"}
+@STRING{IEEE_J_CPMTC      = "{IEEE} Transactions on Components, Packaging and Manufacturing Technology---Part {C}: Manufacturing"}
+@STRING{IEEE_J_CAPT       = "{IEEE} Transactions on Components and Packaging Technology"}
+@STRING{IEEE_J_CAPTS      = "{IEEE} Transactions on Components and Packaging Technologies"}
+@STRING{IEEE_J_CPART      = "{IEEE} Transactions on Component Parts"}
+@STRING{IEEE_J_EPM        = "{IEEE} Transactions on Electronics Packaging Manufacturing"}
+@STRING{IEEE_J_MFT        = "{IEEE} Transactions on Manufacturing Technology"}
+@STRING{IEEE_J_PHP        = "{IEEE} Transactions on Parts, Hybrids and Packaging"}
+@STRING{IEEE_J_PMP        = "{IEEE} Transactions on Parts, Materials and Packaging"}
+
+
+
+CAD
+@STRING{IEEE_J_TCAD       = "{IEEE} Journal on Technology in Computer Aided Design"}
+@STRING{IEEE_J_CAD        = "{IEEE} Transactions on Computer-Aided Design of Integrated Circuits and Systems"}
+
+
+
+coding, data, information, knowledge
+@STRING{IEEE_J_IT         = "{IEEE} Transactions on Information Theory"}
+@STRING{IEEE_J_KDE        = "{IEEE} Transactions on Knowledge and Data Engineering"}
+
+
+
+computers, computation, networking and software
+@STRING{IEEE_J_C          = "{IEEE} Transactions on Computers"}
+@STRING{IEEE_J_CAL        = "{IEEE} Computer Architecture Letters"}
+@STRING{IEEE_J_DSC        = "{IEEE} Transactions on Dependable and Secure Computing"}
+@STRING{IEEE_J_ECOMP      = "{IEEE} Transactions on Electronic Computers"}
+@STRING{IEEE_J_EVC        = "{IEEE} Transactions on Evolutionary Computation"}
+@STRING{IEEE_J_FUZZ       = "{IEEE} Transactions on Fuzzy Systems"}
+@STRING{IEEE_J_IFS        = "{IEEE} Transactions on Information Forensics and Security"}
+@STRING{IEEE_J_MC         = "{IEEE} Transactions on Mobile Computing"}
+@STRING{IEEE_J_NET        = "{IEEE/ACM} Transactions on Networking"}
+@STRING{IEEE_J_NN         = "{IEEE} Transactions on Neural Networks"}
+@STRING{IEEE_J_PDS        = "{IEEE} Transactions on Parallel and Distributed Systems"}
+@STRING{IEEE_J_SE         = "{IEEE} Transactions on Software Engineering"}
+
+
+
+computer graphics, imaging, and multimedia
+@STRING{IEEE_J_JDT        = "{IEEE/OSA} Journal of Display Technology"}
+@STRING{IEEE_J_IP         = "{IEEE} Transactions on Image Processing"}
+@STRING{IEEE_J_MM         = "{IEEE} Transactions on Multimedia"}
+@STRING{IEEE_J_VCG        = "{IEEE} Transactions on Visualization and Computer Graphics"}
+
+
+
+cybernetics, ergonomics, robots, man-machine, and automation
+@STRING{IEEE_J_ASE        = "{IEEE} Transactions on Automation Science and Engineering"}
+@STRING{IEEE_J_JRA        = "{IEEE} Journal of Robotics and Automation"}
+@STRING{IEEE_J_HFE        = "{IEEE} Transactions on Human Factors in Electronics"}
+@STRING{IEEE_J_MMS        = "{IEEE} Transactions on Man-Machine Systems"}
+@STRING{IEEE_J_PAMI       = "{IEEE} Transactions on Pattern Analysis and Machine Intelligence"}
+in 1989 JRA became RA
+in August 2004, RA split into ASE and RO
+@STRING{IEEE_J_RA         = "{IEEE} Transactions on Robotics and Automation"}
+@STRING{IEEE_J_RO         = "{IEEE} Transactions on Robotics"}
+@STRING{IEEE_J_SMC        = "{IEEE} Transactions on Systems, Man, and Cybernetics"}
+@STRING{IEEE_J_SMCA       = "{IEEE} Transactions on Systems, Man, and Cybernetics---Part {A}: Systems and Humans"}
+@STRING{IEEE_J_SMCB       = "{IEEE} Transactions on Systems, Man, and Cybernetics---Part {B}: Cybernetics"}
+@STRING{IEEE_J_SMCC       = "{IEEE} Transactions on Systems, Man, and Cybernetics---Part {C}: Applications and Reviews"}
+@STRING{IEEE_J_SSC        = "{IEEE} Transactions on Systems Science and Cybernetics"}
+
+
+
+earth, wind, fire and water
+@STRING{IEEE_J_GE         = "{IEEE} Transactions on Geoscience Electronics"}
+@STRING{IEEE_J_GRS        = "{IEEE} Transactions on Geoscience and Remote Sensing"}
+@STRING{IEEE_J_GRSL       = "{IEEE} Geoscience and Remote Sensing Letters"}
+@STRING{IEEE_J_OE         = "{IEEE} Journal of Oceanic Engineering"}
+
+
+
+education, engineering, history, IEEE, professional
+@STRING{IEEE_J_CJECE      = "Canadian Journal of Electrical and Computer Engineering"}
+@STRING{IEEE_J_PROC       = "Proceedings of the {IEEE}"}
+@STRING{IEEE_J_EDU        = "{IEEE} Transactions on Education"}
+@STRING{IEEE_J_EM         = "{IEEE} Transactions on Engineering Management"}
+@STRING{IEEE_J_EWS        = "{IEEE} Transactions on Engineering Writing and Speech"}
+@STRING{IEEE_J_PC         = "{IEEE} Transactions on Professional Communication"}
+
+
+
+electromagnetics, antennas, EMI, magnetics and microwave
+@STRING{IEEE_J_AWPL       = "{IEEE} Antennas and Wireless Propagation Letters"}
+@STRING{IEEE_J_MGWL       = "{IEEE} Microwave and Guided Wave Letters"}
+@STRING{IEEE_J_MWCL       = "{IEEE} Microwave and Wireless Components Letters"}
+@STRING{IEEE_J_AP         = "{IEEE} Transactions on Antennas and Propagation"}
+@STRING{IEEE_J_EMC        = "{IEEE} Transactions on Electromagnetic Compatibility"}
+@STRING{IEEE_J_MAG        = "{IEEE} Transactions on Magnetics"}
+@STRING{IEEE_J_MTT        = "{IEEE} Transactions on Microwave Theory and Techniques"}
+@STRING{IEEE_J_RFI        = "{IEEE} Transactions on Radio Frequency Interference"}
+@STRING{IEEE_J_TJMJ       = "{IEEE} Translation Journal on Magnetics in Japan"}
+
+
+
+energy and power
+@STRING{IEEE_J_EC         = "{IEEE} Transactions on Energy Conversion"}
+@STRING{IEEE_J_PEL        = "{IEEE} Power Electronics Letters"}
+@STRING{IEEE_J_PWRAS      = "{IEEE} Transactions on Power Apparatus and Systems"}
+@STRING{IEEE_J_PWRD       = "{IEEE} Transactions on Power Delivery"}
+@STRING{IEEE_J_PWRE       = "{IEEE} Transactions on Power Electronics"}
+@STRING{IEEE_J_PWRS       = "{IEEE} Transactions on Power Systems"}
+
+
+
+industrial, commercial and consumer
+@STRING{IEEE_J_APPIND     = "{IEEE} Transactions on Applications and Industry"}
+@STRING{IEEE_J_BC         = "{IEEE} Transactions on Broadcasting"}
+@STRING{IEEE_J_BCTV       = "{IEEE} Transactions on Broadcast and Television Receivers"}
+@STRING{IEEE_J_CE         = "{IEEE} Transactions on Consumer Electronics"}
+@STRING{IEEE_J_IE         = "{IEEE} Transactions on Industrial Electronics"}
+@STRING{IEEE_J_IECI       = "{IEEE} Transactions on Industrial Electronics and Control Instrumentation"}
+@STRING{IEEE_J_IA         = "{IEEE} Transactions on Industry Applications"}
+@STRING{IEEE_J_IGA        = "{IEEE} Transactions on Industry and General Applications"}
+@STRING{IEEE_J_IINF       = "{IEEE} Transactions on Industrial Informatics"}
+@STRING{IEEE_J_PSE        = "{IEEE} Journal of Product Safety Engineering"}
+
+
+
+instrumentation and measurement
+@STRING{IEEE_J_IM         = "{IEEE} Transactions on Instrumentation and Measurement"}
+
+
+
+insulation and materials
+@STRING{IEEE_J_JEM        = "{IEEE/TMS} Journal of Electronic Materials"}
+@STRING{IEEE_J_DEI        = "{IEEE} Transactions on Dielectrics and Electrical Insulation"}
+@STRING{IEEE_J_EI         = "{IEEE} Transactions on Electrical Insulation"}
+
+
+
+mechanical
+@STRING{IEEE_J_MECH       = "{IEEE/ASME} Transactions on Mechatronics"}
+@STRING{IEEE_J_MEMS       = "{IEEE/ASME} Journal of Microelectromechanical Systems"}
+
+
+
+medical and biological
+@STRING{IEEE_J_BME        = "{IEEE} Transactions on Biomedical Engineering"}
+Note: The B-ME journal later dropped the hyphen and became the BME.
+@STRING{IEEE_J_B-ME       = "{IEEE} Transactions on Bio-Medical Engineering"}
+@STRING{IEEE_J_BMELC      = "{IEEE} Transactions on Bio-Medical Electronics"}
+@STRING{IEEE_J_CBB        = "{IEEE/ACM} Transactions on Computational Biology and Bioinformatics"}
+@STRING{IEEE_J_ITBM       = "{IEEE} Transactions on Information Technology in Biomedicine"}
+@STRING{IEEE_J_ME         = "{IEEE} Transactions on Medical Electronics"}
+@STRING{IEEE_J_MI         = "{IEEE} Transactions on Medical Imaging"}
+@STRING{IEEE_J_NB         = "{IEEE} Transactions on NanoBioscience"}
+@STRING{IEEE_J_NSRE       = "{IEEE} Transactions on Neural Systems and Rehabilitation Engineering"}
+@STRING{IEEE_J_RE         = "{IEEE} Transactions on Rehabilitation Engineering"}
+
+
+
+optics, lightwave and photonics
+@STRING{IEEE_J_PTL        = "{IEEE} Photonics Technology Letters"}
+@STRING{IEEE_J_JLT        = "{IEEE/OSA} Journal of Lightwave Technology"}
+
+
+
+physics, electrons, nanotechnology, nuclear and quantum electronics
+@STRING{IEEE_J_EDL        = "{IEEE} Electron Device Letters"}
+@STRING{IEEE_J_JQE        = "{IEEE} Journal of Quantum Electronics"}
+@STRING{IEEE_J_JSTQE      = "{IEEE} Journal of Selected Topics in Quantum Electronics"}
+@STRING{IEEE_J_ED         = "{IEEE} Transactions on Electron Devices"}
+@STRING{IEEE_J_NANO       = "{IEEE} Transactions on Nanotechnology"}
+@STRING{IEEE_J_NS         = "{IEEE} Transactions on Nuclear Science"}
+@STRING{IEEE_J_PS         = "{IEEE} Transactions on Plasma Science"}
+
+
+
+reliability
+@STRING{IEEE_J_DMR        = "{IEEE} Transactions on Device and Materials Reliability"}
+@STRING{IEEE_J_R          = "{IEEE} Transactions on Reliability"}
+
+
+
+semiconductors, superconductors, electrochemical and solid state
+@STRING{IEEE_J_ESSL       = "{IEEE/ECS} Electrochemical and Solid-State Letters"}
+@STRING{IEEE_J_JSSC       = "{IEEE} Journal of Solid-State Circuits"}
+@STRING{IEEE_J_ASC        = "{IEEE} Transactions on Applied Superconductivity"}
+@STRING{IEEE_J_SM         = "{IEEE} Transactions on Semiconductor Manufacturing"}
+
+
+
+sensors
+@STRING{IEEE_J_SENSOR     = "{IEEE} Sensors Journal"}
+
+
+
+VLSI
+@STRING{IEEE_J_VLSI       = "{IEEE} Transactions on Very Large Scale Integration ({VLSI}) Systems"}
+
+
+
+
+
+
+IEEE Magazines
+
+
+
+@STRING{IEEE_M_AES        = "{IEEE} Aerospace and Electronics Systems Magazine"}
+@STRING{IEEE_M_HIST       = "{IEEE} Annals of the History of Computing"}
+@STRING{IEEE_M_AP         = "{IEEE} Antennas and Propagation Magazine"}
+@STRING{IEEE_M_ASSP       = "{IEEE} {ASSP} Magazine"}
+@STRING{IEEE_M_CD         = "{IEEE} Circuits and Devices Magazine"}
+@STRING{IEEE_M_CAS        = "{IEEE} Circuits and Systems Magazine"}
+@STRING{IEEE_M_COM        = "{IEEE} Communications Magazine"}
+@STRING{IEEE_M_COMSOC     = "{IEEE} Communications Society Magazine"}
+@STRING{IEEE_M_CIM        = "{IEEE} Computational Intelligence Magazine"}
+CSEM changed to CSE in 1999
+@STRING{IEEE_M_CSE        = "{IEEE} Computing in Science and Engineering"}
+@STRING{IEEE_M_CSEM       = "{IEEE} Computational Science and Engineering Magazine"}
+@STRING{IEEE_M_C          = "{IEEE} Computer"}
+@STRING{IEEE_M_CAP        = "{IEEE} Computer Applications in Power"}
+@STRING{IEEE_M_CGA        = "{IEEE} Computer Graphics and Applications"}
+@STRING{IEEE_M_CONC       = "{IEEE} Concurrency"}
+@STRING{IEEE_M_CS         = "{IEEE} Control Systems Magazine"}
+@STRING{IEEE_M_DTC        = "{IEEE} Design and Test of Computers"}
+@STRING{IEEE_M_EI         = "{IEEE} Electrical Insulation Magazine"}
+@STRING{IEEE_M_ETR        = "{IEEE} ElectroTechnology Review"}
+@STRING{IEEE_M_EMB        = "{IEEE} Engineering in Medicine and Biology Magazine"}
+@STRING{IEEE_M_EMR        = "{IEEE} Engineering Management Review"}
+@STRING{IEEE_M_EXP        = "{IEEE} Expert"}
+@STRING{IEEE_M_IA         = "{IEEE} Industry Applications Magazine"}
+@STRING{IEEE_M_IM         = "{IEEE} Instrumentation and Measurement Magazine"}
+@STRING{IEEE_M_IS         = "{IEEE} Intelligent Systems"}
+@STRING{IEEE_M_IC         = "{IEEE} Internet Computing"}
+@STRING{IEEE_M_ITP        = "{IEEE} {IT} Professional"}
+@STRING{IEEE_M_MICRO      = "{IEEE} Micro"}
+@STRING{IEEE_M_MW         = "{IEEE} Microwave Magazine"}
+@STRING{IEEE_M_MM         = "{IEEE} Multimedia"}
+@STRING{IEEE_M_NET        = "{IEEE} Network"}
+@STRING{IEEE_M_PCOM       = "{IEEE} Personal Communications Magazine"}
+@STRING{IEEE_M_POT        = "{IEEE} Potentials"}
+CAP and PER merged to form PE in 2003
+@STRING{IEEE_M_PE         = "{IEEE} Power and Energy Magazine"}
+@STRING{IEEE_M_PER        = "{IEEE} Power Engineering Review"}
+@STRING{IEEE_M_PVC        = "{IEEE} Pervasive Computing"}
+@STRING{IEEE_M_RA         = "{IEEE} Robotics and Automation Magazine"}
+@STRING{IEEE_M_SAP        = "{IEEE} Security and Privacy"}
+@STRING{IEEE_M_SP         = "{IEEE} Signal Processing Magazine"}
+@STRING{IEEE_M_S          = "{IEEE} Software"}
+@STRING{IEEE_M_SPECT      = "{IEEE} Spectrum"}
+@STRING{IEEE_M_TS         = "{IEEE} Technology and Society Magazine"}
+@STRING{IEEE_M_VT         = "{IEEE} Vehicular Technology Magazine"}
+@STRING{IEEE_M_WC         = "{IEEE} Wireless Communications Magazine"}
+@STRING{IEEE_M_TODAY      = "Today's Engineer"}
+
+
+
+
+
+
+IEEE Online Publications 
+
+
+
+@STRING{IEEE_O_CSTO        = "{IEEE} Communications Surveys and Tutorials"}
+@STRING{IEEE_O_DSO         = "{IEEE} Distributed Systems Online"}
+
+
+
+
+
+--
+EOF

--- a/ieee/IEEEtran.bst
+++ b/ieee/IEEEtran.bst
@@ -1,0 +1,2417 @@
+%%
+%% IEEEtran.bst
+%% BibTeX Bibliography Style file for IEEE Journals and Conferences (unsorted)
+%% Version 1.12 (2007/01/11)
+%% 
+%% Copyright (c) 2003-2007 Michael Shell
+%% 
+%% Original starting code base and algorithms obtained from the output of
+%% Patrick W. Daly's makebst package as well as from prior versions of
+%% IEEE BibTeX styles:
+%% 
+%% 1. Howard Trickey and Oren Patashnik's ieeetr.bst  (1985/1988)
+%% 2. Silvano Balemi and Richard H. Roy's IEEEbib.bst (1993)
+%% 
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and/or
+%% http://www.ieee.org/
+%% 
+%% For use with BibTeX version 0.99a or later
+%%
+%% This is a numerical citation style.
+%% 
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEabrv.bib, IEEEfull.bib, IEEEexample.bib,
+%%                    IEEEtran.bst, IEEEtranS.bst, IEEEtranSA.bst,
+%%                    IEEEtranN.bst, IEEEtranSN.bst, IEEEtran_bst_HOWTO.pdf
+%%*************************************************************************
+%
+%
+% Changelog:
+%
+% 1.00 (2002/08/13) Initial release
+%
+% 1.10 (2002/09/27)
+%  1. Corrected minor bug for improperly formed warning message when a
+%     book was not given a title. Thanks to Ming Kin Lai for reporting this.
+%  2. Added support for CTLname_format_string and CTLname_latex_cmd fields
+%     in the BST control entry type.
+%
+% 1.11 (2003/04/02)
+%  1. Fixed bug with URLs containing underscores when using url.sty. Thanks
+%     to Ming Kin Lai for reporting this.
+%
+% 1.12 (2007/01/11)
+%  1. Fixed bug with unwanted comma before "et al." when an entry contained
+%     more than two author names. Thanks to Pallav Gupta for reporting this.
+%  2. Fixed bug with anomalous closing quote in tech reports that have a
+%     type, but without a number or address. Thanks to Mehrdad Mirreza for
+%     reporting this.
+%  3. Use braces in \providecommand in begin.bib to better support
+%     latex2html. TeX style length assignments OK with recent versions
+%     of latex2html - 1.71 (2002/2/1) or later is strongly recommended.
+%     Use of the language field still causes trouble with latex2html.
+%     Thanks to Federico Beffa for reporting this.
+%  4. Added IEEEtran.bst ID and version comment string to .bbl output.
+%  5. Provide a \BIBdecl hook that allows the user to execute commands
+%     just prior to the first entry.
+%  6. Use default urlstyle (is using url.sty) of "same" rather than rm to
+%     better work with a wider variety of bibliography styles.
+%  7. Changed month abbreviations from Sept., July and June to Sep., Jul.,
+%     and Jun., respectively, as IEEE now does. Thanks to Moritz Borgmann
+%     for reporting this.
+%  8. Control entry types should not be considered when calculating longest
+%     label width.
+%  9. Added alias www for electronic/online.
+% 10. Added CTLname_url_prefix control entry type.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% DEFAULTS FOR THE CONTROLS OF THE BST STYLE %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% These are the defaults for the user adjustable controls. The values used
+% here can be overridden by the user via IEEEtranBSTCTL entry type.
+
+% NOTE: The recommended LaTeX command to invoke a control entry type is:
+% 
+%\makeatletter
+%\def\bstctlcite{\@ifnextchar[{\@bstctlcite}{\@bstctlcite[@auxout]}}
+%\def\@bstctlcite[#1]#2{\@bsphack
+%  \@for\@citeb:=#2\do{%
+%    \edef\@citeb{\expandafter\@firstofone\@citeb}%
+%    \if@filesw\immediate\write\csname #1\endcsname{\string\citation{\@citeb}}\fi}%
+%  \@esphack}
+%\makeatother
+%
+% It is called at the start of the document, before the first \cite, like:
+% \bstctlcite{IEEEexample:BSTcontrol}
+%
+% IEEEtran.cls V1.6 and later does provide this command.
+
+
+
+% #0 turns off the display of the number for articles.
+% #1 enables
+FUNCTION {default.is.use.number.for.article} { #1 }
+
+
+% #0 turns off the display of the paper and type fields in @inproceedings.
+% #1 enables
+FUNCTION {default.is.use.paper} { #1 }
+
+
+% #0 turns off the forced use of "et al."
+% #1 enables
+FUNCTION {default.is.forced.et.al} { #0 }
+
+% The maximum number of names that can be present beyond which an "et al."
+% usage is forced. Be sure that num.names.shown.with.forced.et.al (below)
+% is not greater than this value!
+% Note: There are many instances of references in IEEE journals which have
+% a very large number of authors as well as instances in which "et al." is
+% used profusely.
+FUNCTION {default.max.num.names.before.forced.et.al} { #10 }
+
+% The number of names that will be shown with a forced "et al.".
+% Must be less than or equal to max.num.names.before.forced.et.al
+FUNCTION {default.num.names.shown.with.forced.et.al} { #1 }
+
+
+% #0 turns off the alternate interword spacing for entries with URLs.
+% #1 enables
+FUNCTION {default.is.use.alt.interword.spacing} { #1 }
+
+% If alternate interword spacing for entries with URLs is enabled, this is
+% the interword spacing stretch factor that will be used. For example, the
+% default "4" here means that the interword spacing in entries with URLs can
+% stretch to four times normal. Does not have to be an integer. Note that
+% the value specified here can be overridden by the user in their LaTeX
+% code via a command such as: 
+% "\providecommand\BIBentryALTinterwordstretchfactor{1.5}" in addition to
+% that via the IEEEtranBSTCTL entry type.
+FUNCTION {default.ALTinterwordstretchfactor} { "4" }
+
+
+% #0 turns off the "dashification" of repeated (i.e., identical to those
+% of the previous entry) names. IEEE normally does this.
+% #1 enables
+FUNCTION {default.is.dash.repeated.names} { #1 }
+
+
+% The default name format control string.
+FUNCTION {default.name.format.string}{ "{f.~}{vv~}{ll}{, jj}" }
+
+
+% The default LaTeX font command for the names.
+FUNCTION {default.name.latex.cmd}{ "" }
+
+
+% The default URL prefix.
+FUNCTION {default.name.url.prefix}{ "[Online]. Available:" }
+
+
+% Other controls that cannot be accessed via IEEEtranBSTCTL entry type.
+
+% #0 turns off the terminal startup banner/completed message so as to
+% operate more quietly.
+% #1 enables
+FUNCTION {is.print.banners.to.terminal} { #1 }
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% FILE VERSION AND BANNER %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION{bst.file.version} { "1.12" }
+FUNCTION{bst.file.date} { "2007/01/11" }
+FUNCTION{bst.file.website} { "http://www.michaelshell.org/tex/ieeetran/bibtex/" }
+
+FUNCTION {banner.message}
+{ is.print.banners.to.terminal
+     { "-- IEEEtran.bst version" " " * bst.file.version *
+       " (" * bst.file.date * ") " * "by Michael Shell." *
+       top$
+       "-- " bst.file.website *
+       top$
+       "-- See the " quote$ * "IEEEtran_bst_HOWTO.pdf" * quote$ * " manual for usage information." *
+       top$
+     }
+     { skip$ }
+   if$
+}
+
+FUNCTION {completed.message}
+{ is.print.banners.to.terminal
+     { ""
+       top$
+       "Done."
+       top$
+     }
+     { skip$ }
+   if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% STRING CONSTANTS %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {bbl.and}{ "and" }
+FUNCTION {bbl.etal}{ "et~al." }
+FUNCTION {bbl.editors}{ "eds." }
+FUNCTION {bbl.editor}{ "ed." }
+FUNCTION {bbl.edition}{ "ed." }
+FUNCTION {bbl.volume}{ "vol." }
+FUNCTION {bbl.of}{ "of" }
+FUNCTION {bbl.number}{ "no." }
+FUNCTION {bbl.in}{ "in" }
+FUNCTION {bbl.pages}{ "pp." }
+FUNCTION {bbl.page}{ "p." }
+FUNCTION {bbl.chapter}{ "ch." }
+FUNCTION {bbl.paper}{ "paper" }
+FUNCTION {bbl.part}{ "pt." }
+FUNCTION {bbl.patent}{ "Patent" }
+FUNCTION {bbl.patentUS}{ "U.S." }
+FUNCTION {bbl.revision}{ "Rev." }
+FUNCTION {bbl.series}{ "ser." }
+FUNCTION {bbl.standard}{ "Std." }
+FUNCTION {bbl.techrep}{ "Tech. Rep." }
+FUNCTION {bbl.mthesis}{ "Master's thesis" }
+FUNCTION {bbl.phdthesis}{ "Ph.D. dissertation" }
+FUNCTION {bbl.st}{ "st" }
+FUNCTION {bbl.nd}{ "nd" }
+FUNCTION {bbl.rd}{ "rd" }
+FUNCTION {bbl.th}{ "th" }
+
+
+% This is the LaTeX spacer that is used when a larger than normal space
+% is called for (such as just before the address:publisher).
+FUNCTION {large.space} { "\hskip 1em plus 0.5em minus 0.4em\relax " }
+
+% The LaTeX code for dashes that are used to represent repeated names.
+% Note: Some older IEEE journals used something like
+% "\rule{0.275in}{0.5pt}\," which is fairly thick and runs right along
+% the baseline. However, IEEE now uses a thinner, above baseline,
+% six dash long sequence.
+FUNCTION {repeated.name.dashes} { "------" }
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% PREDEFINED STRING MACROS %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+MACRO {jan} {"Jan."}
+MACRO {feb} {"Feb."}
+MACRO {mar} {"Mar."}
+MACRO {apr} {"Apr."}
+MACRO {may} {"May"}
+MACRO {jun} {"Jun."}
+MACRO {jul} {"Jul."}
+MACRO {aug} {"Aug."}
+MACRO {sep} {"Sep."}
+MACRO {oct} {"Oct."}
+MACRO {nov} {"Nov."}
+MACRO {dec} {"Dec."}
+
+
+
+%%%%%%%%%%%%%%%%%%
+%% ENTRY FIELDS %%
+%%%%%%%%%%%%%%%%%%
+
+ENTRY
+  { address
+    assignee
+    author
+    booktitle
+    chapter
+    day
+    dayfiled
+    edition
+    editor
+    howpublished
+    institution
+    intype
+    journal
+    key
+    language
+    month
+    monthfiled
+    nationality
+    note
+    number
+    organization
+    pages
+    paper
+    publisher
+    school
+    series
+    revision
+    title
+    type
+    url
+    volume
+    year
+    yearfiled
+    CTLuse_article_number
+    CTLuse_paper
+    CTLuse_forced_etal
+    CTLmax_names_forced_etal
+    CTLnames_show_etal
+    CTLuse_alt_spacing
+    CTLalt_stretch_factor
+    CTLdash_repeated_names
+    CTLname_format_string
+    CTLname_latex_cmd
+    CTLname_url_prefix
+  }
+  {}
+  { label }
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%
+%% INTEGER VARIABLES %%
+%%%%%%%%%%%%%%%%%%%%%%%
+
+INTEGERS { prev.status.punct this.status.punct punct.std
+           punct.no punct.comma punct.period 
+           prev.status.space this.status.space space.std
+           space.no space.normal space.large
+           prev.status.quote this.status.quote quote.std
+           quote.no quote.close
+           prev.status.nline this.status.nline nline.std
+           nline.no nline.newblock 
+           status.cap cap.std
+           cap.no cap.yes}
+
+INTEGERS { longest.label.width multiresult nameptr namesleft number.label numnames }
+
+INTEGERS { is.use.number.for.article
+           is.use.paper
+           is.forced.et.al
+           max.num.names.before.forced.et.al
+           num.names.shown.with.forced.et.al
+           is.use.alt.interword.spacing
+           is.dash.repeated.names}
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% STRING VARIABLES %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+STRINGS { bibinfo
+          longest.label
+          oldname
+          s
+          t
+          ALTinterwordstretchfactor
+          name.format.string
+          name.latex.cmd
+          name.url.prefix}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+%% LOW LEVEL FUNCTIONS %%
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {initialize.controls}
+{ default.is.use.number.for.article 'is.use.number.for.article :=
+  default.is.use.paper 'is.use.paper :=
+  default.is.forced.et.al 'is.forced.et.al :=
+  default.max.num.names.before.forced.et.al 'max.num.names.before.forced.et.al :=
+  default.num.names.shown.with.forced.et.al 'num.names.shown.with.forced.et.al :=
+  default.is.use.alt.interword.spacing 'is.use.alt.interword.spacing :=
+  default.is.dash.repeated.names 'is.dash.repeated.names :=
+  default.ALTinterwordstretchfactor 'ALTinterwordstretchfactor :=
+  default.name.format.string 'name.format.string :=
+  default.name.latex.cmd 'name.latex.cmd :=
+  default.name.url.prefix 'name.url.prefix :=
+}
+
+
+% This IEEEtran.bst features a very powerful and flexible mechanism for
+% controlling the capitalization, punctuation, spacing, quotation, and
+% newlines of the formatted entry fields. (Note: IEEEtran.bst does not need
+% or use the newline/newblock feature, but it has been implemented for
+% possible future use.) The output states of IEEEtran.bst consist of
+% multiple independent attributes and, as such, can be thought of as being
+% vectors, rather than the simple scalar values ("before.all", 
+% "mid.sentence", etc.) used in most other .bst files.
+% 
+% The more flexible and complex design used here was motivated in part by
+% IEEE's rather unusual bibliography style. For example, IEEE ends the
+% previous field item with a period and large space prior to the publisher
+% address; the @electronic entry types use periods as inter-item punctuation
+% rather than the commas used by the other entry types; and URLs are never
+% followed by periods even though they are the last item in the entry.
+% Although it is possible to accommodate these features with the conventional
+% output state system, the seemingly endless exceptions make for convoluted,
+% unreliable and difficult to maintain code.
+%
+% IEEEtran.bst's output state system can be easily understood via a simple
+% illustration of two most recently formatted entry fields (on the stack):
+%
+%               CURRENT_ITEM
+%               "PREVIOUS_ITEM
+%
+% which, in this example, is to eventually appear in the bibliography as:
+% 
+%               "PREVIOUS_ITEM," CURRENT_ITEM
+%
+% It is the job of the output routine to take the previous item off of the
+% stack (while leaving the current item at the top of the stack), apply its
+% trailing punctuation (including closing quote marks) and spacing, and then
+% to write the result to BibTeX's output buffer:
+% 
+%               "PREVIOUS_ITEM," 
+% 
+% Punctuation (and spacing) between items is often determined by both of the
+% items rather than just the first one. The presence of quotation marks
+% further complicates the situation because, in standard English, trailing
+% punctuation marks are supposed to be contained within the quotes.
+% 
+% IEEEtran.bst maintains two output state (aka "status") vectors which
+% correspond to the previous and current (aka "this") items. Each vector
+% consists of several independent attributes which track punctuation,
+% spacing, quotation, and newlines. Capitalization status is handled by a
+% separate scalar because the format routines, not the output routine,
+% handle capitalization and, therefore, there is no need to maintain the
+% capitalization attribute for both the "previous" and "this" items.
+% 
+% When a format routine adds a new item, it copies the current output status
+% vector to the previous output status vector and (usually) resets the
+% current (this) output status vector to a "standard status" vector. Using a
+% "standard status" vector in this way allows us to redefine what we mean by
+% "standard status" at the start of each entry handler and reuse the same
+% format routines under the various inter-item separation schemes. For
+% example, the standard status vector for the @book entry type may use
+% commas for item separators, while the @electronic type may use periods,
+% yet both entry handlers exploit many of the exact same format routines.
+% 
+% Because format routines have write access to the output status vector of
+% the previous item, they can override the punctuation choices of the
+% previous format routine! Therefore, it becomes trivial to implement rules
+% such as "Always use a period and a large space before the publisher." By
+% pushing the generation of the closing quote mark to the output routine, we
+% avoid all the problems caused by having to close a quote before having all
+% the information required to determine what the punctuation should be.
+%
+% The IEEEtran.bst output state system can easily be expanded if needed.
+% For instance, it is easy to add a "space.tie" attribute value if the
+% bibliography rules mandate that two items have to be joined with an
+% unbreakable space. 
+
+FUNCTION {initialize.status.constants}
+{ #0 'punct.no :=
+  #1 'punct.comma :=
+  #2 'punct.period :=
+  #0 'space.no := 
+  #1 'space.normal :=
+  #2 'space.large :=
+  #0 'quote.no :=
+  #1 'quote.close :=
+  #0 'cap.no :=
+  #1 'cap.yes :=
+  #0 'nline.no :=
+  #1 'nline.newblock :=
+}
+
+FUNCTION {std.status.using.comma}
+{ punct.comma 'punct.std :=
+  space.normal 'space.std :=
+  quote.no 'quote.std :=
+  nline.no 'nline.std :=
+  cap.no 'cap.std :=
+}
+
+FUNCTION {std.status.using.period}
+{ punct.period 'punct.std :=
+  space.normal 'space.std :=
+  quote.no 'quote.std :=
+  nline.no 'nline.std :=
+  cap.yes 'cap.std :=
+}
+
+FUNCTION {initialize.prev.this.status}
+{ punct.no 'prev.status.punct :=
+  space.no 'prev.status.space :=
+  quote.no 'prev.status.quote :=
+  nline.no 'prev.status.nline :=
+  punct.no 'this.status.punct :=
+  space.no 'this.status.space :=
+  quote.no 'this.status.quote :=
+  nline.no 'this.status.nline :=
+  cap.yes 'status.cap :=
+}
+
+FUNCTION {this.status.std}
+{ punct.std 'this.status.punct :=
+  space.std 'this.status.space :=
+  quote.std 'this.status.quote :=
+  nline.std 'this.status.nline :=
+}
+
+FUNCTION {cap.status.std}{ cap.std 'status.cap := }
+
+FUNCTION {this.to.prev.status}
+{ this.status.punct 'prev.status.punct :=
+  this.status.space 'prev.status.space :=
+  this.status.quote 'prev.status.quote :=
+  this.status.nline 'prev.status.nline :=
+}
+
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+
+FUNCTION {and}
+{   { skip$ }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {or}
+{   { pop$ #1 }
+    { skip$ }
+  if$
+}
+
+
+% convert the strings "yes" or "no" to #1 or #0 respectively
+FUNCTION {yes.no.to.int}
+{ "l" change.case$ duplicate$
+    "yes" =
+    { pop$  #1 }
+    { duplicate$ "no" =
+        { pop$ #0 }
+        { "unknown boolean " quote$ * swap$ * quote$ *
+          " in " * cite$ * warning$
+          #0
+        }
+      if$
+    }
+  if$
+}
+
+
+% pushes true if the single char string on the stack is in the
+% range of "0" to "9"
+FUNCTION {is.num}
+{ chr.to.int$
+  duplicate$ "0" chr.to.int$ < not
+  swap$ "9" chr.to.int$ > not and
+}
+
+% multiplies the integer on the stack by a factor of 10
+FUNCTION {bump.int.mag}
+{ #0 'multiresult :=
+    { duplicate$ #0 > }
+    { #1 -
+      multiresult #10 +
+      'multiresult :=
+    }
+  while$
+pop$
+multiresult
+}
+
+% converts a single character string on the stack to an integer
+FUNCTION {char.to.integer}
+{ duplicate$ 
+  is.num
+    { chr.to.int$ "0" chr.to.int$ - }
+    {"noninteger character " quote$ * swap$ * quote$ *
+          " in integer field of " * cite$ * warning$
+    #0
+    }
+  if$
+}
+
+% converts a string on the stack to an integer
+FUNCTION {string.to.integer}
+{ duplicate$ text.length$ 'namesleft :=
+  #1 'nameptr :=
+  #0 'numnames :=
+    { nameptr namesleft > not }
+    { duplicate$ nameptr #1 substring$
+      char.to.integer numnames bump.int.mag +
+      'numnames :=
+      nameptr #1 +
+      'nameptr :=
+    }
+  while$
+pop$
+numnames
+}
+
+
+
+
+% The output routines write out the *next* to the top (previous) item on the
+% stack, adding punctuation and such as needed. Since IEEEtran.bst maintains
+% the output status for the top two items on the stack, these output
+% routines have to consider the previous output status (which corresponds to
+% the item that is being output). Full independent control of punctuation,
+% closing quote marks, spacing, and newblock is provided.
+% 
+% "output.nonnull" does not check for the presence of a previous empty
+% item.
+% 
+% "output" does check for the presence of a previous empty item and will
+% remove an empty item rather than outputing it.
+% 
+% "output.warn" is like "output", but will issue a warning if it detects
+% an empty item.
+
+FUNCTION {output.nonnull}
+{ swap$
+  prev.status.punct punct.comma =
+     { "," * }
+     { skip$ }
+   if$
+  prev.status.punct punct.period =
+     { add.period$ }
+     { skip$ }
+   if$ 
+  prev.status.quote quote.close =
+     { "''" * }
+     { skip$ }
+   if$
+  prev.status.space space.normal =
+     { " " * }
+     { skip$ }
+   if$
+  prev.status.space space.large =
+     { large.space * }
+     { skip$ }
+   if$
+  write$
+  prev.status.nline nline.newblock =
+     { newline$ "\newblock " write$ }
+     { skip$ }
+   if$
+}
+
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+
+FUNCTION {output.warn}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+
+% "fin.entry" is the output routine that handles the last item of the entry
+% (which will be on the top of the stack when "fin.entry" is called).
+
+FUNCTION {fin.entry}
+{ this.status.punct punct.no =
+     { skip$ }
+     { add.period$ }
+   if$
+   this.status.quote quote.close =
+     { "''" * }
+     { skip$ }
+   if$
+write$
+newline$
+}
+
+
+FUNCTION {is.last.char.not.punct}
+{ duplicate$
+   "}" * add.period$
+   #-1 #1 substring$ "." =
+}
+
+FUNCTION {is.multiple.pages}
+{ 't :=
+  #0 'multiresult :=
+    { multiresult not
+      t empty$ not
+      and
+    }
+    { t #1 #1 substring$
+      duplicate$ "-" =
+      swap$ duplicate$ "," =
+      swap$ "+" =
+      or or
+        { #1 'multiresult := }
+        { t #2 global.max$ substring$ 't := }
+      if$
+    }
+  while$
+  multiresult
+}
+
+FUNCTION {capitalize}{ "u" change.case$ "t" change.case$ }
+
+FUNCTION {emphasize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+
+FUNCTION {do.name.latex.cmd}
+{ name.latex.cmd
+  empty$
+    { skip$ }
+    { name.latex.cmd "{" * swap$ * "}" * }
+  if$
+}
+
+% IEEEtran.bst uses its own \BIBforeignlanguage command which directly
+% invokes the TeX hyphenation patterns without the need of the Babel
+% package. Babel does a lot more than switch hyphenation patterns and
+% its loading can cause unintended effects in many class files (such as
+% IEEEtran.cls).
+FUNCTION {select.language}
+{ duplicate$ empty$ 'pop$
+    { language empty$ 'skip$
+        { "\BIBforeignlanguage{" language * "}{" * swap$ * "}" * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tie.or.space.prefix}
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$
+}
+
+FUNCTION {get.bbl.editor}
+{ editor num.names$ #1 > 'bbl.editors 'bbl.editor if$ }
+
+FUNCTION {space.word}{ " " swap$ * " " * }
+
+
+% Field Conditioners, Converters, Checkers and External Interfaces
+
+FUNCTION {empty.field.to.null.string}
+{ duplicate$ empty$
+    { pop$ "" }
+    { skip$ }
+  if$
+}
+
+FUNCTION {either.or.check}
+{ empty$
+    { pop$ }
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+
+FUNCTION {empty.entry.warn}
+{ author empty$ title empty$ howpublished empty$
+  month empty$ year empty$ note empty$ url empty$
+  and and and and and and
+    { "all relevant fields are empty in " cite$ * warning$ }
+    'skip$
+  if$
+}
+
+
+% The bibinfo system provides a way for the electronic parsing/acquisition
+% of a bibliography's contents as is done by ReVTeX. For example, a field
+% could be entered into the bibliography as:
+% \bibinfo{volume}{2}
+% Only the "2" would show up in the document, but the LaTeX \bibinfo command
+% could do additional things with the information. IEEEtran.bst does provide
+% a \bibinfo command via "\providecommand{\bibinfo}[2]{#2}". However, it is
+% currently not used as the bogus bibinfo functions defined here output the
+% entry values directly without the \bibinfo wrapper. The bibinfo functions
+% themselves (and the calls to them) are retained for possible future use.
+% 
+% bibinfo.check avoids acting on missing fields while bibinfo.warn will
+% issue a warning message if a missing field is detected. Prior to calling
+% the bibinfo functions, the user should push the field value and then its
+% name string, in that order.
+
+FUNCTION {bibinfo.check}
+{ swap$ duplicate$ missing$
+    { pop$ pop$ "" }
+    { duplicate$ empty$
+        { swap$ pop$ }
+        { swap$ pop$ }
+      if$
+    }
+  if$
+}
+
+FUNCTION {bibinfo.warn}
+{ swap$ duplicate$ missing$
+    { swap$ "missing " swap$ * " in " * cite$ * warning$ pop$ "" }
+    { duplicate$ empty$
+        { swap$ "empty " swap$ * " in " * cite$ * warning$ }
+        { swap$ pop$ }
+      if$
+    }
+  if$
+}
+
+
+% IEEE separates large numbers with more than 4 digits into groups of
+% three. IEEE uses a small space to separate these number groups. 
+% Typical applications include patent and page numbers.
+
+% number of consecutive digits required to trigger the group separation.
+FUNCTION {large.number.trigger}{ #5 }
+
+% For numbers longer than the trigger, this is the blocksize of the groups.
+% The blocksize must be less than the trigger threshold, and 2 * blocksize
+% must be greater than the trigger threshold (can't do more than one
+% separation on the initial trigger).
+FUNCTION {large.number.blocksize}{ #3 }
+
+% What is actually inserted between the number groups.
+FUNCTION {large.number.separator}{ "\," }
+
+% So as to save on integer variables by reusing existing ones, numnames
+% holds the current number of consecutive digits read and nameptr holds
+% the number that will trigger an inserted space.
+FUNCTION {large.number.separate}
+{ 't :=
+  ""
+  #0 'numnames :=
+  large.number.trigger 'nameptr :=
+  { t empty$ not }
+  { t #-1 #1 substring$ is.num
+      { numnames #1 + 'numnames := }
+      { #0 'numnames := 
+        large.number.trigger 'nameptr :=
+      }
+    if$
+    t #-1 #1 substring$ swap$ *
+    t #-2 global.max$ substring$ 't :=
+    numnames nameptr =
+      { duplicate$ #1 nameptr large.number.blocksize - substring$ swap$
+        nameptr large.number.blocksize - #1 + global.max$ substring$
+        large.number.separator swap$ * *
+        nameptr large.number.blocksize - 'numnames :=
+        large.number.blocksize #1 + 'nameptr :=
+      }
+      { skip$ }
+    if$
+  }
+  while$
+}
+
+% Converts all single dashes "-" to double dashes "--".
+FUNCTION {n.dashify}
+{ large.number.separate
+  't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { t #1 #2 substring$ "--" = not
+            { "--" *
+              t #2 global.max$ substring$ 't :=
+            }
+            {   { t #1 #1 substring$ "-" = }
+                { "-" *
+                  t #2 global.max$ substring$ 't :=
+                }
+              while$
+            }
+          if$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+
+% This function detects entries with names that are identical to that of
+% the previous entry and replaces the repeated names with dashes (if the
+% "is.dash.repeated.names" user control is nonzero).
+FUNCTION {name.or.dash}
+{ 's :=
+   oldname empty$
+     { s 'oldname := s }
+     { s oldname =
+         { is.dash.repeated.names
+              { repeated.name.dashes }
+              { s 'oldname := s }
+            if$
+         }
+         { s 'oldname := s }
+       if$
+     }
+   if$
+}
+
+% Converts the number string on the top of the stack to
+% "numerical ordinal form" (e.g., "7" to "7th"). There is
+% no artificial limit to the upper bound of the numbers as the
+% least significant digit always determines the ordinal form.
+FUNCTION {num.to.ordinal}
+{ duplicate$ #-1 #1 substring$ "1" =
+     { bbl.st * }
+     { duplicate$ #-1 #1 substring$ "2" =
+         { bbl.nd * }
+         { duplicate$ #-1 #1 substring$ "3" =
+             { bbl.rd * }
+             { bbl.th * }
+           if$
+         }
+       if$
+     }
+   if$
+}
+
+% If the string on the top of the stack begins with a number,
+% (e.g., 11th) then replace the string with the leading number
+% it contains. Otherwise retain the string as-is. s holds the
+% extracted number, t holds the part of the string that remains
+% to be scanned.
+FUNCTION {extract.num}
+{ duplicate$ 't :=
+  "" 's :=
+  { t empty$ not }
+  { t #1 #1 substring$
+    t #2 global.max$ substring$ 't :=
+    duplicate$ is.num
+      { s swap$ * 's := }
+      { pop$ "" 't := }
+    if$
+  }
+  while$
+  s empty$
+    'skip$
+    { pop$ s }
+  if$
+}
+
+% Converts the word number string on the top of the stack to
+% Arabic string form. Will be successful up to "tenth".
+FUNCTION {word.to.num}
+{ duplicate$ "l" change.case$ 's :=
+  s "first" =
+    { pop$ "1" }
+    { skip$ }
+  if$
+  s "second" =
+    { pop$ "2" }
+    { skip$ }
+  if$
+  s "third" =
+    { pop$ "3" }
+    { skip$ }
+  if$
+  s "fourth" =
+    { pop$ "4" }
+    { skip$ }
+  if$
+  s "fifth" =
+    { pop$ "5" }
+    { skip$ }
+  if$
+  s "sixth" =
+    { pop$ "6" }
+    { skip$ }
+  if$
+  s "seventh" =
+    { pop$ "7" }
+    { skip$ }
+  if$
+  s "eighth" =
+    { pop$ "8" }
+    { skip$ }
+  if$
+  s "ninth" =
+    { pop$ "9" }
+    { skip$ }
+  if$
+  s "tenth" =
+    { pop$ "10" }
+    { skip$ }
+  if$
+}
+
+
+% Converts the string on the top of the stack to numerical
+% ordinal (e.g., "11th") form.
+FUNCTION {convert.edition}
+{ duplicate$ empty$ 'skip$
+    { duplicate$ #1 #1 substring$ is.num
+        { extract.num
+          num.to.ordinal
+        }
+        { word.to.num
+          duplicate$ #1 #1 substring$ is.num
+            { num.to.ordinal }
+            { "edition ordinal word " quote$ * edition * quote$ *
+              " may be too high (or improper) for conversion" * " in " * cite$ * warning$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% LATEX BIBLIOGRAPHY CODE %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {start.entry}
+{ newline$
+  "\bibitem{" write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  initialize.prev.this.status
+}
+
+% Here we write out all the LaTeX code that we will need. The most involved
+% code sequences are those that control the alternate interword spacing and
+% foreign language hyphenation patterns. The heavy use of \providecommand
+% gives users a way to override the defaults. Special thanks to Javier Bezos,
+% Johannes Braams, Robin Fairbairns, Heiko Oberdiek, Donald Arseneau and all
+% the other gurus on comp.text.tex for their help and advice on the topic of
+% \selectlanguage, Babel and BibTeX.
+FUNCTION {begin.bib}
+{ "% Generated by IEEEtran.bst, version: " bst.file.version * " (" * bst.file.date * ")" *
+  write$ newline$
+  preamble$ empty$ 'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{"  longest.label  * "}" *
+  write$ newline$
+  "\providecommand{\url}[1]{#1}"
+  write$ newline$
+  "\csname url@samestyle\endcsname"
+  write$ newline$
+  "\providecommand{\newblock}{\relax}"
+  write$ newline$
+  "\providecommand{\bibinfo}[2]{#2}"
+  write$ newline$
+  "\providecommand{\BIBentrySTDinterwordspacing}{\spaceskip=0pt\relax}"
+  write$ newline$
+  "\providecommand{\BIBentryALTinterwordstretchfactor}{"
+  ALTinterwordstretchfactor * "}" *
+  write$ newline$
+  "\providecommand{\BIBentryALTinterwordspacing}{\spaceskip=\fontdimen2\font plus "
+  write$ newline$
+  "\BIBentryALTinterwordstretchfactor\fontdimen3\font minus \fontdimen4\font\relax}"
+  write$ newline$
+  "\providecommand{\BIBforeignlanguage}[2]{{%"
+  write$ newline$
+  "\expandafter\ifx\csname l@#1\endcsname\relax"
+  write$ newline$
+  "\typeout{** WARNING: IEEEtran.bst: No hyphenation pattern has been}%"
+  write$ newline$
+  "\typeout{** loaded for the language `#1'. Using the pattern for}%"
+  write$ newline$
+  "\typeout{** the default language instead.}%"
+  write$ newline$
+  "\else"
+  write$ newline$
+  "\language=\csname l@#1\endcsname"
+  write$ newline$
+  "\fi"
+  write$ newline$
+  "#2}}"
+  write$ newline$
+  "\providecommand{\BIBdecl}{\relax}"
+  write$ newline$
+  "\BIBdecl"
+  write$ newline$
+}
+
+FUNCTION {end.bib}
+{ newline$ "\end{thebibliography}" write$ newline$ }
+
+FUNCTION {if.url.alt.interword.spacing}
+{ is.use.alt.interword.spacing 
+     {url empty$ 'skip$ {"\BIBentryALTinterwordspacing" write$ newline$} if$}
+     { skip$ }
+   if$
+}
+
+FUNCTION {if.url.std.interword.spacing}
+{ is.use.alt.interword.spacing 
+     {url empty$ 'skip$ {"\BIBentrySTDinterwordspacing" write$ newline$} if$}
+     { skip$ }
+   if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%
+%% LONGEST LABEL PASS %%
+%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {initialize.longest.label}
+{ "" 'longest.label :=
+  #1 'number.label :=
+  #0 'longest.label.width :=
+}
+
+FUNCTION {longest.label.pass}
+{ type$ "ieeetranbstctl" =
+    { skip$ }
+    { number.label int.to.str$ 'label :=
+      number.label #1 + 'number.label :=
+      label width$ longest.label.width >
+        { label 'longest.label :=
+          label width$ 'longest.label.width :=
+        }
+        { skip$ }
+      if$
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%
+%% FORMAT HANDLERS %%
+%%%%%%%%%%%%%%%%%%%%%
+
+%% Lower Level Formats (used by higher level formats)
+
+FUNCTION {format.address.org.or.pub.date}
+{ 't :=
+  ""
+  year empty$
+    { "empty year in " cite$ * warning$ }
+    { skip$ }
+  if$
+  address empty$ t empty$ and
+  year empty$ and month empty$ and
+    { skip$ }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      address "address" bibinfo.check *
+      t empty$
+        { skip$ }
+        { punct.period 'prev.status.punct :=
+          space.large 'prev.status.space :=
+          address empty$
+            { skip$ }
+            { ": " * }
+          if$
+          t *
+        }
+      if$
+      year empty$ month empty$ and
+        { skip$ }
+        { t empty$ address empty$ and
+            { skip$ }
+            { ", " * }
+          if$
+          month empty$
+            { year empty$
+                { skip$ }
+                { year "year" bibinfo.check * }
+              if$
+            }
+            { month "month" bibinfo.check *
+              year empty$
+                 { skip$ }
+                 { " " * year "year" bibinfo.check * }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+
+FUNCTION {format.names}
+{ 'bibinfo :=
+  duplicate$ empty$ 'skip$ {
+  this.to.prev.status
+  this.status.std
+  's :=
+  "" 't :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      name.format.string
+      format.name$
+      bibinfo bibinfo.check
+      't :=
+      nameptr #1 >
+        { nameptr num.names.shown.with.forced.et.al #1 + =
+          numnames max.num.names.before.forced.et.al >
+          is.forced.et.al and and
+            { "others" 't :=
+              #1 'namesleft :=
+            }
+            { skip$ }
+          if$
+          namesleft #1 >
+            { ", " * t do.name.latex.cmd * }
+            { s nameptr "{ll}" format.name$ duplicate$ "others" =
+                { 't := }
+                { pop$ }
+              if$
+              t "others" =
+                { " " * bbl.etal emphasize * }
+                { numnames #2 >
+                    { "," * }
+                    { skip$ }
+                  if$
+                  bbl.and
+                  space.word * t do.name.latex.cmd *
+                }
+              if$
+            }
+          if$
+        }
+        { t do.name.latex.cmd }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+  cap.status.std
+  } if$
+}
+
+
+
+
+%% Higher Level Formats
+
+%% addresses/locations
+
+FUNCTION {format.address}
+{ address duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% author/editor names
+
+FUNCTION {format.authors}{ author "author" format.names }
+
+FUNCTION {format.editors}
+{ editor "editor" format.names duplicate$ empty$ 'skip$
+    { ", " *
+      get.bbl.editor
+      capitalize
+      *
+    }
+  if$
+}
+
+
+
+%% date
+
+FUNCTION {format.date}
+{
+  month "month" bibinfo.check duplicate$ empty$
+  year  "year" bibinfo.check duplicate$ empty$
+    { swap$ 'skip$
+        { this.to.prev.status
+          this.status.std
+          cap.status.std
+         "there's a month but no year in " cite$ * warning$ }
+      if$
+      *
+    }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      swap$ 'skip$
+        {
+          swap$
+          " " * swap$
+        }
+      if$
+      *
+    }
+  if$
+}
+
+FUNCTION {format.date.electronic}
+{ month "month" bibinfo.check duplicate$ empty$
+  year  "year" bibinfo.check duplicate$ empty$
+    { swap$ 
+        { pop$ }
+        { "there's a month but no year in " cite$ * warning$
+        pop$ ")" * "(" swap$ *
+        this.to.prev.status
+        punct.no 'this.status.punct :=
+        space.normal 'this.status.space :=
+        quote.no 'this.status.quote :=
+        cap.yes  'status.cap :=
+        }
+      if$
+    }
+    { swap$ 
+        { swap$ pop$ ")" * "(" swap$ * }
+        { "(" swap$ * ", " * swap$ * ")" * }
+      if$
+    this.to.prev.status
+    punct.no 'this.status.punct :=
+    space.normal 'this.status.space :=
+    quote.no 'this.status.quote :=
+    cap.yes  'status.cap :=
+    }
+  if$
+}
+
+
+
+%% edition/title
+
+% Note: IEEE considers the edition to be closely associated with
+% the title of a book. So, in IEEEtran.bst the edition is normally handled 
+% within the formatting of the title. The format.edition function is 
+% retained here for possible future use.
+FUNCTION {format.edition}
+{ edition duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      convert.edition
+      status.cap
+        { "t" }
+        { "l" }
+      if$ change.case$
+      "edition" bibinfo.check
+      "~" * bbl.edition *
+      cap.status.std
+    }
+  if$
+}
+
+% This is used to format the booktitle of a conference proceedings.
+% Here we use the "intype" field to provide the user a way to 
+% override the word "in" (e.g., with things like "presented at")
+% Use of intype stops the emphasis of the booktitle to indicate that
+% we no longer mean the written conference proceedings, but the
+% conference itself.
+FUNCTION {format.in.booktitle}
+{ booktitle "booktitle" bibinfo.check duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      select.language
+      intype missing$
+        { emphasize
+          bbl.in " " *
+        }
+        { intype " " * }
+      if$
+      swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+% This is used to format the booktitle of collection.
+% Here the "intype" field is not supported, but "edition" is.
+FUNCTION {format.in.booktitle.edition}
+{ booktitle "booktitle" bibinfo.check duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      select.language
+      emphasize
+      edition empty$ 'skip$
+        { ", " *
+          edition
+          convert.edition
+          "l" change.case$
+          * "~" * bbl.edition *
+        }
+      if$
+      bbl.in " " * swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.article.title}
+{ title duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      "t" change.case$
+    }
+  if$
+  "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    { quote.close 'this.status.quote :=
+      is.last.char.not.punct
+        { punct.std 'this.status.punct := }
+        { punct.no 'this.status.punct := }
+      if$
+      select.language
+      "``" swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.article.title.electronic}
+{ title duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      "t" change.case$ 
+    }
+  if$
+  "title" bibinfo.check
+  duplicate$ empty$ 
+    { skip$ } 
+    { select.language }
+  if$
+}
+
+FUNCTION {format.book.title.edition}
+{ title "title" bibinfo.check
+  duplicate$ empty$
+    { "empty title in " cite$ * warning$ }
+    { this.to.prev.status
+      this.status.std
+      select.language
+      emphasize
+      edition empty$ 'skip$
+        { ", " *
+          edition
+          convert.edition
+          status.cap
+            { "t" }
+            { "l" }
+          if$
+          change.case$
+          * "~" * bbl.edition *
+        }
+      if$
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.book.title}
+{ title "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      select.language
+      emphasize
+    }
+  if$
+}
+
+
+
+%% journal
+
+FUNCTION {format.journal}
+{ journal duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      select.language
+      emphasize
+    }
+  if$
+}
+
+
+
+%% how published
+
+FUNCTION {format.howpublished}
+{ howpublished duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% institutions/organization/publishers/school
+
+FUNCTION {format.institution}
+{ institution duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.organization}
+{ organization duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.address.publisher.date}
+{ publisher "publisher" bibinfo.warn format.address.org.or.pub.date }
+
+FUNCTION {format.address.publisher.date.nowarn}
+{ publisher "publisher" bibinfo.check format.address.org.or.pub.date }
+
+FUNCTION {format.address.organization.date}
+{ organization "organization" bibinfo.check format.address.org.or.pub.date }
+
+FUNCTION {format.school}
+{ school duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% volume/number/series/chapter/pages
+
+FUNCTION {format.volume}
+{ volume empty.field.to.null.string
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      bbl.volume 
+      status.cap
+        { capitalize }
+        { skip$ }
+      if$
+      swap$ tie.or.space.prefix
+      "volume" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.number}
+{ number empty.field.to.null.string
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      status.cap
+         { bbl.number capitalize }
+         { bbl.number }
+       if$
+      swap$ tie.or.space.prefix
+      "number" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.number.if.use.for.article}
+{ is.use.number.for.article 
+     { format.number }
+     { "" }
+   if$
+}
+
+% IEEE does not seem to tie the series so closely with the volume
+% and number as is done in other bibliography styles. Instead the
+% series is treated somewhat like an extension of the title.
+FUNCTION {format.series}
+{ series empty$ 
+   { "" }
+   { this.to.prev.status
+     this.status.std
+     bbl.series " " *
+     series "series" bibinfo.check *
+     cap.status.std
+   }
+ if$
+}
+
+
+FUNCTION {format.chapter}
+{ chapter empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      type empty$
+        { bbl.chapter }
+        { type "l" change.case$
+          "type" bibinfo.check
+        }
+      if$
+      chapter tie.or.space.prefix
+      "chapter" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+% The intended use of format.paper is for paper numbers of inproceedings.
+% The paper type can be overridden via the type field.
+% We allow the type to be displayed even if the paper number is absent
+% for things like "postdeadline paper"
+FUNCTION {format.paper}
+{ is.use.paper
+     { paper empty$
+        { type empty$
+            { "" }
+            { this.to.prev.status
+              this.status.std
+              type "type" bibinfo.check
+              cap.status.std
+            }
+          if$
+        }
+        { this.to.prev.status
+          this.status.std
+          type empty$
+            { bbl.paper }
+            { type "type" bibinfo.check }
+          if$
+          " " * paper
+          "paper" bibinfo.check
+          *
+          cap.status.std
+        }
+      if$
+     }
+     { "" } 
+   if$
+}
+
+
+FUNCTION {format.pages}
+{ pages duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      duplicate$ is.multiple.pages
+        {
+          bbl.pages swap$
+          n.dashify
+        }
+        {
+          bbl.page swap$
+        }
+      if$
+      tie.or.space.prefix
+      "pages" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% technical report number
+
+FUNCTION {format.tech.report.number}
+{ number "number" bibinfo.check
+  this.to.prev.status
+  this.status.std
+  cap.status.std
+  type duplicate$ empty$
+    { pop$ 
+      bbl.techrep
+    }
+    { skip$ }
+  if$
+  "type" bibinfo.check 
+  swap$ duplicate$ empty$
+    { pop$ }
+    { tie.or.space.prefix * * }
+  if$
+}
+
+
+
+%% note
+
+FUNCTION {format.note}
+{ note empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      punct.period 'this.status.punct :=
+      note #1 #1 substring$
+      duplicate$ "{" =
+        { skip$ }
+        { status.cap
+          { "u" }
+          { "l" }
+        if$
+        change.case$
+        }
+      if$
+      note #2 global.max$ substring$ * "note" bibinfo.check
+      cap.yes  'status.cap :=
+    }
+  if$
+}
+
+
+
+%% patent
+
+FUNCTION {format.patent.date}
+{ this.to.prev.status
+  this.status.std
+  year empty$
+    { monthfiled duplicate$ empty$
+        { "monthfiled" bibinfo.check pop$ "" }
+        { "monthfiled" bibinfo.check }
+      if$
+      dayfiled duplicate$ empty$
+        { "dayfiled" bibinfo.check pop$ "" * }
+        { "dayfiled" bibinfo.check 
+          monthfiled empty$ 
+             { "dayfiled without a monthfiled in " cite$ * warning$
+               * 
+             }
+             { " " swap$ * * }
+           if$
+        }
+      if$
+      yearfiled empty$
+        { "no year or yearfiled in " cite$ * warning$ }
+        { yearfiled "yearfiled" bibinfo.check 
+          swap$
+          duplicate$ empty$
+             { pop$ }
+             { ", " * swap$ * }
+           if$
+        }
+      if$
+    }
+    { month duplicate$ empty$
+        { "month" bibinfo.check pop$ "" }
+        { "month" bibinfo.check }
+      if$
+      day duplicate$ empty$
+        { "day" bibinfo.check pop$ "" * }
+        { "day" bibinfo.check 
+          month empty$ 
+             { "day without a month in " cite$ * warning$
+               * 
+             }
+             { " " swap$ * * }
+           if$
+        }
+      if$
+      year "year" bibinfo.check 
+      swap$
+      duplicate$ empty$
+        { pop$ }
+        { ", " * swap$ * }
+      if$
+    }
+  if$
+  cap.status.std
+}
+
+FUNCTION {format.patent.nationality.type.number}
+{ this.to.prev.status
+  this.status.std
+  nationality duplicate$ empty$
+    { "nationality" bibinfo.warn pop$ "" }
+    { "nationality" bibinfo.check
+      duplicate$ "l" change.case$ "united states" =
+        { pop$ bbl.patentUS }
+        { skip$ }
+      if$
+      " " *
+    }
+  if$
+  type empty$
+    { bbl.patent "type" bibinfo.check }
+    { type "type" bibinfo.check }
+  if$  
+  *
+  number duplicate$ empty$
+    { "number" bibinfo.warn pop$ }
+    { "number" bibinfo.check
+      large.number.separate
+      swap$ " " * swap$ *
+    }
+  if$ 
+  cap.status.std
+}
+
+
+
+%% standard
+
+FUNCTION {format.organization.institution.standard.type.number}
+{ this.to.prev.status
+  this.status.std
+  organization duplicate$ empty$
+    { pop$ 
+      institution duplicate$ empty$
+        { "institution" bibinfo.warn }
+        { "institution" bibinfo.warn " " * }
+      if$
+    }
+    { "organization" bibinfo.warn " " * }
+  if$
+  type empty$
+    { bbl.standard "type" bibinfo.check }
+    { type "type" bibinfo.check }
+  if$  
+  *
+  number duplicate$ empty$
+    { "number" bibinfo.check pop$ }
+    { "number" bibinfo.check
+      large.number.separate
+      swap$ " " * swap$ *
+    }
+  if$ 
+  cap.status.std
+}
+
+FUNCTION {format.revision}
+{ revision empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      bbl.revision
+      revision tie.or.space.prefix
+      "revision" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+%% thesis
+
+FUNCTION {format.master.thesis.type}
+{ this.to.prev.status
+  this.status.std
+  type empty$
+    {
+      bbl.mthesis
+    }
+    { 
+      type "type" bibinfo.check
+    }
+  if$
+cap.status.std
+}
+
+FUNCTION {format.phd.thesis.type}
+{ this.to.prev.status
+  this.status.std
+  type empty$
+    {
+      bbl.phdthesis
+    }
+    { 
+      type "type" bibinfo.check
+    }
+  if$
+cap.status.std
+}
+
+
+
+%% URL
+
+FUNCTION {format.url}
+{ url empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      cap.yes 'status.cap :=
+      name.url.prefix " " *
+      "\url{" * url * "}" *
+      punct.no 'this.status.punct :=
+      punct.period 'prev.status.punct :=
+      space.normal 'this.status.space :=
+      space.normal 'prev.status.space :=
+      quote.no 'this.status.quote :=
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%
+%% ENTRY HANDLERS %%
+%%%%%%%%%%%%%%%%%%%%
+
+
+% Note: In many journals, IEEE (or the authors) tend not to show the number
+% for articles, so the display of the number is controlled here by the
+% switch "is.use.number.for.article"
+FUNCTION {article}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.journal "journal" bibinfo.check "journal" output.warn
+  format.volume output
+  format.number.if.use.for.article output
+  format.pages output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {book}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  author empty$
+    { format.editors "author and editor" output.warn }
+    { format.authors output.nonnull }
+  if$
+  name.or.dash
+  format.book.title.edition output
+  format.series output
+  author empty$
+    { skip$ }
+    { format.editors output }
+  if$
+  format.address.publisher.date output
+  format.volume output
+  format.number output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {booklet}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {electronic}
+{ std.status.using.period
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.date.electronic output
+  format.article.title.electronic output
+  format.howpublished "howpublished" bibinfo.check output
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+}
+
+FUNCTION {inbook}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  author empty$
+    { format.editors "author and editor" output.warn }
+    { format.authors output.nonnull }
+  if$
+  name.or.dash
+  format.book.title.edition output
+  format.series output
+  format.address.publisher.date output
+  format.volume output
+  format.number output
+  format.chapter output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {incollection}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.in.booktitle.edition "booktitle" output.warn
+  format.series output
+  format.editors output
+  format.address.publisher.date.nowarn output
+  format.volume output
+  format.number output
+  format.chapter output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {inproceedings}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.in.booktitle "booktitle" output.warn
+  format.series output
+  format.editors output
+  format.volume output
+  format.number output
+  publisher empty$
+    { format.address.organization.date output }
+    { format.organization "organization" bibinfo.check output
+      format.address.publisher.date output
+    }
+  if$
+  format.paper output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {manual}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.book.title.edition "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {mastersthesis}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.master.thesis.type output.nonnull
+  format.school "school" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {misc}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title output
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.pages output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+}
+
+FUNCTION {patent}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title output
+  format.patent.nationality.type.number output
+  format.patent.date output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+}
+
+FUNCTION {periodical}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.editors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.series output
+  format.volume output
+  format.number output
+  format.organization "organization" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {phdthesis}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.phd.thesis.type output.nonnull
+  format.school "school" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {proceedings}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.editors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.series output
+  format.volume output
+  format.number output
+  publisher empty$
+    { format.address.organization.date output }
+    { format.organization "organization" bibinfo.check output
+      format.address.publisher.date output
+    }
+  if$
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {standard}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization.institution.standard.type.number output
+  format.revision output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {techreport}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.institution "institution" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.tech.report.number output.nonnull
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {unpublished}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.date output
+  format.note "note" output.warn
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+
+% The special entry type which provides the user interface to the
+% BST controls
+FUNCTION {IEEEtranBSTCTL}
+{ is.print.banners.to.terminal
+    { "** IEEEtran BST control entry " quote$ * cite$ * quote$ * " detected." *
+      top$
+    }
+    { skip$ }
+  if$
+  CTLuse_article_number
+  empty$
+    { skip$ }
+    { CTLuse_article_number
+      yes.no.to.int
+      'is.use.number.for.article :=
+    }
+  if$
+  CTLuse_paper
+  empty$
+    { skip$ }
+    { CTLuse_paper
+      yes.no.to.int
+      'is.use.paper :=
+    }
+  if$
+  CTLuse_forced_etal
+  empty$
+    { skip$ }
+    { CTLuse_forced_etal
+      yes.no.to.int
+      'is.forced.et.al :=
+    }
+  if$
+  CTLmax_names_forced_etal
+  empty$
+    { skip$ }
+    { CTLmax_names_forced_etal
+      string.to.integer
+      'max.num.names.before.forced.et.al :=
+    }
+  if$
+  CTLnames_show_etal
+  empty$
+    { skip$ }
+    { CTLnames_show_etal
+      string.to.integer
+      'num.names.shown.with.forced.et.al :=
+    }
+  if$
+  CTLuse_alt_spacing
+  empty$
+    { skip$ }
+    { CTLuse_alt_spacing
+      yes.no.to.int
+      'is.use.alt.interword.spacing :=
+    }
+  if$
+  CTLalt_stretch_factor
+  empty$
+    { skip$ }
+    { CTLalt_stretch_factor
+      'ALTinterwordstretchfactor :=
+      "\renewcommand{\BIBentryALTinterwordstretchfactor}{"
+      ALTinterwordstretchfactor * "}" *
+      write$ newline$
+    }
+  if$
+  CTLdash_repeated_names
+  empty$
+    { skip$ }
+    { CTLdash_repeated_names
+      yes.no.to.int
+      'is.dash.repeated.names :=
+    }
+  if$
+  CTLname_format_string
+  empty$
+    { skip$ }
+    { CTLname_format_string
+      'name.format.string :=
+    }
+  if$
+  CTLname_latex_cmd
+  empty$
+    { skip$ }
+    { CTLname_latex_cmd
+      'name.latex.cmd :=
+    }
+  if$
+  CTLname_url_prefix
+  missing$
+    { skip$ }
+    { CTLname_url_prefix
+      'name.url.prefix :=
+    }
+  if$
+
+
+  num.names.shown.with.forced.et.al max.num.names.before.forced.et.al >
+    { "CTLnames_show_etal cannot be greater than CTLmax_names_forced_etal in " cite$ * warning$ 
+      max.num.names.before.forced.et.al 'num.names.shown.with.forced.et.al :=
+    }
+    { skip$ }
+  if$
+}
+
+
+%%%%%%%%%%%%%%%%%%%
+%% ENTRY ALIASES %%
+%%%%%%%%%%%%%%%%%%%
+FUNCTION {conference}{inproceedings}
+FUNCTION {online}{electronic}
+FUNCTION {internet}{electronic}
+FUNCTION {webpage}{electronic}
+FUNCTION {www}{electronic}
+FUNCTION {default.type}{misc}
+
+
+
+%%%%%%%%%%%%%%%%%%
+%% MAIN PROGRAM %%
+%%%%%%%%%%%%%%%%%%
+
+READ
+
+EXECUTE {initialize.controls}
+EXECUTE {initialize.status.constants}
+EXECUTE {banner.message}
+
+EXECUTE {initialize.longest.label}
+ITERATE {longest.label.pass}
+
+EXECUTE {begin.bib}
+ITERATE {call.type$}
+EXECUTE {end.bib}
+
+EXECUTE{completed.message}
+
+
+%% That's all folks, mds.

--- a/ieee/IEEEtran.cls
+++ b/ieee/IEEEtran.cls
@@ -1,0 +1,4733 @@
+%%
+%% IEEEtran.cls 2011/11/03 version V1.8 based on
+%% IEEEtran.cls 2007/03/05 version V1.7a
+%% The changes in V1.8 are made with a single goal in mind:
+%% to change the look of the output using the [conference] option
+%% and the default font size (10pt) to match the Word template more closely.
+%% These changes may well have undesired side effects when other options
+%% are in force!
+%% 
+%% 
+%% This is the official IEEE LaTeX class for authors of the Institute of 
+%% Electrical and Electronics Engineers (IEEE) Transactions journals and
+%% conferences.
+%% 
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and
+%% http://www.ieee.org/
+%%
+%% Based on the original 1993 IEEEtran.cls, but with many bug fixes
+%% and enhancements (from both JVH and MDS) over the 1996/7 version.
+%%
+%%
+%% Contributors:
+%% Gerry Murray (1993), Silvano Balemi (1993),
+%% Jon Dixon (1996), Peter N"uchter (1996),
+%% Juergen von Hagen (2000), and Michael Shell (2001-2007)
+%% 
+%% 
+%% Copyright (c) 1993-2000 by Gerry Murray, Silvano Balemi, 
+%%                         Jon Dixon, Peter N"uchter,
+%%                         Juergen von Hagen
+%%                         and
+%% Copyright (c) 2001-2007 by Michael Shell
+%%
+%% Current maintainer (V1.3 to V1.7): Michael Shell
+%%                                    See:
+%%                                    http://www.michaelshell.org/
+%%                                    for current contact information.
+%%
+%% Special thanks to Peter Wilson (CUA) and Donald Arseneau
+%% for allowing the inclusion of the \@ifmtarg command 
+%% from their ifmtarg LaTeX package. 
+%% 
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+%%                    bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+%% 
+%% Major changes to the user interface should be indicated by an 
+%% increase in the version numbers. If a version is a beta, it will 
+%% be indicated with a BETA suffix, i.e., 1.4 BETA.
+%% Small changes can be indicated by appending letters to the version
+%% such as "IEEEtran_v14a.cls".
+%% In all cases, \Providesclass, any \typeout messages to the user,
+%% \IEEEtransversionmajor and \IEEEtransversionminor must reflect the
+%% correct version information.
+%% The changes should also be documented via source comments.
+%%*************************************************************************
+%%
+%
+% Available class options 
+% e.g., \documentclass[10pt,conference]{IEEEtran} 
+% 
+%             *** choose only one from each category ***
+%
+% 9pt, 10pt, 11pt, 12pt
+%    Sets normal font size. The default is 10pt.
+% 
+% conference, journal, technote, peerreview, peerreviewca
+%    determines format mode - conference papers, journal papers,
+%    correspondence papers (technotes), or peer review papers. The user
+%    should also select 9pt when using technote. peerreview is like
+%    journal mode, but provides for a single-column "cover" title page for
+%    anonymous peer review. The paper title (without the author names) is
+%    repeated at the top of the page after the cover page. For peer review
+%    papers, the \IEEEpeerreviewmaketitle command must be executed (will
+%    automatically be ignored for non-peerreview modes) at the place the
+%    cover page is to end, usually just after the abstract (keywords are
+%    not normally used with peer review papers). peerreviewca is like
+%    peerreview, but allows the author names to be entered and formatted
+%    as with conference mode so that author affiliation and contact
+%    information can be easily seen on the cover page.
+%    The default is journal.
+%
+% draft, draftcls, draftclsnofoot, final
+%    determines if paper is formatted as a widely spaced draft (for
+%    handwritten editor comments) or as a properly typeset final version.
+%    draftcls restricts draft mode to the class file while all other LaTeX
+%    packages (i.e., \usepackage{graphicx}) will behave as final - allows
+%    for a draft paper with visible figures, etc. draftclsnofoot is like
+%    draftcls, but does not display the date and the word "DRAFT" at the foot
+%    of the pages. If using one of the draft modes, the user will probably
+%    also want to select onecolumn.
+%    The default is final.
+%
+% letterpaper, a4paper
+%    determines paper size: 8.5in X 11in or 210mm X 297mm. CHANGING THE PAPER
+%    SIZE WILL NOT ALTER THE TYPESETTING OF THE DOCUMENT - ONLY THE MARGINS
+%    WILL BE AFFECTED. In particular, documents using the a4paper option will
+%    have reduced side margins (A4 is narrower than US letter) and a longer
+%    bottom margin (A4 is longer than US letter). For both cases, the top
+%    margins will be the same and the text will be horizontally centered. 
+%    For final submission to IEEE, authors should use US letter (8.5 X 11in)
+%    paper. Note that authors should ensure that all post-processing 
+%    (ps, pdf, etc.) uses the same paper specificiation as the .tex document.
+%    Problems here are by far the number one reason for incorrect margins.
+%    IEEEtran will automatically set the default paper size under pdflatex 
+%    (without requiring a change to pdftex.cfg), so this issue is more
+%    important to dvips users. Fix config.ps, config.pdf, or ~/.dvipsrc for
+%    dvips, or use the dvips -t papersize option instead as needed. See the
+%    testflow documentation
+%    http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/testflow
+%    for more details on dvips paper size configuration.
+%    The default is letterpaper.
+%
+% oneside, twoside
+%    determines if layout follows single sided or two sided (duplex)
+%    printing. The only notable change is with the headings at the top of
+%    the pages.
+%    The default is oneside.
+%
+% onecolumn, twocolumn
+%    determines if text is organized into one or two columns per page. One
+%    column mode is usually used only with draft papers.
+%    The default is twocolumn.
+%
+% compsoc
+%    Use the format of the IEEE Computer Society.
+%
+% romanappendices
+%    Use the "Appendix I" convention when numbering appendices. IEEEtran.cls
+%    now defaults to Alpha "Appendix A" convention - the opposite of what
+%    v1.6b and earlier did.
+%
+% captionsoff
+%    disables the display of the figure/table captions. Some IEEE journals
+%    request that captions be removed and figures/tables be put on pages
+%    of their own at the end of an initial paper submission. The endfloat
+%    package can be used with this class option to achieve this format.
+%
+% nofonttune
+%    turns off tuning of the font interword spacing. Maybe useful to those
+%    not using the standard Times fonts or for those who have already "tuned"
+%    their fonts.
+%    The default is to enable IEEEtran to tune font parameters.
+%
+%
+%----------
+% Available CLASSINPUTs provided (all are macros unless otherwise noted):
+% \CLASSINPUTbaselinestretch
+% \CLASSINPUTinnersidemargin
+% \CLASSINPUToutersidemargin
+% \CLASSINPUTtoptextmargin
+% \CLASSINPUTbottomtextmargin
+%
+% Available CLASSINFOs provided:
+% \ifCLASSINFOpdf                       (TeX if conditional)
+% \CLASSINFOpaperwidth                  (macro)
+% \CLASSINFOpaperheight                 (macro)
+% \CLASSINFOnormalsizebaselineskip      (length)
+% \CLASSINFOnormalsizeunitybaselineskip (length)
+%
+% Available CLASSOPTIONs provided:
+% all class option flags (TeX if conditionals) unless otherwise noted,
+% e.g., \ifCLASSOPTIONcaptionsoff
+% point size options provided as a single macro:
+% \CLASSOPTIONpt
+% which will be defined as 9, 10, 11, or 12 depending on the document's
+% normalsize point size.
+% also, class option peerreviewca implies the use of class option peerreview
+% and classoption draft implies the use of class option draftcls
+
+
+
+
+
+\ProvidesClass{IEEEtran}[2012/11/21 V1.8c by Harald Hanche-Olsen and Anders Christensen]
+\typeout{-- Based on V1.7a by Michael Shell}
+\typeout{-- See the "IEEEtran_HOWTO" manual for usage information.}
+\typeout{-- http://www.michaelshell.org/tex/ieeetran/}
+\NeedsTeXFormat{LaTeX2e}
+
+% IEEEtran.cls version numbers, provided as of V1.3
+% These values serve as a way a .tex file can
+% determine if the new features are provided.
+% The version number of this IEEEtrans.cls can be obtained from 
+% these values. i.e., V1.4
+% KEEP THESE AS INTEGERS! i.e., NO {4a} or anything like that-
+% (no need to enumerate "a" minor changes here)
+\def\IEEEtransversionmajor{1}
+\def\IEEEtransversionminor{7}
+
+% These do nothing, but provide them like in article.cls
+\newif\if@restonecol
+\newif\if@titlepage
+
+
+% class option conditionals
+\newif\ifCLASSOPTIONonecolumn       \CLASSOPTIONonecolumnfalse
+\newif\ifCLASSOPTIONtwocolumn       \CLASSOPTIONtwocolumntrue
+
+\newif\ifCLASSOPTIONoneside         \CLASSOPTIONonesidetrue
+\newif\ifCLASSOPTIONtwoside         \CLASSOPTIONtwosidefalse
+
+\newif\ifCLASSOPTIONfinal           \CLASSOPTIONfinaltrue
+\newif\ifCLASSOPTIONdraft           \CLASSOPTIONdraftfalse
+\newif\ifCLASSOPTIONdraftcls        \CLASSOPTIONdraftclsfalse
+\newif\ifCLASSOPTIONdraftclsnofoot  \CLASSOPTIONdraftclsnofootfalse
+
+\newif\ifCLASSOPTIONpeerreview      \CLASSOPTIONpeerreviewfalse
+\newif\ifCLASSOPTIONpeerreviewca    \CLASSOPTIONpeerreviewcafalse
+
+\newif\ifCLASSOPTIONjournal         \CLASSOPTIONjournaltrue
+\newif\ifCLASSOPTIONconference      \CLASSOPTIONconferencefalse
+\newif\ifCLASSOPTIONtechnote        \CLASSOPTIONtechnotefalse
+
+\newif\ifCLASSOPTIONnofonttune      \CLASSOPTIONnofonttunefalse
+
+\newif\ifCLASSOPTIONcaptionsoff     \CLASSOPTIONcaptionsofffalse
+
+\newif\ifCLASSOPTIONcompsoc         \CLASSOPTIONcompsocfalse
+
+\newif\ifCLASSOPTIONromanappendices \CLASSOPTIONromanappendicesfalse
+
+
+% class info conditionals
+
+% indicates if pdf (via pdflatex) output
+\newif\ifCLASSINFOpdf               \CLASSINFOpdffalse
+
+
+% V1.6b internal flag to show if using a4paper
+\newif\if@IEEEusingAfourpaper       \@IEEEusingAfourpaperfalse
+
+
+
+% IEEEtran class scratch pad registers
+% dimen
+\newdimen\@IEEEtrantmpdimenA
+\newdimen\@IEEEtrantmpdimenB
+% count
+\newcount\@IEEEtrantmpcountA
+\newcount\@IEEEtrantmpcountB
+% token list
+\newtoks\@IEEEtrantmptoksA
+
+% we use \CLASSOPTIONpt so that we can ID the point size (even for 9pt docs)
+% as well as LaTeX's \@ptsize to retain some compatability with some
+% external packages
+\def\@ptsize{0}
+% LaTeX does not support 9pt, so we set \@ptsize to 0 - same as that of 10pt
+\DeclareOption{9pt}{\def\CLASSOPTIONpt{9}\def\@ptsize{0}}
+\DeclareOption{10pt}{\def\CLASSOPTIONpt{10}\def\@ptsize{0}}
+\DeclareOption{11pt}{\def\CLASSOPTIONpt{11}\def\@ptsize{1}}
+\DeclareOption{12pt}{\def\CLASSOPTIONpt{12}\def\@ptsize{2}}
+
+
+
+\DeclareOption{letterpaper}{\setlength{\paperheight}{11in}%
+                            \setlength{\paperwidth}{8.5in}%
+                            \@IEEEusingAfourpaperfalse
+                            \def\CLASSOPTIONpaper{letter}%
+                            \def\CLASSINFOpaperwidth{8.5in}%
+                            \def\CLASSINFOpaperheight{11in}}
+
+
+\DeclareOption{a4paper}{\setlength{\paperheight}{297mm}%
+                        \setlength{\paperwidth}{210mm}%
+                        \@IEEEusingAfourpapertrue
+                        \def\CLASSOPTIONpaper{a4}%
+                        \def\CLASSINFOpaperwidth{210mm}%
+                        \def\CLASSINFOpaperheight{297mm}}
+
+\DeclareOption{oneside}{\@twosidefalse\@mparswitchfalse
+                        \CLASSOPTIONonesidetrue\CLASSOPTIONtwosidefalse}
+\DeclareOption{twoside}{\@twosidetrue\@mparswitchtrue
+                        \CLASSOPTIONtwosidetrue\CLASSOPTIONonesidefalse}
+
+\DeclareOption{onecolumn}{\CLASSOPTIONonecolumntrue\CLASSOPTIONtwocolumnfalse}
+\DeclareOption{twocolumn}{\CLASSOPTIONtwocolumntrue\CLASSOPTIONonecolumnfalse}
+
+% If the user selects draft, then this class AND any packages
+% will go into draft mode.
+\DeclareOption{draft}{\CLASSOPTIONdrafttrue\CLASSOPTIONdraftclstrue
+                      \CLASSOPTIONdraftclsnofootfalse} 
+% draftcls is for a draft mode which will not affect any packages
+% used by the document.
+\DeclareOption{draftcls}{\CLASSOPTIONdraftfalse\CLASSOPTIONdraftclstrue
+                         \CLASSOPTIONdraftclsnofootfalse} 
+% draftclsnofoot is like draftcls, but without the footer.
+\DeclareOption{draftclsnofoot}{\CLASSOPTIONdraftfalse\CLASSOPTIONdraftclstrue
+                               \CLASSOPTIONdraftclsnofoottrue} 
+\DeclareOption{final}{\CLASSOPTIONdraftfalse\CLASSOPTIONdraftclsfalse
+                      \CLASSOPTIONdraftclsnofootfalse}
+
+\DeclareOption{journal}{\CLASSOPTIONpeerreviewfalse\CLASSOPTIONpeerreviewcafalse
+                        \CLASSOPTIONjournaltrue\CLASSOPTIONconferencefalse\CLASSOPTIONtechnotefalse}
+
+\DeclareOption{conference}{\CLASSOPTIONpeerreviewfalse\CLASSOPTIONpeerreviewcafalse
+                           \CLASSOPTIONjournalfalse\CLASSOPTIONconferencetrue\CLASSOPTIONtechnotefalse}
+
+\DeclareOption{technote}{\CLASSOPTIONpeerreviewfalse\CLASSOPTIONpeerreviewcafalse
+                         \CLASSOPTIONjournalfalse\CLASSOPTIONconferencefalse\CLASSOPTIONtechnotetrue}
+
+\DeclareOption{peerreview}{\CLASSOPTIONpeerreviewtrue\CLASSOPTIONpeerreviewcafalse
+                           \CLASSOPTIONjournalfalse\CLASSOPTIONconferencefalse\CLASSOPTIONtechnotefalse}
+
+\DeclareOption{peerreviewca}{\CLASSOPTIONpeerreviewtrue\CLASSOPTIONpeerreviewcatrue
+                             \CLASSOPTIONjournalfalse\CLASSOPTIONconferencefalse\CLASSOPTIONtechnotefalse}
+
+\DeclareOption{nofonttune}{\CLASSOPTIONnofonttunetrue}
+
+\DeclareOption{captionsoff}{\CLASSOPTIONcaptionsofftrue}
+
+\DeclareOption{compsoc}{\CLASSOPTIONcompsoctrue}
+
+\DeclareOption{romanappendices}{\CLASSOPTIONromanappendicestrue}
+
+
+% default to US letter paper, 10pt, twocolumn, one sided, final, journal
+\ExecuteOptions{letterpaper,10pt,twocolumn,oneside,final,journal}
+% overrride these defaults per user requests
+\ProcessOptions
+
+
+
+% Computer Society conditional execution command
+\long\def\@IEEEcompsoconly#1{\relax\ifCLASSOPTIONcompsoc\relax#1\relax\fi\relax}
+% inverse
+\long\def\@IEEEnotcompsoconly#1{\relax\ifCLASSOPTIONcompsoc\else\relax#1\relax\fi\relax}
+% compsoc conference
+\long\def\@IEEEcompsocconfonly#1{\relax\ifCLASSOPTIONcompsoc\ifCLASSOPTIONconference\relax#1\relax\fi\fi\relax}
+% compsoc not conference
+\long\def\@IEEEcompsocnotconfonly#1{\relax\ifCLASSOPTIONcompsoc\ifCLASSOPTIONconference\else\relax#1\relax\fi\fi\relax}
+
+
+% IEEE uses Times Roman font, so we'll default to Times.
+% These three commands make up the entire times.sty package.
+\renewcommand{\sfdefault}{phv}
+\renewcommand{\rmdefault}{ptm}
+\renewcommand{\ttdefault}{pcr}
+
+\@IEEEcompsoconly{\typeout{-- Using IEEE Computer Society mode.}}
+
+% V1.7 compsoc nonconference papers, use Palatino/Palladio as the main text font,
+% not Times Roman.
+\@IEEEcompsocnotconfonly{\renewcommand{\rmdefault}{ppl}}
+
+% enable Times/Palatino main text font
+\normalfont\selectfont
+
+
+
+
+
+% V1.7 conference notice message hook
+\def\@IEEEconsolenoticeconference{\typeout{}%
+\typeout{** Conference Paper **}%
+\typeout{Before submitting the final camera ready copy, remember to:}%
+\typeout{}%
+\typeout{ 1. Manually equalize the lengths of two columns on the last page}%
+\typeout{ of your paper;}%
+\typeout{}%
+\typeout{ 2. Ensure that any PostScript and/or PDF output post-processing}%
+\typeout{ uses only Type 1 fonts and that every step in the generation}%
+\typeout{ process uses the appropriate paper size.}%
+\typeout{}}
+
+
+% we can send console reminder messages to the user here
+\AtEndDocument{\ifCLASSOPTIONconference\@IEEEconsolenoticeconference\fi}
+
+
+% warn about the use of single column other than for draft mode
+\ifCLASSOPTIONtwocolumn\else%
+  \ifCLASSOPTIONdraftcls\else%
+   \typeout{** ATTENTION: Single column mode is not typically used with IEEE publications.}%
+  \fi%
+\fi
+
+
+% V1.7 improved paper size setting code.
+% Set pdfpage and dvips paper sizes. Conditional tests are similar to that
+% of ifpdf.sty. Retain within {} to ensure tested macros are never altered,
+% even if only effect is to set them to \relax.
+% if \pdfoutput is undefined or equal to relax, output a dvips special
+{\@ifundefined{pdfoutput}{\AtBeginDvi{\special{papersize=\CLASSINFOpaperwidth,\CLASSINFOpaperheight}}}{%
+% pdfoutput is defined and not equal to \relax
+% check for pdfpageheight existence just in case someone sets pdfoutput
+% under non-pdflatex. If exists, set them regardless of value of \pdfoutput.
+\@ifundefined{pdfpageheight}{\relax}{\global\pdfpagewidth\paperwidth
+\global\pdfpageheight\paperheight}%
+% if using \pdfoutput=0 under pdflatex, send dvips papersize special
+\ifcase\pdfoutput
+\AtBeginDvi{\special{papersize=\CLASSINFOpaperwidth,\CLASSINFOpaperheight}}%
+\else
+% we are using pdf output, set CLASSINFOpdf flag
+\global\CLASSINFOpdftrue
+\fi}}
+
+% let the user know the selected papersize
+\typeout{-- Using \CLASSINFOpaperwidth\space x \CLASSINFOpaperheight\space
+(\CLASSOPTIONpaper)\space paper.}
+
+\ifCLASSINFOpdf
+\typeout{-- Using PDF output.}
+\else
+\typeout{-- Using DVI output.}
+\fi
+
+
+% The idea hinted here is for LaTeX to generate markleft{} and markright{}
+% automatically for you after you enter \author{}, \journal{},
+% \journaldate{}, journalvol{}, \journalnum{}, etc.
+% However, there may be some backward compatibility issues here as
+% well as some special applications for IEEEtran.cls and special issues
+% that may require the flexible \markleft{}, \markright{} and/or \markboth{}.
+% We'll leave this as an open future suggestion.
+%\newcommand{\journal}[1]{\def\@journal{#1}}
+%\def\@journal{}
+
+
+
+% pointsize values
+% used with ifx to determine the document's normal size
+\def\@IEEEptsizenine{9}
+\def\@IEEEptsizeten{10}
+\def\@IEEEptsizeeleven{11}
+\def\@IEEEptsizetwelve{12}
+
+
+
+% FONT DEFINITIONS (No sizexx.clo file needed) 
+% V1.6 revised font sizes, displayskip values and
+%      revised normalsize baselineskip to reduce underfull vbox problems
+%      on the 58pc = 696pt = 9.5in text height we want
+%      normalsize     #lines/column  baselineskip (aka leading)
+%             9pt     63             11.0476pt (truncated down)
+%            10pt     58             12pt      (exact)
+%            11pt     52             13.3846pt (truncated down)
+%            12pt     50             13.92pt   (exact)
+%
+
+% we need to store the nominal baselineskip for the given font size
+% in case baselinestretch ever changes.
+% this is a dimen, so it will not hold stretch or shrink
+\newdimen\@IEEEnormalsizeunitybaselineskip
+\@IEEEnormalsizeunitybaselineskip\baselineskip
+
+\ifx\CLASSOPTIONpt\@IEEEptsizenine
+\typeout{-- This is a 9 point document.}
+\def\normalsize{\@setfontsize{\normalsize}{9}{11.0476pt}}%
+\setlength{\@IEEEnormalsizeunitybaselineskip}{11.0476pt}%
+\normalsize
+\abovedisplayskip 1.5ex plus3pt minus1pt%
+\belowdisplayskip \abovedisplayskip%
+\abovedisplayshortskip 0pt plus3pt%
+\belowdisplayshortskip 1.5ex plus3pt minus1pt
+\def\small{\@setfontsize{\small}{8.5}{10pt}}
+\def\footnotesize{\@setfontsize{\footnotesize}{8}{9pt}}
+\def\scriptsize{\@setfontsize{\scriptsize}{7}{8pt}}
+\def\tiny{\@setfontsize{\tiny}{5}{6pt}}
+% sublargesize is the same as large - 10pt
+\def\sublargesize{\@setfontsize{\sublargesize}{10}{12pt}}
+\def\large{\@setfontsize{\large}{10}{12pt}}
+\def\Large{\@setfontsize{\Large}{12}{14pt}}
+\def\LARGE{\@setfontsize{\LARGE}{14}{17pt}}
+\def\huge{\@setfontsize{\huge}{17}{20pt}}
+\def\Huge{\@setfontsize{\Huge}{20}{24pt}}
+\fi
+
+
+% Check if we have selected 10 points
+\ifx\CLASSOPTIONpt\@IEEEptsizeten
+\typeout{-- This is a 10 point document.}
+\def\normalsize{\@setfontsize{\normalsize}{10}{11}}%
+\setlength{\@IEEEnormalsizeunitybaselineskip}{11pt}%
+\normalsize
+\abovedisplayskip 1.5ex plus4pt minus2pt%
+\belowdisplayskip \abovedisplayskip%
+\abovedisplayshortskip 0pt plus4pt%
+\belowdisplayshortskip 1.5ex plus4pt minus2pt
+\def\small{\@setfontsize{\small}{9}{10pt}}
+\def\footnotesize{\@setfontsize{\footnotesize}{8}{9pt}}
+\def\scriptsize{\@setfontsize{\scriptsize}{7}{8pt}}
+\def\tiny{\@setfontsize{\tiny}{5}{6pt}}
+% sublargesize is a tad smaller than large - 11pt
+\def\sublargesize{\@setfontsize{\sublargesize}{11}{13.4pt}}
+\def\large{\@setfontsize{\large}{12}{14pt}}
+\def\Large{\@setfontsize{\Large}{14}{17pt}}
+\def\LARGE{\@setfontsize{\LARGE}{17}{20pt}}
+\def\huge{\@setfontsize{\huge}{20}{24pt}}
+\def\Huge{\@setfontsize{\Huge}{24}{28pt}}
+\fi
+
+
+% Check if we have selected 11 points
+\ifx\CLASSOPTIONpt\@IEEEptsizeeleven
+\typeout{-- This is an 11 point document.}
+\def\normalsize{\@setfontsize{\normalsize}{11}{13.3846pt}}%
+\setlength{\@IEEEnormalsizeunitybaselineskip}{13.3846pt}%
+\normalsize
+\abovedisplayskip 1.5ex plus5pt minus3pt%
+\belowdisplayskip \abovedisplayskip%
+\abovedisplayshortskip 0pt plus5pt%
+\belowdisplayshortskip 1.5ex plus5pt minus3pt
+\def\small{\@setfontsize{\small}{10}{12pt}}
+\def\footnotesize{\@setfontsize{\footnotesize}{9}{10.5pt}}
+\def\scriptsize{\@setfontsize{\scriptsize}{8}{9pt}}
+\def\tiny{\@setfontsize{\tiny}{6}{7pt}}
+% sublargesize is the same as large - 12pt
+\def\sublargesize{\@setfontsize{\sublargesize}{12}{14pt}}
+\def\large{\@setfontsize{\large}{12}{14pt}}
+\def\Large{\@setfontsize{\Large}{14}{17pt}}
+\def\LARGE{\@setfontsize{\LARGE}{17}{20pt}}
+\def\huge{\@setfontsize{\huge}{20}{24pt}}
+\def\Huge{\@setfontsize{\Huge}{24}{28pt}}
+\fi
+
+
+% Check if we have selected 12 points
+\ifx\CLASSOPTIONpt\@IEEEptsizetwelve
+\typeout{-- This is a 12 point document.}
+\def\normalsize{\@setfontsize{\normalsize}{12}{13.92pt}}%
+\setlength{\@IEEEnormalsizeunitybaselineskip}{13.92pt}%
+\normalsize
+\abovedisplayskip 1.5ex plus6pt minus4pt%
+\belowdisplayskip \abovedisplayskip%
+\abovedisplayshortskip 0pt plus6pt%
+\belowdisplayshortskip 1.5ex plus6pt minus4pt
+\def\small{\@setfontsize{\small}{10}{12pt}}
+\def\footnotesize{\@setfontsize{\footnotesize}{9}{10.5pt}}
+\def\scriptsize{\@setfontsize{\scriptsize}{8}{9pt}}
+\def\tiny{\@setfontsize{\tiny}{6}{7pt}}
+% sublargesize is the same as large - 14pt
+\def\sublargesize{\@setfontsize{\sublargesize}{14}{17pt}}
+\def\large{\@setfontsize{\large}{14}{17pt}}
+\def\Large{\@setfontsize{\Large}{17}{20pt}}
+\def\LARGE{\@setfontsize{\LARGE}{20}{24pt}}
+\def\huge{\@setfontsize{\huge}{22}{26pt}}
+\def\Huge{\@setfontsize{\Huge}{24}{28pt}}
+\fi
+
+
+% V1.6 The Computer Modern Fonts will issue a substitution warning for
+% 24pt titles (24.88pt is used instead) increase the substitution
+% tolerance to turn off this warning
+\def\fontsubfuzz{.9pt}
+% However, the default (and correct) Times font will scale exactly as needed.
+
+
+% warn the user in case they forget to use the 9pt option with
+% technote
+\ifCLASSOPTIONtechnote%
+ \ifx\CLASSOPTIONpt\@IEEEptsizenine\else%
+  \typeout{** ATTENTION: Technotes are normally 9pt documents.}%
+ \fi%
+\fi
+
+
+% V1.7
+% Improved \textunderscore to provide a much better fake _ when used with
+% OT1 encoding. Under OT1, detect use of pcr or cmtt \ttfamily and use
+% available true _ glyph for those two typewriter fonts.
+\def\@IEEEstringptm{ptm} % Times Roman family
+\def\@IEEEstringppl{ppl} % Palatino Roman family
+\def\@IEEEstringphv{phv} % Helvetica Sans Serif family
+\def\@IEEEstringpcr{pcr} % Courier typewriter family
+\def\@IEEEstringcmtt{cmtt} % Computer Modern typewriter family
+\DeclareTextCommandDefault{\textunderscore}{\leavevmode
+\ifx\f@family\@IEEEstringpcr\string_\else
+\ifx\f@family\@IEEEstringcmtt\string_\else
+\ifx\f@family\@IEEEstringptm\kern 0em\vbox{\hrule\@width 0.5em\@height 0.5pt\kern -0.3ex}\else
+\ifx\f@family\@IEEEstringppl\kern 0em\vbox{\hrule\@width 0.5em\@height 0.5pt\kern -0.3ex}\else
+\ifx\f@family\@IEEEstringphv\kern -0.03em\vbox{\hrule\@width 0.62em\@height 0.52pt\kern -0.33ex}\kern -0.03em\else
+\kern 0.09em\vbox{\hrule\@width 0.6em\@height 0.44pt\kern -0.63pt\kern -0.42ex}\kern 0.09em\fi\fi\fi\fi\fi\relax}
+
+
+
+
+% set the default \baselinestretch
+\def\baselinestretch{1}
+\ifCLASSOPTIONdraftcls
+  \def\baselinestretch{1.5}% default baselinestretch for draft modes
+\fi 
+
+
+% process CLASSINPUT baselinestretch
+\ifx\CLASSINPUTbaselinestretch\@IEEEundefined
+\else
+  \edef\baselinestretch{\CLASSINPUTbaselinestretch} % user CLASSINPUT override
+  \typeout{** ATTENTION: Overriding \string\baselinestretch\space to
+           \baselinestretch\space via \string\CLASSINPUT.}
+\fi
+
+\normalsize % make \baselinestretch take affect
+
+
+
+
+% store the normalsize baselineskip
+\newdimen\CLASSINFOnormalsizebaselineskip
+\CLASSINFOnormalsizebaselineskip=\baselineskip\relax
+% and the normalsize unity (baselinestretch=1) baselineskip
+% we could save a register by giving the user access to
+% \@IEEEnormalsizeunitybaselineskip. However, let's protect
+% its read only internal status
+\newdimen\CLASSINFOnormalsizeunitybaselineskip
+\CLASSINFOnormalsizeunitybaselineskip=\@IEEEnormalsizeunitybaselineskip\relax
+% store the nominal value of jot
+\newdimen\IEEEnormaljot
+\IEEEnormaljot=0.25\baselineskip\relax
+
+% set \jot
+\jot=\IEEEnormaljot\relax
+
+
+
+
+% V1.6, we are now going to fine tune the interword spacing
+% The default interword glue for Times under TeX appears to use a
+% nominal interword spacing of 25% (relative to the font size, i.e., 1em)
+% a maximum of 40% and a minimum of 19%.
+% For example, 10pt text uses an interword glue of:
+% 
+% 2.5pt plus 1.49998pt minus 0.59998pt
+% 
+% However, IEEE allows for a more generous range which reduces the need
+% for hyphenation, especially for two column text. Furthermore, IEEE
+% tends to use a little bit more nominal space between the words.
+% IEEE's interword spacing percentages appear to be:
+% 35% nominal
+% 23% minimum
+% 50% maximum
+% (They may even be using a tad more for the largest fonts such as 24pt.)
+% 
+% for bold text, IEEE increases the spacing a little more:
+% 37.5% nominal
+% 23% minimum
+% 55% maximum
+
+% here are the interword spacing ratios we'll use
+% for medium (normal weight)
+\def\@IEEEinterspaceratioM{0.35}
+\def\@IEEEinterspaceMINratioM{0.23}
+\def\@IEEEinterspaceMAXratioM{0.50}
+
+% for bold
+\def\@IEEEinterspaceratioB{0.375}
+\def\@IEEEinterspaceMINratioB{0.23}
+\def\@IEEEinterspaceMAXratioB{0.55}
+
+
+% command to revise the interword spacing for the current font under TeX:
+% \fontdimen2 = nominal interword space
+% \fontdimen3 = interword stretch
+% \fontdimen4 = interword shrink
+% since all changes to the \fontdimen are global, we can enclose these commands
+% in braces to confine any font attribute or length changes
+\def\@@@IEEEsetfontdimens#1#2#3{{%
+\setlength{\@IEEEtrantmpdimenB}{\f@size pt}% grab the font size in pt, could use 1em instead.
+\setlength{\@IEEEtrantmpdimenA}{#1\@IEEEtrantmpdimenB}%
+\fontdimen2\font=\@IEEEtrantmpdimenA\relax
+\addtolength{\@IEEEtrantmpdimenA}{-#2\@IEEEtrantmpdimenB}%
+\fontdimen3\font=-\@IEEEtrantmpdimenA\relax
+\setlength{\@IEEEtrantmpdimenA}{#1\@IEEEtrantmpdimenB}%
+\addtolength{\@IEEEtrantmpdimenA}{-#3\@IEEEtrantmpdimenB}%
+\fontdimen4\font=\@IEEEtrantmpdimenA\relax}}
+
+% revise the interword spacing for each font weight
+\def\@@IEEEsetfontdimens{{%
+\mdseries
+\@@@IEEEsetfontdimens{\@IEEEinterspaceratioM}{\@IEEEinterspaceMAXratioM}{\@IEEEinterspaceMINratioM}%
+\bfseries
+\@@@IEEEsetfontdimens{\@IEEEinterspaceratioB}{\@IEEEinterspaceMAXratioB}{\@IEEEinterspaceMINratioB}%
+}}
+
+% revise the interword spacing for each font shape
+% \slshape is not often used for IEEE work and is not altered here. The \scshape caps are
+% already a tad too large in the free LaTeX fonts (as compared to what IEEE uses) so we
+% won't alter these either.
+\def\@IEEEsetfontdimens{{%
+\normalfont
+\@@IEEEsetfontdimens
+\normalfont\itshape
+\@@IEEEsetfontdimens
+}}
+
+% command to revise the interword spacing for each font size (and shape
+% and weight). Only the \rmfamily is done here as \ttfamily uses a 
+% fixed spacing and \sffamily is not used as the main text of IEEE papers.
+\def\@IEEEtunefonts{{\selectfont\rmfamily
+\tiny\@IEEEsetfontdimens
+\scriptsize\@IEEEsetfontdimens
+\footnotesize\@IEEEsetfontdimens
+\small\@IEEEsetfontdimens
+\normalsize\@IEEEsetfontdimens
+\sublargesize\@IEEEsetfontdimens
+\large\@IEEEsetfontdimens
+\LARGE\@IEEEsetfontdimens
+\huge\@IEEEsetfontdimens
+\Huge\@IEEEsetfontdimens}}
+
+% if the nofonttune class option is not given, revise the interword spacing
+% now - in case IEEEtran makes any default length measurements, and make
+% sure all the default fonts are loaded
+\ifCLASSOPTIONnofonttune\else
+\@IEEEtunefonts
+\fi
+
+% and again at the start of the document in case the user loaded different fonts
+\AtBeginDocument{\ifCLASSOPTIONnofonttune\else\@IEEEtunefonts\fi}
+
+
+
+% V1.6 
+% LaTeX is a little to quick to use hyphenations
+% So, we increase the penalty for their use and raise
+% the badness level that triggers an underfull hbox
+% warning. The author may still have to tweak things,
+% but the appearance will be much better "right out
+% of the box" than that under V1.5 and prior.
+% TeX default is 50
+\hyphenpenalty=750
+% If we didn't adjust the interword spacing, 2200 might be better.
+% The TeX default is 1000
+\hbadness=1350
+% IEEE does not use extra spacing after punctuation
+\frenchspacing
+
+% V1.7 increase this a tad to discourage equation breaks
+\binoppenalty=1000 % default 700
+\relpenalty=800     % default 500
+
+
+% margin note stuff
+\marginparsep      10pt
+\marginparwidth    20pt
+\marginparpush     25pt
+
+
+% if things get too close, go ahead and let them touch
+\lineskip            0pt
+\normallineskip      0pt
+\lineskiplimit       0pt
+\normallineskiplimit 0pt
+
+% The distance from the lower edge of the text body to the
+% footline
+\footskip 0.4in
+
+% normally zero, should be relative to font height.
+% put in a little rubber to help stop some bad breaks (underfull vboxes)
+\parskip 0ex plus 0.2ex minus 0.1ex
+\ifCLASSOPTIONconference
+\parskip 6pt plus 2pt minus 1pt
+\fi
+
+\parindent    1.0em
+\ifCLASSOPTIONconference
+\parindent 14.45pt
+\fi
+
+\topmargin    -49.0pt
+\headheight   12pt
+\headsep      0.25in
+
+% use the normal font baselineskip
+% so that \topskip is unaffected by changes in \baselinestretch
+\topskip=\@IEEEnormalsizeunitybaselineskip
+\textheight       58pc  % 9.63in, 696pt
+% Tweak textheight to a perfect integer number of lines/page.
+% The normal baselineskip for each document point size is used 
+% to determine these values.
+\ifx\CLASSOPTIONpt\@IEEEptsizenine\textheight=63\@IEEEnormalsizeunitybaselineskip\fi      % 63 lines/page
+\ifx\CLASSOPTIONpt\@IEEEptsizeten\textheight=58\@IEEEnormalsizeunitybaselineskip\fi       % 58 lines/page
+\ifx\CLASSOPTIONpt\@IEEEptsizeeleven\textheight=52\@IEEEnormalsizeunitybaselineskip\fi    % 52 lines/page
+\ifx\CLASSOPTIONpt\@IEEEptsizetwelve\textheight=50\@IEEEnormalsizeunitybaselineskip\fi    % 50 lines/page
+
+
+\columnsep       1.5pc
+\textwidth       184.2mm
+ 
+
+% the default side margins are equal
+\if@IEEEusingAfourpaper 
+\oddsidemargin        14.32mm
+\evensidemargin       14.32mm
+\else
+\oddsidemargin        0.680in
+\evensidemargin       0.680in
+\fi
+% compensate for LaTeX's 1in offset
+\addtolength{\oddsidemargin}{-1in}
+\addtolength{\evensidemargin}{-1in}
+
+
+
+% adjust margins for conference mode
+\ifCLASSOPTIONconference
+ \topmargin        -0.25in
+ % we retain the reserved, but unused space for headers
+ \addtolength{\topmargin}{-\headheight}
+ \addtolength{\topmargin}{-\headsep}
+ \textheight        9.25in % The standard for conferences (668.4975pt)
+ % Tweak textheight to a perfect integer number of lines/page.
+ \ifx\CLASSOPTIONpt\@IEEEptsizenine\textheight=61\@IEEEnormalsizeunitybaselineskip\fi      % 61 lines/page
+ \ifx\CLASSOPTIONpt\@IEEEptsizeten\textheight=62\@IEEEnormalsizeunitybaselineskip\fi       % 62 lines/page
+ \ifx\CLASSOPTIONpt\@IEEEptsizeeleven\textheight=50\@IEEEnormalsizeunitybaselineskip\fi    % 50 lines/page
+ \ifx\CLASSOPTIONpt\@IEEEptsizetwelve\textheight=48\@IEEEnormalsizeunitybaselineskip\fi    % 48 lines/page
+\fi
+
+
+% compsoc conference
+\ifCLASSOPTIONcompsoc
+\ifCLASSOPTIONconference
+ % compsoc conference use a larger value for columnsep
+ \columnsep 0.375in
+ % compsoc conferences want 1in top margin, 1.125in bottom margin
+ \topmargin        0in
+ \addtolength{\topmargin}{-6pt}% we tweak this a tad to better comply with top of line stuff
+ % we retain the reserved, but unused space for headers
+ \addtolength{\topmargin}{-\headheight}
+ \addtolength{\topmargin}{-\headsep}
+ \textheight        8.875in % (641.39625pt)
+ % Tweak textheight to a perfect integer number of lines/page.
+ \ifx\CLASSOPTIONpt\@IEEEptsizenine\textheight=58\@IEEEnormalsizeunitybaselineskip\fi      % 58 lines/page
+ \ifx\CLASSOPTIONpt\@IEEEptsizeten\textheight=53\@IEEEnormalsizeunitybaselineskip\fi       % 53 lines/page
+ \ifx\CLASSOPTIONpt\@IEEEptsizeeleven\textheight=48\@IEEEnormalsizeunitybaselineskip\fi    % 48 lines/page
+ \ifx\CLASSOPTIONpt\@IEEEptsizetwelve\textheight=46\@IEEEnormalsizeunitybaselineskip\fi    % 46 lines/page 
+ \textwidth 6.5in
+ % the default side margins are equal
+ \if@IEEEusingAfourpaper 
+  \oddsidemargin        22.45mm
+  \evensidemargin       22.45mm
+ \else
+  \oddsidemargin        1in
+  \evensidemargin       1in
+ \fi
+ % compensate for LaTeX's 1in offset
+ \addtolength{\oddsidemargin}{-1in}
+ \addtolength{\evensidemargin}{-1in}
+\fi\fi
+
+
+
+% draft mode settings override that of all other modes
+% provides a nice 1in margin all around the paper and extra
+% space between the lines for editor's comments
+\ifCLASSOPTIONdraftcls 
+  % want 1in from top of paper to text
+  \setlength{\topmargin}{-\headsep}%
+  \addtolength{\topmargin}{-\headheight}%
+  % we want 1in side margins regardless of paper type
+  \oddsidemargin      0in
+  \evensidemargin     0in
+  % set the text width
+  \setlength{\textwidth}{\paperwidth}%
+  \addtolength{\textwidth}{-2.0in}%
+  \setlength{\textheight}{\paperheight}%
+  \addtolength{\textheight}{-2.0in}%
+  % digitize textheight to be an integer number of lines.
+  % this may cause the bottom margin to be off a tad
+  \addtolength{\textheight}{-1\topskip}%
+  \divide\textheight  by \baselineskip%
+  \multiply\textheight  by \baselineskip%
+  \addtolength{\textheight}{\topskip}%
+\fi
+
+
+
+% process CLASSINPUT inner/outer margin
+% if inner margin defined, but outer margin not, set outer to inner.
+\ifx\CLASSINPUTinnersidemargin\@IEEEundefined
+\else
+  \ifx\CLASSINPUToutersidemargin\@IEEEundefined
+    \edef\CLASSINPUToutersidemargin{\CLASSINPUTinnersidemargin}
+  \fi
+\fi
+
+\ifx\CLASSINPUToutersidemargin\@IEEEundefined
+\else
+  % if outer margin defined, but inner margin not, set inner to outer.
+  \ifx\CLASSINPUTinnersidemargin\@IEEEundefined
+    \edef\CLASSINPUTinnersidemargin{\CLASSINPUToutersidemargin}
+  \fi
+  \setlength{\oddsidemargin}{\CLASSINPUTinnersidemargin}
+  \ifCLASSOPTIONtwoside
+    \setlength{\evensidemargin}{\CLASSINPUToutersidemargin}
+  \else
+    \setlength{\evensidemargin}{\CLASSINPUTinnersidemargin}
+  \fi
+  \addtolength{\oddsidemargin}{-1in}
+  \addtolength{\evensidemargin}{-1in}
+  \setlength{\textwidth}{\paperwidth}
+  \addtolength{\textwidth}{-\CLASSINPUTinnersidemargin}
+  \addtolength{\textwidth}{-\CLASSINPUToutersidemargin}
+  \typeout{** ATTENTION: Overriding inner side margin to \CLASSINPUTinnersidemargin\space and 
+           outer side margin to \CLASSINPUToutersidemargin\space via \string\CLASSINPUT.}
+\fi
+
+
+
+% process CLASSINPUT top/bottom text margin
+% if toptext margin defined, but bottomtext margin not, set bottomtext to toptext margin
+\ifx\CLASSINPUTtoptextmargin\@IEEEundefined
+\else
+  \ifx\CLASSINPUTbottomtextmargin\@IEEEundefined
+    \edef\CLASSINPUTbottomtextmargin{\CLASSINPUTtoptextmargin}
+  \fi
+\fi
+
+\ifx\CLASSINPUTbottomtextmargin\@IEEEundefined
+\else
+  % if bottomtext margin defined, but toptext margin not, set toptext to bottomtext margin
+  \ifx\CLASSINPUTtoptextmargin\@IEEEundefined
+    \edef\CLASSINPUTtoptextmargin{\CLASSINPUTbottomtextmargin}
+  \fi
+  \setlength{\topmargin}{\CLASSINPUTtoptextmargin}
+  \addtolength{\topmargin}{-1in}
+  \addtolength{\topmargin}{-\headheight}
+  \addtolength{\topmargin}{-\headsep}
+  \setlength{\textheight}{\paperheight}
+  \addtolength{\textheight}{-\CLASSINPUTtoptextmargin}
+  \addtolength{\textheight}{-\CLASSINPUTbottomtextmargin}
+  % in the default format we use the normal baselineskip as topskip
+  % we only need 0.7 of this to clear typical top text and we need
+  % an extra 0.3 spacing at the bottom for descenders. This will
+  % correct for both.
+  \addtolength{\topmargin}{-0.3\@IEEEnormalsizeunitybaselineskip}
+  \typeout{** ATTENTION: Overriding top text margin to \CLASSINPUTtoptextmargin\space and 
+           bottom text margin to \CLASSINPUTbottomtextmargin\space via \string\CLASSINPUT.}
+\fi
+
+
+
+
+
+
+
+% LIST SPACING CONTROLS
+
+% Controls the amount of EXTRA spacing
+% above and below \trivlist 
+% Both \list and IED lists override this.
+% However, \trivlist will use this as will most
+% things built from \trivlist like the \center
+% environment.
+\topsep           0.5\baselineskip
+
+% Controls the additional spacing around lists preceded
+% or followed by blank lines. IEEE does not increase
+% spacing before or after paragraphs so it is set to zero.
+% \z@ is the same as zero, but faster.
+\partopsep          \z@
+
+% Controls the spacing between paragraphs in lists. 
+% IEEE does not increase spacing before or after paragraphs
+% so this is also zero. 
+% With IEEEtran.cls, global changes to
+% this value DO affect lists (but not IED lists).
+\parsep             \z@
+
+% Controls the extra spacing between list items. 
+% IEEE does not put extra spacing between items.
+% With IEEEtran.cls, global changes to this value DO affect
+% lists (but not IED lists).
+\itemsep            \z@
+
+% \itemindent is the amount to indent the FIRST line of a list
+% item. It is auto set to zero within the \list environment. To alter
+% it, you have to do so when you call the \list.
+% However, IEEE uses this for the theorem environment
+% There is an alternative value for this near \leftmargini below
+\itemindent         -1em
+
+% \leftmargin, the spacing from the left margin of the main text to
+% the left of the main body of a list item is set by \list.
+% Hence this statement does nothing for lists.
+% But, quote and verse do use it for indention.
+\leftmargin         2em
+
+% we retain this stuff from the older IEEEtran.cls so that \list
+% will work the same way as before. However, itemize, enumerate and
+% description (IED) could care less about what these are as they
+% all are overridden.
+\leftmargini        2em
+%\itemindent         2em  % Alternative values: sometimes used.
+%\leftmargini        0em
+\leftmarginii       1em
+\leftmarginiii    1.5em
+\leftmarginiv     1.5em
+\leftmarginv      1.0em
+\leftmarginvi     1.0em
+\labelsep         0.5em 
+\labelwidth         \z@
+
+
+% The old IEEEtran.cls behavior of \list is retained.
+% However, the new V1.3 IED list environments override all the
+% @list stuff (\@listX is called within \list for the
+% appropriate level just before the user's list_decl is called). 
+% \topsep is now 2pt as IEEE puts a little extra space around
+% lists - used by those non-IED macros that depend on \list.
+% Note that \parsep and \itemsep are not redefined as in 
+% the sizexx.clo \@listX (which article.cls uses) so global changes
+% of these values DO affect \list
+% 
+\def\@listi{\leftmargin\leftmargini \topsep 2pt plus 1pt minus 1pt}
+\let\@listI\@listi
+\def\@listii{\leftmargin\leftmarginii\labelwidth\leftmarginii%
+    \advance\labelwidth-\labelsep \topsep 2pt}
+\def\@listiii{\leftmargin\leftmarginiii\labelwidth\leftmarginiii%
+    \advance\labelwidth-\labelsep \topsep 2pt}
+\def\@listiv{\leftmargin\leftmarginiv\labelwidth\leftmarginiv%
+    \advance\labelwidth-\labelsep \topsep 2pt}
+\def\@listv{\leftmargin\leftmarginv\labelwidth\leftmarginv%
+    \advance\labelwidth-\labelsep \topsep 2pt}
+\def\@listvi{\leftmargin\leftmarginvi\labelwidth\leftmarginvi%
+    \advance\labelwidth-\labelsep \topsep 2pt}
+
+
+% IEEE uses 5) not 5.
+\def\labelenumi{\theenumi)}     \def\theenumi{\arabic{enumi}}
+
+% IEEE uses a) not (a)
+\def\labelenumii{\theenumii)}  \def\theenumii{\alph{enumii}}
+
+% IEEE uses iii) not iii.
+\def\labelenumiii{\theenumiii)} \def\theenumiii{\roman{enumiii}}
+
+% IEEE uses A) not A.
+\def\labelenumiv{\theenumiv)}   \def\theenumiv{\Alph{enumiv}}
+
+% exactly the same as in article.cls
+\def\p@enumii{\theenumi}
+\def\p@enumiii{\theenumi(\theenumii)}
+\def\p@enumiv{\p@enumiii\theenumiii}
+
+% itemized list label styles
+\def\labelitemi{$\bullet$}
+\def\labelitemii{$\circ$}
+\def\labelitemiii{\vrule height 0.8ex depth -0.2ex width 0.6ex}
+\def\labelitemiv{$\ast$}
+
+
+
+% **** V1.3 ENHANCEMENTS ****
+% Itemize, Enumerate and Description (IED) List Controls
+% ***************************
+% 
+% 
+% IEEE seems to use at least two different values by
+% which ITEMIZED list labels are indented to the right
+% For The Journal of Lightwave Technology (JLT) and The Journal
+% on Selected Areas in Communications (JSAC), they tend to use
+% an indention equal to \parindent. For Transactions on Communications
+% they tend to indent ITEMIZED lists a little more--- 1.3\parindent.
+% We'll provide both values here for you so that you can choose 
+% which one you like in your document using a command such as:
+% setlength{\IEEEilabelindent}{\IEEEilabelindentB}
+\newdimen\IEEEilabelindentA
+\IEEEilabelindentA \parindent
+
+\newdimen\IEEEilabelindentB
+\IEEEilabelindentB 1.3\parindent
+% However, we'll default to using \parindent
+% which makes more sense to me
+\newdimen\IEEEilabelindent
+\IEEEilabelindent \IEEEilabelindentA
+
+
+% This controls the default amount the enumerated list labels
+% are indented to the right.
+% Normally, this is the same as the paragraph indention
+\newdimen\IEEEelabelindent
+\IEEEelabelindent \parindent
+
+% This controls the default amount the description list labels
+% are indented to the right.
+% Normally, this is the same as the paragraph indention
+\newdimen\IEEEdlabelindent
+\IEEEdlabelindent \parindent
+
+% This is the value actually used within the IED lists.
+% The IED environments automatically set its value to
+% one of the three values above, so global changes do 
+% not have any effect
+\newdimen\IEEElabelindent
+\IEEElabelindent \parindent
+
+% The actual amount labels will be indented is
+% \IEEElabelindent multiplied by the factor below
+% corresponding to the level of nesting depth
+% This provides a means by which the user can
+% alter the effective \IEEElabelindent for deeper
+% levels
+% There may not be such a thing as correct "standard IEEE"
+% values. What IEEE actually does may depend on the specific
+% circumstances.
+% The first list level almost always has full indention.
+% The second levels I've seen have only 75% of the normal indentation
+% Three level or greater nestings are very rare. I am guessing
+% that they don't use any indentation.
+\def\IEEElabelindentfactori{1.0}   % almost always one
+\def\IEEElabelindentfactorii{0.75} % 0.0 or 1.0 may be used in some cases
+\def\IEEElabelindentfactoriii{0.0} % 0.75? 0.5? 0.0?
+\def\IEEElabelindentfactoriv{0.0}
+\def\IEEElabelindentfactorv{0.0}
+\def\IEEElabelindentfactorvi{0.0}
+
+% value actually used within IED lists, it is auto
+% set to one of the 6 values above
+% global changes here have no effect
+\def\IEEElabelindentfactor{1.0}
+
+% This controls the default spacing between the end of the IED
+% list labels and the list text, when normal text is used for
+% the labels.
+\newdimen\IEEEiednormlabelsep
+\IEEEiednormlabelsep \parindent
+
+% This controls the default spacing between the end of the IED
+% list labels and the list text, when math symbols are used for
+% the labels (nomenclature lists). IEEE usually increases the 
+% spacing in these cases
+\newdimen\IEEEiedmathlabelsep
+\IEEEiedmathlabelsep 1.2em
+
+% This controls the extra vertical separation put above and
+% below each IED list. IEEE usually puts a little extra spacing
+% around each list. However, this spacing is barely noticeable.
+\newskip\IEEEiedtopsep
+\IEEEiedtopsep 2pt plus 1pt minus 1pt
+
+
+% This command is executed within each IED list environment
+% at the beginning of the list. You can use this to set the 
+% parameters for some/all your IED list(s) without disturbing 
+% global parameters that affect things other than lists.
+% i.e., renewcommand{\IEEEiedlistdecl}{\setlength{\labelsep}{5em}}
+% will alter the \labelsep for the next list(s) until 
+% \IEEEiedlistdecl is redefined. 
+\def\IEEEiedlistdecl{\relax}
+
+% This command provides an easy way to set \leftmargin based
+% on the \labelwidth, \labelsep and the argument \IEEElabelindent
+% Usage: \IEEEcalcleftmargin{width-to-indent-the-label}
+% output is in the \leftmargin variable, i.e., effectively:
+% \leftmargin = argument + \labelwidth + \labelsep
+% Note controlled spacing here, shield end of lines with %
+\def\IEEEcalcleftmargin#1{\setlength{\leftmargin}{#1}%
+\addtolength{\leftmargin}{\labelwidth}%
+\addtolength{\leftmargin}{\labelsep}}
+
+% This command provides an easy way to set \labelwidth to the
+% width of the given text. It is the same as
+% \settowidth{\labelwidth}{label-text}
+% and useful as a shorter alternative.
+% Typically used to set \labelwidth to be the width
+% of the longest label in the list
+\def\IEEEsetlabelwidth#1{\settowidth{\labelwidth}{#1}}
+
+% When this command is executed, IED lists will use the 
+% IEEEiedmathlabelsep label separation rather than the normal
+% spacing. To have an effect, this command must be executed via
+% the \IEEEiedlistdecl or within the option of the IED list
+% environments.
+\def\IEEEusemathlabelsep{\setlength{\labelsep}{\IEEEiedmathlabelsep}}
+
+% A flag which controls whether the IED lists automatically
+% calculate \leftmargin from \IEEElabelindent, \labelwidth and \labelsep
+% Useful if you want to specify your own \leftmargin
+% This flag must be set (\IEEEnocalcleftmargintrue or \IEEEnocalcleftmarginfalse) 
+% via the \IEEEiedlistdecl or within the option of the IED list
+% environments to have an effect.
+\newif\ifIEEEnocalcleftmargin
+\IEEEnocalcleftmarginfalse
+
+% A flag which controls whether \IEEElabelindent is multiplied by
+% the \IEEElabelindentfactor for each list level.
+% This flag must be set via the \IEEEiedlistdecl or within the option 
+% of the IED list environments to have an effect.
+\newif\ifIEEEnolabelindentfactor
+\IEEEnolabelindentfactorfalse
+
+
+% internal variable to indicate type of IED label
+% justification
+% 0 - left; 1 - center; 2 - right
+\def\@IEEEiedjustify{0}
+
+
+% commands to allow the user to control IED
+% label justifications. Use these commands within
+% the IED environment option or in the \IEEEiedlistdecl
+% Note that changing the normal list justifications
+% is nonstandard and IEEE may not like it if you do so!
+% I include these commands as they may be helpful to
+% those who are using these enhanced list controls for
+% other non-IEEE related LaTeX work.
+% itemize and enumerate automatically default to right
+% justification, description defaults to left.
+\def\IEEEiedlabeljustifyl{\def\@IEEEiedjustify{0}}%left
+\def\IEEEiedlabeljustifyc{\def\@IEEEiedjustify{1}}%center
+\def\IEEEiedlabeljustifyr{\def\@IEEEiedjustify{2}}%right
+
+
+
+
+% commands to save to and restore from the list parameter copies
+% this allows us to set all the list parameters within
+% the list_decl and prevent \list (and its \@list) 
+% from overriding any of our parameters
+% V1.6 use \edefs instead of dimen's to conserve dimen registers
+% Note controlled spacing here, shield end of lines with %
+\def\@IEEEsavelistparams{\edef\@IEEEiedtopsep{\the\topsep}%
+\edef\@IEEEiedlabelwidth{\the\labelwidth}%
+\edef\@IEEEiedlabelsep{\the\labelsep}%
+\edef\@IEEEiedleftmargin{\the\leftmargin}%
+\edef\@IEEEiedpartopsep{\the\partopsep}%
+\edef\@IEEEiedparsep{\the\parsep}%
+\edef\@IEEEieditemsep{\the\itemsep}%
+\edef\@IEEEiedrightmargin{\the\rightmargin}%
+\edef\@IEEEiedlistparindent{\the\listparindent}%
+\edef\@IEEEieditemindent{\the\itemindent}}
+
+% Note controlled spacing here
+\def\@IEEErestorelistparams{\topsep\@IEEEiedtopsep\relax%
+\labelwidth\@IEEEiedlabelwidth\relax%
+\labelsep\@IEEEiedlabelsep\relax%
+\leftmargin\@IEEEiedleftmargin\relax%
+\partopsep\@IEEEiedpartopsep\relax%
+\parsep\@IEEEiedparsep\relax%
+\itemsep\@IEEEieditemsep\relax%
+\rightmargin\@IEEEiedrightmargin\relax%
+\listparindent\@IEEEiedlistparindent\relax%
+\itemindent\@IEEEieditemindent\relax}
+
+
+% v1.6b provide original LaTeX IED list environments
+% note that latex.ltx defines \itemize and \enumerate, but not \description
+% which must be created by the base classes
+% save original LaTeX itemize and enumerate
+\let\LaTeXitemize\itemize
+\let\endLaTeXitemize\enditemize
+\let\LaTeXenumerate\enumerate
+\let\endLaTeXenumerate\endenumerate
+
+% provide original LaTeX description environment from article.cls
+\newenvironment{LaTeXdescription}
+               {\list{}{\labelwidth\z@ \itemindent-\leftmargin
+                        \let\makelabel\descriptionlabel}}
+               {\endlist}
+\newcommand*\descriptionlabel[1]{\hspace\labelsep
+                                 \normalfont\bfseries #1}
+
+
+% override LaTeX's default IED lists
+\def\itemize{\@IEEEitemize}
+\def\enditemize{\@endIEEEitemize}
+\def\enumerate{\@IEEEenumerate}
+\def\endenumerate{\@endIEEEenumerate}
+\def\description{\@IEEEdescription}
+\def\enddescription{\@endIEEEdescription}
+
+% provide the user with aliases - may help those using packages that
+% override itemize, enumerate, or description
+\def\IEEEitemize{\@IEEEitemize}
+\def\endIEEEitemize{\@endIEEEitemize}
+\def\IEEEenumerate{\@IEEEenumerate}
+\def\endIEEEenumerate{\@endIEEEenumerate}
+\def\IEEEdescription{\@IEEEdescription}
+\def\endIEEEdescription{\@endIEEEdescription}
+
+
+% V1.6 we want to keep the IEEEtran IED list definitions as our own internal
+% commands so they are protected against redefinition
+\def\@IEEEitemize{\@ifnextchar[{\@@IEEEitemize}{\@@IEEEitemize[\relax]}}
+\def\@IEEEenumerate{\@ifnextchar[{\@@IEEEenumerate}{\@@IEEEenumerate[\relax]}}
+\def\@IEEEdescription{\@ifnextchar[{\@@IEEEdescription}{\@@IEEEdescription[\relax]}}
+\def\@endIEEEitemize{\endlist}
+\def\@endIEEEenumerate{\endlist}
+\def\@endIEEEdescription{\endlist}
+
+
+% DO NOT ALLOW BLANK LINES TO BE IN THESE IED ENVIRONMENTS
+% AS THIS WILL FORCE NEW PARAGRAPHS AFTER THE IED LISTS
+% IEEEtran itemized list MDS 1/2001
+% Note controlled spacing here, shield end of lines with %
+\def\@@IEEEitemize[#1]{%
+                \ifnum\@itemdepth>3\relax\@toodeep\else%
+                \ifnum\@listdepth>5\relax\@toodeep\else%
+                \advance\@itemdepth\@ne%
+                \edef\@itemitem{labelitem\romannumeral\the\@itemdepth}%
+                % get the labelindentfactor for this level
+                \advance\@listdepth\@ne% we need to know what the level WILL be
+                \edef\IEEElabelindentfactor{\csname IEEElabelindentfactor\romannumeral\the\@listdepth\endcsname}%
+                \advance\@listdepth-\@ne% undo our increment
+                \def\@IEEEiedjustify{2}% right justified labels are default
+                % set other defaults
+                \IEEEnocalcleftmarginfalse%
+                \IEEEnolabelindentfactorfalse%
+                \topsep\IEEEiedtopsep%
+                \IEEElabelindent\IEEEilabelindent%
+                \labelsep\IEEEiednormlabelsep%
+                \partopsep 0ex%
+                \parsep 0ex%
+                \itemsep \parskip%
+                \rightmargin 0em%
+                \listparindent 0em%
+                \itemindent 0em%
+                % calculate the label width
+                % the user can override this later if
+                % they specified a \labelwidth
+                \settowidth{\labelwidth}{\csname labelitem\romannumeral\the\@itemdepth\endcsname}%
+                \@IEEEsavelistparams% save our list parameters
+                \list{\csname\@itemitem\endcsname}{%
+                \@IEEErestorelistparams% override any list{} changes
+                                       % to our globals
+                \let\makelabel\@IEEEiedmakelabel% v1.6b setup \makelabel
+                \IEEEiedlistdecl% let user alter parameters
+                #1\relax%
+                % If the user has requested not to use the
+                % labelindent factor, don't revise \labelindent
+                \ifIEEEnolabelindentfactor\relax%
+                \else\IEEElabelindent=\IEEElabelindentfactor\labelindent%
+                \fi%
+                % Unless the user has requested otherwise,
+                % calculate our left margin based
+                % on \IEEElabelindent, \labelwidth and
+                % \labelsep
+                \ifIEEEnocalcleftmargin\relax%
+                \else\IEEEcalcleftmargin{\IEEElabelindent}%
+                \fi}\fi\fi}%
+
+
+% DO NOT ALLOW BLANK LINES TO BE IN THESE IED ENVIRONMENTS
+% AS THIS WILL FORCE NEW PARAGRAPHS AFTER THE IED LISTS
+% IEEEtran enumerate list MDS 1/2001
+% Note controlled spacing here, shield end of lines with %
+\def\@@IEEEenumerate[#1]{%
+                \ifnum\@enumdepth>3\relax\@toodeep\else%
+                \ifnum\@listdepth>5\relax\@toodeep\else%
+                \advance\@enumdepth\@ne%
+                \edef\@enumctr{enum\romannumeral\the\@enumdepth}%
+                % get the labelindentfactor for this level
+                \advance\@listdepth\@ne% we need to know what the level WILL be
+                \edef\IEEElabelindentfactor{\csname IEEElabelindentfactor\romannumeral\the\@listdepth\endcsname}%
+                \advance\@listdepth-\@ne% undo our increment
+                \def\@IEEEiedjustify{2}% right justified labels are default
+                % set other defaults
+                \IEEEnocalcleftmarginfalse%
+                \IEEEnolabelindentfactorfalse%
+                \topsep\IEEEiedtopsep%
+                \IEEElabelindent\IEEEelabelindent%
+                \labelsep\IEEEiednormlabelsep%
+                \partopsep 0ex%
+                \parsep 0ex%
+                \itemsep 0ex%
+                \rightmargin 0em%
+                \listparindent 0em%
+                \itemindent 0em%
+                % calculate the label width
+                % We'll set it to the width suitable for all labels using
+                % normalfont 1) to 9)
+                % The user can override this later
+                \settowidth{\labelwidth}{9)}%
+                \@IEEEsavelistparams% save our list parameters
+                \list{\csname label\@enumctr\endcsname}{\usecounter{\@enumctr}%
+                \@IEEErestorelistparams% override any list{} changes
+                                       % to our globals
+                \let\makelabel\@IEEEiedmakelabel% v1.6b setup \makelabel
+                \IEEEiedlistdecl% let user alter parameters 
+                #1\relax%
+                % If the user has requested not to use the
+                % IEEElabelindent factor, don't revise \IEEElabelindent
+                \ifIEEEnolabelindentfactor\relax%
+                \else\IEEElabelindent=\IEEElabelindentfactor\IEEElabelindent%
+                \fi%
+                % Unless the user has requested otherwise,
+                % calculate our left margin based
+                % on \IEEElabelindent, \labelwidth and
+                % \labelsep
+                \ifIEEEnocalcleftmargin\relax%
+                \else\IEEEcalcleftmargin{\IEEElabelindent}%
+                \fi}\fi\fi}%
+
+
+% DO NOT ALLOW BLANK LINES TO BE IN THESE IED ENVIRONMENTS
+% AS THIS WILL FORCE NEW PARAGRAPHS AFTER THE IED LISTS
+% IEEEtran description list MDS 1/2001
+% Note controlled spacing here, shield end of lines with %
+\def\@@IEEEdescription[#1]{%
+                \ifnum\@listdepth>5\relax\@toodeep\else%
+                % get the labelindentfactor for this level
+                \advance\@listdepth\@ne% we need to know what the level WILL be
+                \edef\IEEElabelindentfactor{\csname IEEElabelindentfactor\romannumeral\the\@listdepth\endcsname}%
+                \advance\@listdepth-\@ne% undo our increment
+                \def\@IEEEiedjustify{0}% left justified labels are default
+                % set other defaults
+                \IEEEnocalcleftmarginfalse%
+                \IEEEnolabelindentfactorfalse%
+                \topsep\IEEEiedtopsep% 
+                \IEEElabelindent\IEEEdlabelindent%
+                % assume normal labelsep
+                \labelsep\IEEEiednormlabelsep%
+                \partopsep 0ex%
+                \parsep 0ex%
+                \itemsep 0ex%
+                \rightmargin 0em%
+                \listparindent 0em%
+                \itemindent 0em%
+                % Bogus label width in case the user forgets
+                % to set it.
+                % TIP: If you want to see what a variable's width is you
+                % can use the TeX command \showthe\width-variable to 
+                % display it on the screen during compilation 
+                % (This might be helpful to know when you need to find out
+                % which label is the widest)
+                \settowidth{\labelwidth}{Hello}%
+                \@IEEEsavelistparams% save our list parameters
+                \list{}{\@IEEErestorelistparams% override any list{} changes
+                                               % to our globals
+                \let\makelabel\@IEEEiedmakelabel% v1.6b setup \makelabel
+                \IEEEiedlistdecl% let user alter parameters 
+                #1\relax%
+                % If the user has requested not to use the
+                % labelindent factor, don't revise \IEEElabelindent
+                \ifIEEEnolabelindentfactor\relax%
+                \else\IEEElabelindent=\IEEElabelindentfactor\IEEElabelindent%
+                \fi%
+                % Unless the user has requested otherwise,
+                % calculate our left margin based
+                % on \IEEElabelindent, \labelwidth and
+                % \labelsep
+                \ifIEEEnocalcleftmargin\relax%
+                \else\IEEEcalcleftmargin{\IEEElabelindent}\relax%
+                \fi}\fi}
+
+% v1.6b we use one makelabel that does justification as needed.
+\def\@IEEEiedmakelabel#1{\relax\if\@IEEEiedjustify 0\relax
+\makebox[\labelwidth][l]{\normalfont #1}\else
+\if\@IEEEiedjustify 1\relax
+\makebox[\labelwidth][c]{\normalfont #1}\else
+\makebox[\labelwidth][r]{\normalfont #1}\fi\fi}
+
+
+% VERSE and QUOTE
+% V1.7 define environments with newenvironment
+\newenvironment{verse}{\let\\=\@centercr
+    \list{}{\itemsep\z@ \itemindent -1.5em \listparindent \itemindent
+    \rightmargin\leftmargin\advance\leftmargin 1.5em}\item\relax}
+    {\endlist}
+\newenvironment{quotation}{\list{}{\listparindent 1.5em \itemindent\listparindent
+    \rightmargin\leftmargin \parsep 0pt plus 1pt}\item\relax}
+    {\endlist}
+\newenvironment{quote}{\list{}{\rightmargin\leftmargin}\item\relax}
+    {\endlist}
+
+
+% \titlepage
+% provided only for backward compatibility. \maketitle is the correct
+% way to create the title page. 
+\newif\if@restonecol
+\def\titlepage{\@restonecolfalse\if@twocolumn\@restonecoltrue\onecolumn
+    \else \newpage \fi \thispagestyle{empty}\c@page\z@}
+\def\endtitlepage{\if@restonecol\twocolumn \else \newpage \fi}
+
+% standard values from article.cls
+\arraycolsep     5pt
+\arrayrulewidth .4pt
+\doublerulesep   2pt
+
+\tabcolsep       6pt
+\tabbingsep      0.5em
+
+
+%% FOOTNOTES
+%
+%\skip\footins 10pt plus 4pt minus 2pt
+% V1.6 respond to changes in font size
+% space added above the footnotes (if present)
+\skip\footins 0.9\baselineskip  plus 0.4\baselineskip  minus 0.2\baselineskip
+
+% V1.6, we need to make \footnotesep responsive to changes
+% in \baselineskip or strange spacings will result when in
+% draft mode. Here is a little LaTeX secret - \footnotesep
+% determines the height of an invisible strut that is placed
+% *above* the baseline of footnotes after the first. Since
+% LaTeX considers the space for characters to be 0.7/baselineskip
+% above the baseline and 0.3/baselineskip below it, we need to
+% use 0.7/baselineskip as a \footnotesep to maintain equal spacing
+% between all the lines of the footnotes. IEEE often uses a tad
+% more, so use 0.8\baselineskip. This slightly larger value also helps
+% the text to clear the footnote marks. Note that \thanks in IEEEtran
+% uses its own value of \footnotesep which is set in \maketitle.
+{\footnotesize
+\global\footnotesep 0.8\baselineskip}
+
+\def\unnumberedfootnote{\gdef\@thefnmark{\quad}\@footnotetext}
+
+\skip\@mpfootins 0.3\baselineskip
+\fboxsep = 3pt
+\fboxrule = .4pt
+% V1.6 use 1em, then use LaTeX2e's \@makefnmark
+% Note that IEEE normally *left* aligns the footnote marks, so we don't need
+% box resizing tricks here.
+%\long\def\@makefnmark{\scriptsize\normalfont\@thefnmark}
+\long\def\@makefntext#1{\parindent 1em\indent\hbox{\@makefnmark}#1}% V1.6 use 1em
+\long\def\@maketablefntext#1{\raggedleft\leavevmode\hbox{\@makefnmark}#1}
+% V1.7 compsoc does not use superscipts for footnote marks
+\ifCLASSOPTIONcompsoc
+\def\@IEEEcompsocmakefnmark{\hbox{\normalfont\@thefnmark.\ }}
+\long\def\@makefntext#1{\parindent 1em\indent\hbox{\@IEEEcompsocmakefnmark}#1}
+\fi
+
+% IEEE does not use footnote rules. Or do they?
+\def\footnoterule{\vskip-2pt \hrule height 0.6pt depth \z@ \vskip1.6pt\relax}
+\toks@\expandafter{\@setminipage\let\footnoterule\relax\footnotesep\z@}
+\edef\@setminipage{\the\toks@}
+
+% V1.7 for compsoc, IEEE uses a footnote rule only for \thanks. We devise a "one-shot"
+% system to implement this.
+\newif\if@IEEEenableoneshotfootnoterule
+\@IEEEenableoneshotfootnoterulefalse
+\ifCLASSOPTIONcompsoc
+\def\footnoterule{\relax\if@IEEEenableoneshotfootnoterule
+\kern-5pt
+\hbox to \columnwidth{\hfill\vrule width 0.5\columnwidth height 0.4pt\hfill}
+\kern4.6pt
+\global\@IEEEenableoneshotfootnoterulefalse
+\else
+\relax
+\fi}
+\fi
+
+% V1.6 do not allow LaTeX to break a footnote across multiple pages
+\interfootnotelinepenalty=10000
+
+% V1.6 discourage breaks within equations
+% Note that amsmath normally sets this to 10000,
+% but LaTeX2e normally uses 100.
+\interdisplaylinepenalty=2500
+
+% default allows section depth up to /paragraph
+\setcounter{secnumdepth}{4}
+
+% technotes do not allow /paragraph
+\ifCLASSOPTIONtechnote
+   \setcounter{secnumdepth}{3}
+\fi
+% neither do compsoc conferences
+\@IEEEcompsocconfonly{\setcounter{secnumdepth}{3}}
+
+
+\newcounter{section}
+\newcounter{subsection}[section]
+\newcounter{subsubsection}[subsection]
+\newcounter{paragraph}[subsubsection]
+
+% used only by IEEEtran's IEEEeqnarray as other packages may
+% have their own, different, implementations
+\newcounter{IEEEsubequation}[equation]
+
+% as shown when called by user from \ref, \label and in table of contents
+\def\theequation{\arabic{equation}}                          % 1
+\def\theIEEEsubequation{\theequation\alph{IEEEsubequation}}  % 1a (used only by IEEEtran's IEEEeqnarray)
+\ifCLASSOPTIONcompsoc
+% compsoc is all arabic
+\def\thesection{\arabic{section}}                
+\def\thesubsection{\thesection.\arabic{subsection}}
+\def\thesubsubsection{\thesubsection.\arabic{subsubsection}}
+\def\theparagraph{\thesubsubsection.\arabic{paragraph}}
+\else
+\def\thesection{\Roman{section}}                             % I
+% V1.7, \mbox prevents breaks around - 
+\def\thesubsection{\mbox{\thesection-\Alph{subsection}}}     % I-A
+% V1.7 use I-A1 format used by IEEE rather than I-A.1
+\def\thesubsubsection{\thesubsection\arabic{subsubsection}}  % I-A1
+\def\theparagraph{\thesubsubsection\alph{paragraph}}         % I-A1a
+\fi
+
+% From Heiko Oberdiek. Because of the \mbox in \thesubsection, we need to
+% tell hyperref to disable the \mbox command when making PDF bookmarks.
+% This done already with hyperref.sty version 6.74o and later, but
+% it will not hurt to do it here again for users of older versions.
+\@ifundefined{pdfstringdefPreHook}{\let\pdfstringdefPreHook\@empty}{}%
+\g@addto@macro\pdfstringdefPreHook{\let\mbox\relax}
+
+
+% Main text forms (how shown in main text headings)
+% V1.6, using \thesection in \thesectiondis allows changes
+% in the former to automatically appear in the latter
+\ifCLASSOPTIONcompsoc
+  \ifCLASSOPTIONconference% compsoc conference
+    \def\thesectiondis{\thesection.}
+    \def\thesubsectiondis{\thesectiondis\arabic{subsection}.}
+    \def\thesubsubsectiondis{\thesubsectiondis\arabic{subsubsection}.}
+    \def\theparagraphdis{\thesubsubsectiondis\arabic{paragraph}.}
+  \else% compsoc not conferencs
+    \def\thesectiondis{\thesection}
+    \def\thesubsectiondis{\thesectiondis.\arabic{subsection}}
+    \def\thesubsubsectiondis{\thesubsectiondis.\arabic{subsubsection}}
+    \def\theparagraphdis{\thesubsubsectiondis.\arabic{paragraph}}
+  \fi
+\else% not compsoc
+  \def\thesectiondis{\thesection.}                   % I.
+  \def\thesubsectiondis{\Alph{subsection}.}          % B.
+  \def\thesubsubsectiondis{\arabic{subsubsection})}  % 3)
+  \def\theparagraphdis{\alph{paragraph})}            % d)
+\fi
+
+% just like LaTeX2e's \@eqnnum
+\def\theequationdis{{\normalfont \normalcolor (\theequation)}}% (1)
+% IEEEsubequation used only by IEEEtran's IEEEeqnarray
+\def\theIEEEsubequationdis{{\normalfont \normalcolor (\theIEEEsubequation)}}% (1a)
+% redirect LaTeX2e's equation number display and all that depend on
+% it, through IEEEtran's \theequationdis
+\def\@eqnnum{\theequationdis}
+
+
+
+% V1.7 provide string macros as article.cls does
+\def\contentsname{Contents}
+\def\listfigurename{List of Figures}
+\def\listtablename{List of Tables}
+\def\refname{References}
+\def\indexname{Index}
+\def\figurename{Fig.}
+\def\tablename{TABLE}
+\@IEEEcompsocconfonly{\def\figurename{Figure}\def\tablename{Table}}
+\def\partname{Part}
+\def\appendixname{Appendix}
+\def\abstractname{Abstract}
+% IEEE specific names
+\def\IEEEkeywordsname{Keywords}
+\def\IEEEproofname{Proof}
+
+
+% LIST OF FIGURES AND TABLES AND TABLE OF CONTENTS
+%
+\def\@pnumwidth{1.55em}
+\def\@tocrmarg{2.55em}
+\def\@dotsep{4.5}
+\setcounter{tocdepth}{3}
+
+% adjusted some spacings here so that section numbers will not easily 
+% collide with the section titles. 
+% VIII; VIII-A; and VIII-A.1 are usually the worst offenders.
+% MDS 1/2001
+\def\tableofcontents{\section*{\contentsname}\@starttoc{toc}}
+\def\l@section#1#2{\addpenalty{\@secpenalty}\addvspace{1.0em plus 1pt}%
+    \@tempdima 2.75em \begingroup \parindent \z@ \rightskip \@pnumwidth%
+    \parfillskip-\@pnumwidth {\bfseries\leavevmode #1}\hfil\hbox to\@pnumwidth{\hss #2}\par%
+    \endgroup}
+% argument format #1:level, #2:labelindent,#3:labelsep
+\def\l@subsection{\@dottedtocline{2}{2.75em}{3.75em}}
+\def\l@subsubsection{\@dottedtocline{3}{6.5em}{4.5em}}
+% must provide \l@ defs for ALL sublevels EVEN if tocdepth
+% is such as they will not appear in the table of contents
+% these defs are how TOC knows what level these things are!
+\def\l@paragraph{\@dottedtocline{4}{6.5em}{5.5em}}
+\def\l@subparagraph{\@dottedtocline{5}{6.5em}{6.5em}}
+\def\listoffigures{\section*{\listfigurename}\@starttoc{lof}}
+\def\l@figure{\@dottedtocline{1}{0em}{2.75em}}
+\def\listoftables{\section*{\listtablename}\@starttoc{lot}}
+\let\l@table\l@figure
+
+
+%% Definitions for floats
+%%
+%% Normal Floats
+\floatsep 1\baselineskip plus  0.2\baselineskip minus  0.2\baselineskip
+\textfloatsep 1.7\baselineskip plus  0.2\baselineskip minus  0.4\baselineskip
+\@fptop 0pt plus 1fil
+\@fpsep 0.75\baselineskip plus 2fil 
+\@fpbot 0pt plus 1fil
+\def\topfraction{0.9}
+\def\bottomfraction{0.4}
+\def\floatpagefraction{0.8}
+% V1.7, let top floats approach 90% of page
+\def\textfraction{0.1}
+
+%% Double Column Floats
+\dblfloatsep 1\baselineskip plus  0.2\baselineskip minus  0.2\baselineskip
+
+\dbltextfloatsep 1.7\baselineskip plus  0.2\baselineskip minus  0.4\baselineskip
+% Note that it would be nice if the rubber here actually worked in LaTeX2e.
+% There is a long standing limitation in LaTeX, first discovered (to the best
+% of my knowledge) by Alan Jeffrey in 1992. LaTeX ignores the stretchable
+% portion of \dbltextfloatsep, and as a result, double column figures can and
+% do result in an non-integer number of lines in the main text columns with
+% underfull vbox errors as a consequence. A post to comp.text.tex
+% by Donald Arseneau confirms that this had not yet been fixed in 1998.
+% IEEEtran V1.6 will fix this problem for you in the titles, but it doesn't
+% protect you from other double floats. Happy vspace'ing.
+
+\@dblfptop 0pt plus 1fil
+\@dblfpsep 0.75\baselineskip plus 2fil
+\@dblfpbot 0pt plus 1fil
+\def\dbltopfraction{0.8}
+\def\dblfloatpagefraction{0.8}
+\setcounter{dbltopnumber}{4}
+
+\intextsep 1\baselineskip plus 0.2\baselineskip minus  0.2\baselineskip
+\setcounter{topnumber}{2}
+\setcounter{bottomnumber}{2}
+\setcounter{totalnumber}{4}
+
+
+
+% article class provides these, we should too.
+\newlength\abovecaptionskip
+\newlength\belowcaptionskip
+% but only \abovecaptionskip is used above figure captions and *below* table
+% captions
+\setlength\abovecaptionskip{0.65\baselineskip}
+\setlength\belowcaptionskip{0.75\baselineskip}
+% V1.6 create hooks in case the caption spacing ever needs to be
+% overridden by a user
+\def\@IEEEfigurecaptionsepspace{\vskip\abovecaptionskip\relax}%
+\def\@IEEEtablecaptionsepspace{\vskip\belowcaptionskip\relax}%
+
+
+% 1.6b revise caption system so that \@makecaption uses two arguments
+% as with LaTeX2e. Otherwise, there will be problems when using hyperref.
+\def\@IEEEtablestring{table}
+
+\ifCLASSOPTIONcompsoc
+% V1.7 compsoc \@makecaption
+\ifCLASSOPTIONconference% compsoc conference
+\long\def\@makecaption#1#2{%
+% test if is a for a figure or table
+\ifx\@captype\@IEEEtablestring%
+% if a table, do table caption
+\normalsize\begin{center}{\normalfont\sffamily\normalsize {#1.}~ #2}\end{center}%
+\@IEEEtablecaptionsepspace
+% if not a table, format it as a figure
+\else
+\@IEEEfigurecaptionsepspace
+\setbox\@tempboxa\hbox{\normalfont\sffamily\normalsize {#1.}~ #2}%
+\ifdim \wd\@tempboxa >\hsize%
+% if caption is longer than a line, let it wrap around
+\setbox\@tempboxa\hbox{\normalfont\sffamily\normalsize {#1.}~ }%
+\parbox[t]{\hsize}{\normalfont\sffamily\normalsize \noindent\unhbox\@tempboxa#2}%
+% if caption is shorter than a line, center
+\else%
+\hbox to\hsize{\normalfont\sffamily\normalsize\hfil\box\@tempboxa\hfil}%
+\fi\fi}
+\else% nonconference compsoc
+\long\def\@makecaption#1#2{%
+% test if is a for a figure or table
+\ifx\@captype\@IEEEtablestring%
+% if a table, do table caption
+\normalsize\begin{center}{\normalfont\sffamily\normalsize #1}\\{\normalfont\sffamily\normalsize #2}\end{center}%
+\@IEEEtablecaptionsepspace
+% if not a table, format it as a figure
+\else
+\@IEEEfigurecaptionsepspace
+\setbox\@tempboxa\hbox{\normalfont\sffamily\normalsize {#1.}~ #2}%
+\ifdim \wd\@tempboxa >\hsize%
+% if caption is longer than a line, let it wrap around
+\setbox\@tempboxa\hbox{\normalfont\sffamily\normalsize {#1.}~ }%
+\parbox[t]{\hsize}{\normalfont\sffamily\normalsize \noindent\unhbox\@tempboxa#2}%
+% if caption is shorter than a line, left justify
+\else%
+\hbox to\hsize{\normalfont\sffamily\normalsize\box\@tempboxa\hfil}%
+\fi\fi}
+\fi
+
+\else% traditional noncompsoc \@makecaption
+\long\def\@makecaption#1#2{%
+% test if is a for a figure or table
+\ifx\@captype\@IEEEtablestring%
+% if a table, do table caption
+\footnotesize{\centering\normalfont\footnotesize#1.\qquad\scshape #2\par}%
+\@IEEEtablecaptionsepspace
+% if not a table, format it as a figure
+\else
+\@IEEEfigurecaptionsepspace
+% 3/2001 use footnotesize, not small; use two nonbreaking spaces, not one
+\setbox\@tempboxa\hbox{\normalfont\footnotesize {#1.}~~ #2}%
+\ifdim \wd\@tempboxa >\hsize%
+% if caption is longer than a line, let it wrap around
+\setbox\@tempboxa\hbox{\normalfont\footnotesize {#1.}~~ }%
+\parbox[t]{\hsize}{\normalfont\footnotesize\noindent\unhbox\@tempboxa#2}%
+% if caption is shorter than a line, center if conference, left justify otherwise
+\else%
+\ifCLASSOPTIONconference \hbox to\hsize{\normalfont\footnotesize\box\@tempboxa\hfil}%
+\else \hbox to\hsize{\normalfont\footnotesize\box\@tempboxa\hfil}%
+\fi\fi\fi}
+\fi
+
+
+
+% V1.7 disable captions class option, do so in a way that retains operation of \label
+% within \caption
+\ifCLASSOPTIONcaptionsoff
+\long\def\@makecaption#1#2{\vspace*{2em}\footnotesize\begin{center}{\footnotesize #1}\end{center}%
+\let\@IEEEtemporiglabeldefsave\label
+\let\@IEEEtemplabelargsave\relax
+\def\label##1{\gdef\@IEEEtemplabelargsave{##1}}%
+\setbox\@tempboxa\hbox{#2}%
+\let\label\@IEEEtemporiglabeldefsave
+\ifx\@IEEEtemplabelargsave\relax\else\label{\@IEEEtemplabelargsave}\fi}
+\fi
+
+
+% V1.7 define end environments with \def not \let so as to work OK with
+% preview-latex
+\newcounter{figure}
+\def\thefigure{\@arabic\c@figure}
+\def\fps@figure{tbp}
+\def\ftype@figure{1}
+\def\ext@figure{lof}
+\def\fnum@figure{\figurename~\thefigure}
+\def\figure{\@float{figure}}
+\def\endfigure{\end@float}
+\@namedef{figure*}{\@dblfloat{figure}}
+\@namedef{endfigure*}{\end@dblfloat}
+\newcounter{table}
+\ifCLASSOPTIONcompsoc
+\def\thetable{\arabic{table}}
+\else
+\def\thetable{\@Roman\c@table}
+\fi
+\def\fps@table{tbp}
+\def\ftype@table{2}
+\def\ext@table{lot}
+\def\fnum@table{\tablename~\thetable}
+% V1.6 IEEE uses 8pt text for tables
+% to default to footnotesize, we hack into LaTeX2e's \@floatboxreset and pray
+\def\table{\def\@floatboxreset{\reset@font\scriptsize\@setminipage}%
+  \let\@makefntext\@maketablefntext
+  \@float{table}}
+\def\endtable{\end@float}
+% v1.6b double column tables need to default to footnotesize as well.
+\@namedef{table*}{\def\@floatboxreset{\reset@font\scriptsize\@setminipage}\@dblfloat{table}}
+\@namedef{endtable*}{\end@dblfloat}
+
+
+
+
+%%
+%% START OF IEEEeqnarry DEFINITIONS
+%%
+%% Inspired by the concepts, examples, and previous works of LaTeX 
+%% coders and developers such as Donald Arseneau, Fred Bartlett, 
+%% David Carlisle, Tony Liu, Frank Mittelbach, Piet van Oostrum, 
+%% Roland Winkler and Mark Wooding.
+%% I don't make the claim that my work here is even near their calibre. ;)
+
+
+% hook to allow easy changeover to IEEEtran.cls/tools.sty error reporting
+\def\@IEEEclspkgerror{\ClassError{IEEEtran}}
+
+\newif\if@IEEEeqnarraystarform% flag to indicate if the environment was called as the star form
+\@IEEEeqnarraystarformfalse
+
+\newif\if@advanceIEEEeqncolcnt% tracks if the environment should advance the col counter
+% allows a way to make an \IEEEeqnarraybox that can be used within an \IEEEeqnarray
+% used by IEEEeqnarraymulticol so that it can work properly in both
+\@advanceIEEEeqncolcnttrue
+
+\newcount\@IEEEeqnnumcols % tracks how many IEEEeqnarray cols are defined
+\newcount\@IEEEeqncolcnt  % tracks how many IEEEeqnarray cols the user actually used
+
+
+% The default math style used by the columns
+\def\IEEEeqnarraymathstyle{\displaystyle}
+% The default text style used by the columns
+% default to using the current font
+\def\IEEEeqnarraytextstyle{\relax}
+
+% like the iedlistdecl but for \IEEEeqnarray
+\def\IEEEeqnarraydecl{\relax}
+\def\IEEEeqnarrayboxdecl{\relax}
+
+% \yesnumber is the opposite of \nonumber
+% a novel concept with the same def as the equationarray package
+% However, we give IEEE versions too since some LaTeX packages such as 
+% the MDWtools mathenv.sty redefine \nonumber to something else.
+\providecommand{\yesnumber}{\global\@eqnswtrue}
+\def\IEEEyesnumber{\global\@eqnswtrue}
+\def\IEEEnonumber{\global\@eqnswfalse}
+
+
+\def\IEEEyessubnumber{\global\@IEEEissubequationtrue\global\@eqnswtrue%
+\if@IEEEeqnarrayISinner% only do something inside an IEEEeqnarray
+\if@IEEElastlinewassubequation\addtocounter{equation}{-1}\else\setcounter{IEEEsubequation}{1}\fi%
+\def\@currentlabel{\p@IEEEsubequation\theIEEEsubequation}\fi}
+
+% flag to indicate that an equation is a sub equation
+\newif\if@IEEEissubequation%
+\@IEEEissubequationfalse
+
+% allows users to "push away" equations that get too close to the equation numbers
+\def\IEEEeqnarraynumspace{\hphantom{\if@IEEEissubequation\theIEEEsubequationdis\else\theequationdis\fi}}
+
+% provides a way to span multiple columns within IEEEeqnarray environments
+% will consider \if@advanceIEEEeqncolcnt before globally advancing the
+% column counter - so as to work within \IEEEeqnarraybox
+% usage: \IEEEeqnarraymulticol{number cols. to span}{col type}{cell text}
+\long\def\IEEEeqnarraymulticol#1#2#3{\multispan{#1}%
+% check if column is defined
+\relax\expandafter\ifx\csname @IEEEeqnarraycolDEF#2\endcsname\@IEEEeqnarraycolisdefined%
+\csname @IEEEeqnarraycolPRE#2\endcsname#3\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\csname @IEEEeqnarraycolPOST#2\endcsname%
+\else% if not, error and use default type
+\@IEEEclspkgerror{Invalid column type "#2" in \string\IEEEeqnarraymulticol.\MessageBreak
+Using a default centering column instead}%
+{You must define IEEEeqnarray column types before use.}%
+\csname @IEEEeqnarraycolPRE@IEEEdefault\endcsname#3\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\csname @IEEEeqnarraycolPOST@IEEEdefault\endcsname%
+\fi%
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by #1\relax\fi}
+
+% like \omit, but maintains track of the column counter for \IEEEeqnarray
+\def\IEEEeqnarrayomit{\omit\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by 1\relax\fi}
+
+
+% provides a way to define a letter referenced column type
+% usage: \IEEEeqnarraydefcol{col. type letter/name}{pre insertion text}{post insertion text}
+\def\IEEEeqnarraydefcol#1#2#3{\expandafter\def\csname @IEEEeqnarraycolPRE#1\endcsname{#2}%
+\expandafter\def\csname @IEEEeqnarraycolPOST#1\endcsname{#3}%
+\expandafter\def\csname @IEEEeqnarraycolDEF#1\endcsname{1}}
+
+
+% provides a way to define a numerically referenced inter-column glue types
+% usage: \IEEEeqnarraydefcolsep{col. glue number}{glue definition}
+\def\IEEEeqnarraydefcolsep#1#2{\expandafter\def\csname @IEEEeqnarraycolSEP\romannumeral #1\endcsname{#2}%
+\expandafter\def\csname @IEEEeqnarraycolSEPDEF\romannumeral #1\endcsname{1}}
+
+
+\def\@IEEEeqnarraycolisdefined{1}% just a macro for 1, used for checking undefined column types
+
+
+% expands and appends the given argument to the \@IEEEtrantmptoksA token list
+% used to build up the \halign preamble
+\def\@IEEEappendtoksA#1{\edef\@@IEEEappendtoksA{\@IEEEtrantmptoksA={\the\@IEEEtrantmptoksA #1}}%
+\@@IEEEappendtoksA}
+
+% also appends to \@IEEEtrantmptoksA, but does not expand the argument
+% uses \toks8 as a scratchpad register
+\def\@IEEEappendNOEXPANDtoksA#1{\toks8={#1}%
+\edef\@@IEEEappendNOEXPANDtoksA{\@IEEEtrantmptoksA={\the\@IEEEtrantmptoksA\the\toks8}}%
+\@@IEEEappendNOEXPANDtoksA}
+
+% define some common column types for the user
+% math
+\IEEEeqnarraydefcol{l}{$\IEEEeqnarraymathstyle}{$\hfil}
+\IEEEeqnarraydefcol{c}{\hfil$\IEEEeqnarraymathstyle}{$\hfil}
+\IEEEeqnarraydefcol{r}{\hfil$\IEEEeqnarraymathstyle}{$}
+\IEEEeqnarraydefcol{L}{$\IEEEeqnarraymathstyle{}}{{}$\hfil}
+\IEEEeqnarraydefcol{C}{\hfil$\IEEEeqnarraymathstyle{}}{{}$\hfil}
+\IEEEeqnarraydefcol{R}{\hfil$\IEEEeqnarraymathstyle{}}{{}$}
+% text
+\IEEEeqnarraydefcol{s}{\IEEEeqnarraytextstyle}{\hfil}
+\IEEEeqnarraydefcol{t}{\hfil\IEEEeqnarraytextstyle}{\hfil}
+\IEEEeqnarraydefcol{u}{\hfil\IEEEeqnarraytextstyle}{}
+
+% vertical rules
+\IEEEeqnarraydefcol{v}{}{\vrule width\arrayrulewidth}
+\IEEEeqnarraydefcol{vv}{\vrule width\arrayrulewidth\hfil}{\hfil\vrule width\arrayrulewidth}
+\IEEEeqnarraydefcol{V}{}{\vrule width\arrayrulewidth\hskip\doublerulesep\vrule width\arrayrulewidth}
+\IEEEeqnarraydefcol{VV}{\vrule width\arrayrulewidth\hskip\doublerulesep\vrule width\arrayrulewidth\hfil}%
+{\hfil\vrule width\arrayrulewidth\hskip\doublerulesep\vrule width\arrayrulewidth}
+
+% horizontal rules
+\IEEEeqnarraydefcol{h}{}{\leaders\hrule height\arrayrulewidth\hfil}
+\IEEEeqnarraydefcol{H}{}{\leaders\vbox{\hrule width\arrayrulewidth\vskip\doublerulesep\hrule width\arrayrulewidth}\hfil}
+
+% plain
+\IEEEeqnarraydefcol{x}{}{}
+\IEEEeqnarraydefcol{X}{$}{$}
+
+% the default column type to use in the event a column type is not defined
+\IEEEeqnarraydefcol{@IEEEdefault}{\hfil$\IEEEeqnarraymathstyle}{$\hfil}
+
+
+% a zero tabskip (used for "-" col types)
+\def\@IEEEeqnarraycolSEPzero{0pt plus 0pt minus 0pt}
+% a centering tabskip (used for "+" col types)
+\def\@IEEEeqnarraycolSEPcenter{1000pt plus 0pt minus 1000pt}
+
+% top level default tabskip glues for the start, end, and inter-column
+% may be reset within environments not always at the top level, e.g., \IEEEeqnarraybox
+\edef\@IEEEeqnarraycolSEPdefaultstart{\@IEEEeqnarraycolSEPcenter}% default start glue
+\edef\@IEEEeqnarraycolSEPdefaultend{\@IEEEeqnarraycolSEPcenter}% default end glue
+\edef\@IEEEeqnarraycolSEPdefaultmid{\@IEEEeqnarraycolSEPzero}% default inter-column glue
+
+
+
+% creates a vertical rule that extends from the bottom to the top a a cell
+% Provided in case other packages redefine \vline some other way.
+% usage: \IEEEeqnarrayvrule[rule thickness]
+% If no argument is provided, \arrayrulewidth will be used for the rule thickness. 
+\newcommand\IEEEeqnarrayvrule[1][\arrayrulewidth]{\vrule\@width#1\relax}
+
+% creates a blank separator row
+% usage: \IEEEeqnarrayseprow[separation length][font size commands]
+% default is \IEEEeqnarrayseprow[0.25\normalbaselineskip][\relax]
+% blank arguments inherit the default values
+% uses \skip5 as a scratch register - calls \@IEEEeqnarraystrutsize which uses more scratch registers
+\def\IEEEeqnarrayseprow{\relax\@ifnextchar[{\@IEEEeqnarrayseprow}{\@IEEEeqnarrayseprow[0.25\normalbaselineskip]}}
+\def\@IEEEeqnarrayseprow[#1]{\relax\@ifnextchar[{\@@IEEEeqnarrayseprow[#1]}{\@@IEEEeqnarrayseprow[#1][\relax]}}
+\def\@@IEEEeqnarrayseprow[#1][#2]{\def\@IEEEeqnarrayseprowARGONE{#1}%
+\ifx\@IEEEeqnarrayseprowARGONE\@empty%
+% get the skip value, based on the font commands
+% use skip5 because \IEEEeqnarraystrutsize uses \skip0, \skip2, \skip3
+% assign within a bogus box to confine the font changes
+{\setbox0=\hbox{#2\relax\global\skip5=0.25\normalbaselineskip}}%
+\else%
+{\setbox0=\hbox{#2\relax\global\skip5=#1}}%
+\fi%
+\@IEEEeqnarrayhoptolastcolumn\IEEEeqnarraystrutsize{\skip5}{0pt}[\relax]\relax}
+
+% creates a blank separator row, but omits all the column templates
+% usage: \IEEEeqnarrayseprowcut[separation length][font size commands]
+% default is \IEEEeqnarrayseprowcut[0.25\normalbaselineskip][\relax]
+% blank arguments inherit the default values
+% uses \skip5 as a scratch register - calls \@IEEEeqnarraystrutsize which uses more scratch registers
+\def\IEEEeqnarrayseprowcut{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarrayseprowcut}{\@IEEEeqnarrayseprowcut[0.25\normalbaselineskip]}}
+\def\@IEEEeqnarrayseprowcut[#1]{\relax\@ifnextchar[{\@@IEEEeqnarrayseprowcut[#1]}{\@@IEEEeqnarrayseprowcut[#1][\relax]}}
+\def\@@IEEEeqnarrayseprowcut[#1][#2]{\def\@IEEEeqnarrayseprowARGONE{#1}%
+\ifx\@IEEEeqnarrayseprowARGONE\@empty%
+% get the skip value, based on the font commands
+% use skip5 because \IEEEeqnarraystrutsize uses \skip0, \skip2, \skip3
+% assign within a bogus box to confine the font changes
+{\setbox0=\hbox{#2\relax\global\skip5=0.25\normalbaselineskip}}%
+\else%
+{\setbox0=\hbox{#2\relax\global\skip5=#1}}%
+\fi%
+\IEEEeqnarraystrutsize{\skip5}{0pt}[\relax]\relax}
+
+
+
+% draws a single rule across all the columns optional
+% argument determines the rule width, \arrayrulewidth is the default
+% updates column counter as needed and turns off struts
+% usage: \IEEEeqnarrayrulerow[rule line thickness]
+\def\IEEEeqnarrayrulerow{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarrayrulerow}{\@IEEEeqnarrayrulerow[\arrayrulewidth]}}
+\def\@IEEEeqnarrayrulerow[#1]{\leaders\hrule height#1\hfil\relax% put in our rule 
+% turn off any struts
+\IEEEeqnarraystrutsize{0pt}{0pt}[\relax]\relax}
+
+
+% draws a double rule by using a single rule row, a separator row, and then
+% another single rule row 
+% first optional argument determines the rule thicknesses, \arrayrulewidth is the default
+% second optional argument determines the rule spacing, \doublerulesep is the default
+% usage: \IEEEeqnarraydblrulerow[rule line thickness][rule spacing]
+\def\IEEEeqnarraydblrulerow{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarraydblrulerow}{\@IEEEeqnarraydblrulerow[\arrayrulewidth]}}
+\def\@IEEEeqnarraydblrulerow[#1]{\relax\@ifnextchar[{\@@IEEEeqnarraydblrulerow[#1]}%
+{\@@IEEEeqnarraydblrulerow[#1][\doublerulesep]}}
+\def\@@IEEEeqnarraydblrulerow[#1][#2]{\def\@IEEEeqnarraydblrulerowARG{#1}%
+% we allow the user to say \IEEEeqnarraydblrulerow[][]
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]\relax%
+\fi%
+\def\@IEEEeqnarraydblrulerowARG{#2}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\\\IEEEeqnarrayseprow[\doublerulesep][\relax]%
+\else%
+\\\IEEEeqnarrayseprow[#2][\relax]%
+\fi%
+\\\multispan{\@IEEEeqnnumcols}%
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\def\@IEEEeqnarraydblrulerowARG{#1}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]%
+\fi%
+}
+
+% draws a double rule by using a single rule row, a separator (cutting) row, and then
+% another single rule row 
+% first optional argument determines the rule thicknesses, \arrayrulewidth is the default
+% second optional argument determines the rule spacing, \doublerulesep is the default
+% usage: \IEEEeqnarraydblrulerow[rule line thickness][rule spacing]
+\def\IEEEeqnarraydblrulerowcut{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarraydblrulerowcut}{\@IEEEeqnarraydblrulerowcut[\arrayrulewidth]}}
+\def\@IEEEeqnarraydblrulerowcut[#1]{\relax\@ifnextchar[{\@@IEEEeqnarraydblrulerowcut[#1]}%
+{\@@IEEEeqnarraydblrulerowcut[#1][\doublerulesep]}}
+\def\@@IEEEeqnarraydblrulerowcut[#1][#2]{\def\@IEEEeqnarraydblrulerowARG{#1}%
+% we allow the user to say \IEEEeqnarraydblrulerow[][]
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]%
+\fi%
+\def\@IEEEeqnarraydblrulerowARG{#2}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\\\IEEEeqnarrayseprowcut[\doublerulesep][\relax]%
+\else%
+\\\IEEEeqnarrayseprowcut[#2][\relax]%
+\fi%
+\\\multispan{\@IEEEeqnnumcols}%
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\def\@IEEEeqnarraydblrulerowARG{#1}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]%
+\fi%
+}
+
+
+
+% inserts a full row's worth of &'s
+% relies on \@IEEEeqnnumcols to provide the correct number of columns
+% uses \@IEEEtrantmptoksA, \count0 as scratch registers
+\def\@IEEEeqnarrayhoptolastcolumn{\@IEEEtrantmptoksA={}\count0=1\relax%
+\loop% add cols if the user did not use them all
+\ifnum\count0<\@IEEEeqnnumcols\relax%
+\@IEEEappendtoksA{&}%
+\advance\count0 by 1\relax% update the col count
+\repeat%
+\the\@IEEEtrantmptoksA%execute the &'s
+}
+
+
+
+\newif\if@IEEEeqnarrayISinner % flag to indicate if we are within the lines
+\@IEEEeqnarrayISinnerfalse    % of an IEEEeqnarray - after the IEEEeqnarraydecl
+
+\edef\@IEEEeqnarrayTHEstrutheight{0pt} % height and depth of IEEEeqnarray struts
+\edef\@IEEEeqnarrayTHEstrutdepth{0pt}
+
+\edef\@IEEEeqnarrayTHEmasterstrutheight{0pt} % default height and depth of
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{0pt}  % struts within an IEEEeqnarray
+
+\edef\@IEEEeqnarrayTHEmasterstrutHSAVE{0pt} % saved master strut height
+\edef\@IEEEeqnarrayTHEmasterstrutDSAVE{0pt} % and depth
+
+\newif\if@IEEEeqnarrayusemasterstrut % flag to indicate that the master strut value
+\@IEEEeqnarrayusemasterstruttrue     % is to be used
+
+
+
+% saves the strut height and depth of the master strut
+\def\@IEEEeqnarraymasterstrutsave{\relax%
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+% remove stretchability
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% save values
+\edef\@IEEEeqnarrayTHEmasterstrutHSAVE{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutDSAVE{\the\dimen2}}
+
+% restores the strut height and depth of the master strut
+\def\@IEEEeqnarraymasterstrutrestore{\relax%
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutHSAVE\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutDSAVE\relax%
+% remove stretchability
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% restore values
+\edef\@IEEEeqnarrayTHEmasterstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{\the\dimen2}}
+
+
+% globally restores the strut height and depth to the 
+% master values and sets the master strut flag to true
+\def\@IEEEeqnarraystrutreset{\relax%
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+% remove stretchability
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% restore values
+\xdef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\xdef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\global\@IEEEeqnarrayusemasterstruttrue}
+
+
+% if the master strut is not to be used, make the current
+% values of \@IEEEeqnarrayTHEstrutheight, \@IEEEeqnarrayTHEstrutdepth
+% and the use master strut flag, global
+% this allows user strut commands issued in the last column to be carried
+% into the isolation/strut column
+\def\@IEEEeqnarrayglobalizestrutstatus{\relax%
+\if@IEEEeqnarrayusemasterstrut\else%
+\xdef\@IEEEeqnarrayTHEstrutheight{\@IEEEeqnarrayTHEstrutheight}%
+\xdef\@IEEEeqnarrayTHEstrutdepth{\@IEEEeqnarrayTHEstrutdepth}%
+\global\@IEEEeqnarrayusemasterstrutfalse%
+\fi}
+
+
+
+% usage: \IEEEeqnarraystrutsize{height}{depth}[font size commands]
+% If called outside the lines of an IEEEeqnarray, sets the height
+% and depth of both the master and local struts. If called inside
+% an IEEEeqnarray line, sets the height and depth of the local strut
+% only and sets the flag to indicate the use of the local strut
+% values. If the height or depth is left blank, 0.7\normalbaselineskip
+% and 0.3\normalbaselineskip will be used, respectively.
+% The optional argument can be used to evaluate the lengths under
+% a different font size and styles. If none is specified, the current
+% font is used.
+% uses scratch registers \skip0, \skip2, \skip3, \dimen0, \dimen2
+\def\IEEEeqnarraystrutsize#1#2{\relax\@ifnextchar[{\@IEEEeqnarraystrutsize{#1}{#2}}{\@IEEEeqnarraystrutsize{#1}{#2}[\relax]}}
+\def\@IEEEeqnarraystrutsize#1#2[#3]{\def\@IEEEeqnarraystrutsizeARG{#1}%
+\ifx\@IEEEeqnarraystrutsizeARG\@empty%
+{\setbox0=\hbox{#3\relax\global\skip3=0.7\normalbaselineskip}}%
+\skip0=\skip3\relax%
+\else% arg one present
+{\setbox0=\hbox{#3\relax\global\skip3=#1\relax}}%
+\skip0=\skip3\relax%
+\fi% if null arg
+\def\@IEEEeqnarraystrutsizeARG{#2}%
+\ifx\@IEEEeqnarraystrutsizeARG\@empty%
+{\setbox0=\hbox{#3\relax\global\skip3=0.3\normalbaselineskip}}%
+\skip2=\skip3\relax%
+\else% arg two present
+{\setbox0=\hbox{#3\relax\global\skip3=#2\relax}}%
+\skip2=\skip3\relax%
+\fi% if null arg
+% remove stretchability, just to be safe
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% dimen0 = height, dimen2 = depth
+\if@IEEEeqnarrayISinner% inner does not touch master strut size
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstrutfalse% do not use master
+\else% outer, have to set master strut too
+\edef\@IEEEeqnarrayTHEmasterstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{\the\dimen2}%
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstruttrue% use master strut
+\fi}
+
+
+% usage: \IEEEeqnarraystrutsizeadd{added height}{added depth}[font size commands]
+% If called outside the lines of an IEEEeqnarray, adds the given height
+% and depth to both the master and local struts.
+% If called inside an IEEEeqnarray line, adds the given height and depth
+% to the local strut only and sets the flag to indicate the use 
+% of the local strut values.
+% In both cases, if a height or depth is left blank, 0pt is used instead.
+% The optional argument can be used to evaluate the lengths under
+% a different font size and styles. If none is specified, the current
+% font is used.
+% uses scratch registers \skip0, \skip2, \skip3, \dimen0, \dimen2
+\def\IEEEeqnarraystrutsizeadd#1#2{\relax\@ifnextchar[{\@IEEEeqnarraystrutsizeadd{#1}{#2}}{\@IEEEeqnarraystrutsizeadd{#1}{#2}[\relax]}}
+\def\@IEEEeqnarraystrutsizeadd#1#2[#3]{\def\@IEEEeqnarraystrutsizearg{#1}%
+\ifx\@IEEEeqnarraystrutsizearg\@empty%
+\skip0=0pt\relax%
+\else% arg one present
+{\setbox0=\hbox{#3\relax\global\skip3=#1}}%
+\skip0=\skip3\relax%
+\fi% if null arg
+\def\@IEEEeqnarraystrutsizearg{#2}%
+\ifx\@IEEEeqnarraystrutsizearg\@empty%
+\skip2=0pt\relax%
+\else% arg two present
+{\setbox0=\hbox{#3\relax\global\skip3=#2}}%
+\skip2=\skip3\relax%
+\fi% if null arg
+% remove stretchability, just to be safe
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% dimen0 = height, dimen2 = depth
+\if@IEEEeqnarrayISinner% inner does not touch master strut size
+% get local strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEstrutdepth\relax%
+% add it to the user supplied values
+\advance\dimen0 by \skip0\relax%
+\advance\dimen2 by \skip2\relax%
+% update the local strut size
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstrutfalse% do not use master
+\else% outer, have to set master strut too
+% get master strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+% add it to the user supplied values
+\advance\dimen0 by \skip0\relax%
+\advance\dimen2 by \skip2\relax%
+% update the local and master strut sizes
+\edef\@IEEEeqnarrayTHEmasterstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{\the\dimen2}%
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstruttrue% use master strut
+\fi}
+
+
+% allow user a way to see the struts
+\newif\ifIEEEvisiblestruts
+\IEEEvisiblestrutsfalse
+
+% inserts an invisible strut using the master or local strut values
+% uses scratch registers \skip0, \skip2, \dimen0, \dimen2
+\def\@IEEEeqnarrayinsertstrut{\relax%
+\if@IEEEeqnarrayusemasterstrut
+% get master strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+\else%
+% get local strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEstrutdepth\relax%
+\fi%
+% remove stretchability, probably not needed
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% dimen0 = height, dimen2 = depth
+% allow user to see struts if desired
+\ifIEEEvisiblestruts%
+\vrule width0.2pt height\dimen0 depth\dimen2\relax%
+\else%
+\vrule width0pt height\dimen0 depth\dimen2\relax\fi}
+
+
+% creates an invisible strut, useable even outside \IEEEeqnarray
+% if \IEEEvisiblestrutstrue, the strut will be visible and 0.2pt wide. 
+% usage: \IEEEstrut[height][depth][font size commands]
+% default is \IEEEstrut[0.7\normalbaselineskip][0.3\normalbaselineskip][\relax]
+% blank arguments inherit the default values
+% uses \dimen0, \dimen2, \skip0, \skip2
+\def\IEEEstrut{\relax\@ifnextchar[{\@IEEEstrut}{\@IEEEstrut[0.7\normalbaselineskip]}}
+\def\@IEEEstrut[#1]{\relax\@ifnextchar[{\@@IEEEstrut[#1]}{\@@IEEEstrut[#1][0.3\normalbaselineskip]}}
+\def\@@IEEEstrut[#1][#2]{\relax\@ifnextchar[{\@@@IEEEstrut[#1][#2]}{\@@@IEEEstrut[#1][#2][\relax]}}
+\def\@@@IEEEstrut[#1][#2][#3]{\mbox{#3\relax%
+\def\@IEEEstrutARG{#1}%
+\ifx\@IEEEstrutARG\@empty%
+\skip0=0.7\normalbaselineskip\relax%
+\else%
+\skip0=#1\relax%
+\fi%
+\def\@IEEEstrutARG{#2}%
+\ifx\@IEEEstrutARG\@empty%
+\skip2=0.3\normalbaselineskip\relax%
+\else%
+\skip2=#2\relax%
+\fi%
+% remove stretchability, probably not needed
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+\ifIEEEvisiblestruts%
+\vrule width0.2pt height\dimen0 depth\dimen2\relax%
+\else%
+\vrule width0.0pt height\dimen0 depth\dimen2\relax\fi}}
+
+
+% enables strut mode by setting a default strut size and then zeroing the
+% \baselineskip, \lineskip, \lineskiplimit and \jot
+\def\IEEEeqnarraystrutmode{\IEEEeqnarraystrutsize{0.7\normalbaselineskip}{0.3\normalbaselineskip}[\relax]%
+\baselineskip=0pt\lineskip=0pt\lineskiplimit=0pt\jot=0pt}
+
+
+
+\def\IEEEeqnarray{\@IEEEeqnarraystarformfalse\@IEEEeqnarray}
+\def\endIEEEeqnarray{\end@IEEEeqnarray}
+
+\@namedef{IEEEeqnarray*}{\@IEEEeqnarraystarformtrue\@IEEEeqnarray}
+\@namedef{endIEEEeqnarray*}{\end@IEEEeqnarray}
+
+
+% \IEEEeqnarray is an enhanced \eqnarray. 
+% The star form defaults to not putting equation numbers at the end of each row.
+% usage: \IEEEeqnarray[decl]{cols}
+\def\@IEEEeqnarray{\relax\@ifnextchar[{\@@IEEEeqnarray}{\@@IEEEeqnarray[\relax]}}
+\def\@@IEEEeqnarray[#1]#2{%
+   % default to showing the equation number or not based on whether or not
+   % the star form was involked
+   \if@IEEEeqnarraystarform\global\@eqnswfalse
+   \else% not the star form
+   \global\@eqnswtrue
+   \fi% if star form
+   \@IEEEissubequationfalse% default to no subequations
+   \@IEEElastlinewassubequationfalse% assume last line is not a sub equation
+   \@IEEEeqnarrayISinnerfalse% not yet within the lines of the halign
+   \@IEEEeqnarraystrutsize{0pt}{0pt}[\relax]% turn off struts by default
+   \@IEEEeqnarrayusemasterstruttrue% use master strut till user asks otherwise
+   \IEEEvisiblestrutsfalse% diagnostic mode defaults to off
+   % no extra space unless the user specifically requests it
+   \lineskip=0pt\relax
+   \lineskiplimit=0pt\relax
+   \baselineskip=\normalbaselineskip\relax%
+   \jot=\IEEEnormaljot\relax%
+   \mathsurround\z@\relax% no extra spacing around math
+   \@advanceIEEEeqncolcnttrue% advance the col counter for each col the user uses, 
+                             % used in \IEEEeqnarraymulticol and in the preamble build
+   \stepcounter{equation}% advance equation counter before first line
+   \setcounter{IEEEsubequation}{0}% no subequation yet 
+   \def\@currentlabel{\p@equation\theequation}% redefine the ref label
+   \IEEEeqnarraydecl\relax% allow a way for the user to make global overrides
+   #1\relax% allow user to override defaults
+   \let\\\@IEEEeqnarraycr% replace newline with one that can put in eqn. numbers
+   \global\@IEEEeqncolcnt\z@% col. count = 0 for first line
+   \@IEEEbuildpreamble #2\end\relax% build the preamble and put it into \@IEEEtrantmptoksA 
+   % put in the column for the equation number
+   \ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi% col separator for those after the first
+   \toks0={##}%
+   % advance the \@IEEEeqncolcnt for the isolation col, this helps with error checking
+   \@IEEEappendtoksA{\global\advance\@IEEEeqncolcnt by 1\relax}%
+   % add the isolation column
+   \@IEEEappendtoksA{\tabskip\z@skip\bgroup\the\toks0\egroup}%
+   % advance the \@IEEEeqncolcnt for the equation number col, this helps with error checking
+   \@IEEEappendtoksA{&\global\advance\@IEEEeqncolcnt by 1\relax}%
+   % add the equation number col to the preamble
+   \@IEEEappendtoksA{\tabskip\z@skip\hb@xt@\z@\bgroup\hss\the\toks0\egroup}%
+   % note \@IEEEeqnnumcols does not count the equation col or isolation col
+   % set the starting tabskip glue as determined by the preamble build
+   \tabskip=\@IEEEBPstartglue\relax
+   % begin the display alignment
+   \@IEEEeqnarrayISinnertrue% commands are now within the lines
+   $$\everycr{}\halign to\displaywidth\bgroup
+   % "exspand" the preamble
+   \span\the\@IEEEtrantmptoksA\cr}
+
+% enter isolation/strut column (or the next column if the user did not use
+% every column), record the strut status, complete the columns, do the strut if needed,
+% restore counters to correct values and exit
+\def\end@IEEEeqnarray{\@IEEEeqnarrayglobalizestrutstatus&\@@IEEEeqnarraycr\egroup%
+\if@IEEElastlinewassubequation\global\advance\c@IEEEsubequation\m@ne\fi%
+\global\advance\c@equation\m@ne%
+$$\@ignoretrue}
+
+% need a way to remember if last line is a subequation
+\newif\if@IEEElastlinewassubequation%
+\@IEEElastlinewassubequationfalse
+
+% IEEEeqnarray uses a modifed \\ instead of the plain \cr to
+% end rows. This allows for things like \\*[vskip amount]
+% This "cr" macros are modified versions those for LaTeX2e's eqnarray
+% the {\ifnum0=`} braces must be kept away from the last column to avoid
+% altering spacing of its math, so we use & to advance to the next column
+% as there is an isolation/strut column after the user's columns
+\def\@IEEEeqnarraycr{\@IEEEeqnarrayglobalizestrutstatus&% save strut status and advance to next column
+   {\ifnum0=`}\fi
+   \@ifstar{%
+      \global\@eqpen\@M\@IEEEeqnarrayYCR
+   }{%
+      \global\@eqpen\interdisplaylinepenalty \@IEEEeqnarrayYCR
+   }%
+}
+
+\def\@IEEEeqnarrayYCR{\@testopt\@IEEEeqnarrayXCR\z@skip}
+
+\def\@IEEEeqnarrayXCR[#1]{%
+   \ifnum0=`{\fi}%
+   \@@IEEEeqnarraycr
+   \noalign{\penalty\@eqpen\vskip\jot\vskip #1\relax}}%
+
+\def\@@IEEEeqnarraycr{\@IEEEtrantmptoksA={}% clear token register
+    \advance\@IEEEeqncolcnt by -1\relax% adjust col count because of the isolation column
+    \ifnum\@IEEEeqncolcnt>\@IEEEeqnnumcols\relax
+    \@IEEEclspkgerror{Too many columns within the IEEEeqnarray\MessageBreak
+                          environment}%
+    {Use fewer \string &'s or put more columns in the IEEEeqnarry column\MessageBreak 
+     specifications.}\relax%
+    \else
+    \loop% add cols if the user did not use them all
+    \ifnum\@IEEEeqncolcnt<\@IEEEeqnnumcols\relax
+    \@IEEEappendtoksA{&}%
+    \advance\@IEEEeqncolcnt by 1\relax% update the col count
+    \repeat
+    % this number of &'s will take us the the isolation column
+    \fi
+    % execute the &'s
+    \the\@IEEEtrantmptoksA%
+    % handle the strut/isolation column
+    \@IEEEeqnarrayinsertstrut% do the strut if needed
+    \@IEEEeqnarraystrutreset% reset the strut system for next line or IEEEeqnarray
+    &% and enter the equation number column
+    % is this line needs an equation number, display it and advance the
+    % (sub)equation counters, record what type this line was
+    \if@eqnsw%
+     \if@IEEEissubequation\theIEEEsubequationdis\addtocounter{equation}{1}\stepcounter{IEEEsubequation}%
+     \global\@IEEElastlinewassubequationtrue%
+     \else% display a standard equation number, initialize the IEEEsubequation counter
+     \theequationdis\stepcounter{equation}\setcounter{IEEEsubequation}{0}%
+     \global\@IEEElastlinewassubequationfalse\fi%
+    \fi%
+    % reset the eqnsw flag to indicate default preference of the display of equation numbers
+    \if@IEEEeqnarraystarform\global\@eqnswfalse\else\global\@eqnswtrue\fi
+    \global\@IEEEissubequationfalse% reset the subequation flag
+    % reset the number of columns the user actually used
+    \global\@IEEEeqncolcnt\z@\relax
+    % the real end of the line
+    \cr}
+
+
+
+
+
+% \IEEEeqnarraybox is like \IEEEeqnarray except the box form puts everything
+% inside a vtop, vbox, or vcenter box depending on the letter in the second
+% optional argument (t,b,c). Vbox is the default. Unlike \IEEEeqnarray,
+% equation numbers are not displayed and \IEEEeqnarraybox can be nested.
+% \IEEEeqnarrayboxm is for math mode (like \array) and does not put the vbox
+% within an hbox.
+% \IEEEeqnarrayboxt is for text mode (like \tabular) and puts the vbox within
+% a \hbox{$ $} construct.
+% \IEEEeqnarraybox will auto detect whether to use \IEEEeqnarrayboxm or 
+% \IEEEeqnarrayboxt depending on the math mode.
+% The third optional argument specifies the width this box is to be set to -
+% natural width is the default.
+% The * forms do not add \jot line spacing
+% usage: \IEEEeqnarraybox[decl][pos][width]{cols}
+\def\IEEEeqnarrayboxm{\@IEEEeqnarraystarformfalse\@IEEEeqnarrayboxHBOXSWfalse\@IEEEeqnarraybox}
+\def\endIEEEeqnarrayboxm{\end@IEEEeqnarraybox}
+\@namedef{IEEEeqnarrayboxm*}{\@IEEEeqnarraystarformtrue\@IEEEeqnarrayboxHBOXSWfalse\@IEEEeqnarraybox}
+\@namedef{endIEEEeqnarrayboxm*}{\end@IEEEeqnarraybox}
+
+\def\IEEEeqnarrayboxt{\@IEEEeqnarraystarformfalse\@IEEEeqnarrayboxHBOXSWtrue\@IEEEeqnarraybox}
+\def\endIEEEeqnarrayboxt{\end@IEEEeqnarraybox}
+\@namedef{IEEEeqnarrayboxt*}{\@IEEEeqnarraystarformtrue\@IEEEeqnarrayboxHBOXSWtrue\@IEEEeqnarraybox}
+\@namedef{endIEEEeqnarrayboxt*}{\end@IEEEeqnarraybox}
+
+\def\IEEEeqnarraybox{\@IEEEeqnarraystarformfalse\ifmmode\@IEEEeqnarrayboxHBOXSWfalse\else\@IEEEeqnarrayboxHBOXSWtrue\fi%
+\@IEEEeqnarraybox}
+\def\endIEEEeqnarraybox{\end@IEEEeqnarraybox}
+
+\@namedef{IEEEeqnarraybox*}{\@IEEEeqnarraystarformtrue\ifmmode\@IEEEeqnarrayboxHBOXSWfalse\else\@IEEEeqnarrayboxHBOXSWtrue\fi%
+\@IEEEeqnarraybox}
+\@namedef{endIEEEeqnarraybox*}{\end@IEEEeqnarraybox}
+
+% flag to indicate if the \IEEEeqnarraybox needs to put things into an hbox{$ $} 
+% for \vcenter in non-math mode
+\newif\if@IEEEeqnarrayboxHBOXSW%
+\@IEEEeqnarrayboxHBOXSWfalse
+
+\def\@IEEEeqnarraybox{\relax\@ifnextchar[{\@@IEEEeqnarraybox}{\@@IEEEeqnarraybox[\relax]}}
+\def\@@IEEEeqnarraybox[#1]{\relax\@ifnextchar[{\@@@IEEEeqnarraybox[#1]}{\@@@IEEEeqnarraybox[#1][b]}}
+\def\@@@IEEEeqnarraybox[#1][#2]{\relax\@ifnextchar[{\@@@@IEEEeqnarraybox[#1][#2]}{\@@@@IEEEeqnarraybox[#1][#2][\relax]}}
+
+% #1 = decl; #2 = t,b,c; #3 = width, #4 = col specs
+\def\@@@@IEEEeqnarraybox[#1][#2][#3]#4{\@IEEEeqnarrayISinnerfalse % not yet within the lines of the halign
+   \@IEEEeqnarraymasterstrutsave% save current master strut values
+   \@IEEEeqnarraystrutsize{0pt}{0pt}[\relax]% turn off struts by default
+   \@IEEEeqnarrayusemasterstruttrue% use master strut till user asks otherwise
+   \IEEEvisiblestrutsfalse% diagnostic mode defaults to off
+   % no extra space unless the user specifically requests it
+   \lineskip=0pt\relax%
+   \lineskiplimit=0pt\relax%
+   \baselineskip=\normalbaselineskip\relax%
+   \jot=\IEEEnormaljot\relax%
+   \mathsurround\z@\relax% no extra spacing around math
+   % the default end glues are zero for an \IEEEeqnarraybox
+   \edef\@IEEEeqnarraycolSEPdefaultstart{\@IEEEeqnarraycolSEPzero}% default start glue
+   \edef\@IEEEeqnarraycolSEPdefaultend{\@IEEEeqnarraycolSEPzero}% default end glue
+   \edef\@IEEEeqnarraycolSEPdefaultmid{\@IEEEeqnarraycolSEPzero}% default inter-column glue
+   \@advanceIEEEeqncolcntfalse% do not advance the col counter for each col the user uses, 
+                              % used in \IEEEeqnarraymulticol and in the preamble build
+   \IEEEeqnarrayboxdecl\relax% allow a way for the user to make global overrides
+   #1\relax% allow user to override defaults
+   \let\\\@IEEEeqnarrayboxcr% replace newline with one that allows optional spacing
+   \@IEEEbuildpreamble #4\end\relax% build the preamble and put it into \@IEEEtrantmptoksA
+   % add an isolation column to the preamble to stop \\'s {} from getting into the last col
+   \ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi% col separator for those after the first
+   \toks0={##}%
+   % add the isolation column to the preamble
+   \@IEEEappendtoksA{\tabskip\z@skip\bgroup\the\toks0\egroup}% 
+   % set the starting tabskip glue as determined by the preamble build
+   \tabskip=\@IEEEBPstartglue\relax
+   % begin the alignment
+   \everycr{}%
+   % use only the very first token to determine the positioning
+   % this stops some problems when the user uses more than one letter,
+   % but is probably not worth the effort
+   % \noindent is used as a delimiter
+   \def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+   \@IEEEgrabfirstoken#2\relax\relax\noindent
+   % \@IEEEgrabbedfirstoken has the first token, the rest are discarded
+   % if we need to put things into and hbox and go into math mode, do so now
+   \if@IEEEeqnarrayboxHBOXSW \leavevmode \hbox \bgroup $\fi%
+   % use the appropriate vbox type
+   \if\@IEEEgrabbedfirstoken t\relax\vtop\else\if\@IEEEgrabbedfirstoken c\relax%
+   \vcenter\else\vbox\fi\fi\bgroup%
+   \@IEEEeqnarrayISinnertrue% commands are now within the lines
+   \ifx#3\relax\halign\else\halign to #3\relax\fi%
+   \bgroup
+   % "exspand" the preamble
+   \span\the\@IEEEtrantmptoksA\cr}
+
+% carry strut status and enter the isolation/strut column, 
+% exit from math mode if needed, and exit
+\def\end@IEEEeqnarraybox{\@IEEEeqnarrayglobalizestrutstatus% carry strut status
+&% enter isolation/strut column
+\@IEEEeqnarrayinsertstrut% do strut if needed
+\@IEEEeqnarraymasterstrutrestore% restore the previous master strut values
+% reset the strut system for next IEEEeqnarray
+% (sets local strut values back to previous master strut values)
+\@IEEEeqnarraystrutreset%
+% ensure last line, exit from halign, close vbox
+\crcr\egroup\egroup%
+% exit from math mode and close hbox if needed
+\if@IEEEeqnarrayboxHBOXSW $\egroup\fi}
+
+
+
+% IEEEeqnarraybox uses a modifed \\ instead of the plain \cr to
+% end rows. This allows for things like \\[vskip amount]
+% This "cr" macros are modified versions those for LaTeX2e's eqnarray
+% For IEEEeqnarraybox, \\* is the same as \\
+% the {\ifnum0=`} braces must be kept away from the last column to avoid
+% altering spacing of its math, so we use & to advance to the isolation/strut column
+% carry strut status into isolation/strut column
+\def\@IEEEeqnarrayboxcr{\@IEEEeqnarrayglobalizestrutstatus% carry strut status
+&% enter isolation/strut column
+\@IEEEeqnarrayinsertstrut% do strut if needed
+% reset the strut system for next line or IEEEeqnarray
+\@IEEEeqnarraystrutreset%
+{\ifnum0=`}\fi%
+\@ifstar{\@IEEEeqnarrayboxYCR}{\@IEEEeqnarrayboxYCR}}
+
+% test and setup the optional argument to \\[]
+\def\@IEEEeqnarrayboxYCR{\@testopt\@IEEEeqnarrayboxXCR\z@skip}
+
+% IEEEeqnarraybox does not automatically increase line spacing by \jot
+\def\@IEEEeqnarrayboxXCR[#1]{\ifnum0=`{\fi}%
+\cr\noalign{\if@IEEEeqnarraystarform\else\vskip\jot\fi\vskip#1\relax}}
+
+
+
+% starts the halign preamble build
+\def\@IEEEbuildpreamble{\@IEEEtrantmptoksA={}% clear token register
+\let\@IEEEBPcurtype=u%current column type is not yet known
+\let\@IEEEBPprevtype=s%the previous column type was the start
+\let\@IEEEBPnexttype=u%next column type is not yet known
+% ensure these are valid
+\def\@IEEEBPcurglue={0pt plus 0pt minus 0pt}%
+\def\@IEEEBPcurcolname{@IEEEdefault}% name of current column definition
+% currently acquired numerically referenced glue
+% use a name that is easier to remember
+\let\@IEEEBPcurnum=\@IEEEtrantmpcountA%
+\@IEEEBPcurnum=0%
+% tracks number of columns in the preamble
+\@IEEEeqnnumcols=0%
+% record the default end glues
+\edef\@IEEEBPstartglue{\@IEEEeqnarraycolSEPdefaultstart}%
+\edef\@IEEEBPendglue{\@IEEEeqnarraycolSEPdefaultend}%
+% now parse the user's column specifications
+\@@IEEEbuildpreamble}
+
+
+% parses and builds the halign preamble
+\def\@@IEEEbuildpreamble#1#2{\let\@@nextIEEEbuildpreamble=\@@IEEEbuildpreamble%
+% use only the very first token to check the end
+% \noindent is used as a delimiter as \end can be present here
+\def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+\@IEEEgrabfirstoken#1\relax\relax\noindent
+\ifx\@IEEEgrabbedfirstoken\end\let\@@nextIEEEbuildpreamble=\@@IEEEfinishpreamble\else%
+% identify current and next token type
+\@IEEEgetcoltype{#1}{\@IEEEBPcurtype}{1}% current, error on invalid
+\@IEEEgetcoltype{#2}{\@IEEEBPnexttype}{0}% next, no error on invalid next
+% if curtype is a glue, get the glue def
+\if\@IEEEBPcurtype g\@IEEEgetcurglue{#1}{\@IEEEBPcurglue}\fi%
+% if curtype is a column, get the column def and set the current column name
+\if\@IEEEBPcurtype c\@IEEEgetcurcol{#1}\fi%
+% if curtype is a numeral, acquire the user defined glue
+\if\@IEEEBPcurtype n\@IEEEprocessNcol{#1}\fi%
+% process the acquired glue 
+\if\@IEEEBPcurtype g\@IEEEprocessGcol\fi%
+% process the acquired col 
+\if\@IEEEBPcurtype c\@IEEEprocessCcol\fi%
+% ready prevtype for next col spec.
+\let\@IEEEBPprevtype=\@IEEEBPcurtype%
+% be sure and put back the future token(s) as a group
+\fi\@@nextIEEEbuildpreamble{#2}}
+
+
+% executed just after preamble build is completed
+% warn about zero cols, and if prevtype type = u, put in end tabskip glue
+\def\@@IEEEfinishpreamble#1{\ifnum\@IEEEeqnnumcols<1\relax
+\@IEEEclspkgerror{No column specifiers declared for IEEEeqnarray}%
+{At least one column type must be declared for each IEEEeqnarray.}%
+\fi%num cols less than 1
+%if last type undefined, set default end tabskip glue
+\if\@IEEEBPprevtype u\@IEEEappendtoksA{\tabskip=\@IEEEBPendglue}\fi}
+
+
+% Identify and return the column specifier's type code
+\def\@IEEEgetcoltype#1#2#3{%
+% use only the very first token to determine the type
+% \noindent is used as a delimiter as \end can be present here
+\def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+\@IEEEgrabfirstoken#1\relax\relax\noindent
+% \@IEEEgrabfirstoken has the first token, the rest are discarded
+% n = number
+% g = glue (any other char in catagory 12)
+% c = letter
+% e = \end
+% u = undefined
+% third argument: 0 = no error message, 1 = error on invalid char
+\let#2=u\relax% assume invalid until know otherwise
+\ifx\@IEEEgrabbedfirstoken\end\let#2=e\else
+\ifcat\@IEEEgrabbedfirstoken\relax\else% screen out control sequences
+\if0\@IEEEgrabbedfirstoken\let#2=n\else
+\if1\@IEEEgrabbedfirstoken\let#2=n\else
+\if2\@IEEEgrabbedfirstoken\let#2=n\else
+\if3\@IEEEgrabbedfirstoken\let#2=n\else
+\if4\@IEEEgrabbedfirstoken\let#2=n\else
+\if5\@IEEEgrabbedfirstoken\let#2=n\else
+\if6\@IEEEgrabbedfirstoken\let#2=n\else
+\if7\@IEEEgrabbedfirstoken\let#2=n\else
+\if8\@IEEEgrabbedfirstoken\let#2=n\else
+\if9\@IEEEgrabbedfirstoken\let#2=n\else
+\ifcat,\@IEEEgrabbedfirstoken\let#2=g\relax
+\else\ifcat a\@IEEEgrabbedfirstoken\let#2=c\relax\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi
+\if#2u\relax
+\if0\noexpand#3\relax\else\@IEEEclspkgerror{Invalid character in column specifications}%
+{Only letters, numerals and certain other symbols are allowed \MessageBreak
+as IEEEeqnarray column specifiers.}\fi\fi}
+
+
+% identify the current letter referenced column
+% if invalid, use a default column
+\def\@IEEEgetcurcol#1{\expandafter\ifx\csname @IEEEeqnarraycolDEF#1\endcsname\@IEEEeqnarraycolisdefined%
+\def\@IEEEBPcurcolname{#1}\else% invalid column name
+\@IEEEclspkgerror{Invalid column type "#1" in column specifications.\MessageBreak
+Using a default centering column instead}%
+{You must define IEEEeqnarray column types before use.}%
+\def\@IEEEBPcurcolname{@IEEEdefault}\fi}
+
+
+% identify and return the predefined (punctuation) glue value
+\def\@IEEEgetcurglue#1#2{%
+% ! = \! (neg small)  -0.16667em (-3/18 em)
+% , = \, (small)       0.16667em ( 3/18 em)
+% : = \: (med)         0.22222em ( 4/18 em)
+% ; = \; (large)       0.27778em ( 5/18 em)
+% ' = \quad            1em
+% " = \qquad           2em
+% . = 0.5\arraycolsep
+% / = \arraycolsep
+% ? = 2\arraycolsep
+% * = 1fil
+% + = \@IEEEeqnarraycolSEPcenter
+% - = \@IEEEeqnarraycolSEPzero
+% Note that all em values are referenced to the math font (textfont2) fontdimen6
+% value for 1em.
+% 
+% use only the very first token to determine the type
+% this prevents errant tokens from getting in the main text
+% \noindent is used as a delimiter here
+\def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+\@IEEEgrabfirstoken#1\relax\relax\noindent
+% get the math font 1em value
+% LaTeX2e's NFSS2 does not preload the fonts, but \IEEEeqnarray needs
+% to gain access to the math (\textfont2) font's spacing parameters.
+% So we create a bogus box here that uses the math font to ensure
+% that \textfont2 is loaded and ready. If this is not done,
+% the \textfont2 stuff here may not work.
+% Thanks to Bernd Raichle for his 1997 post on this topic.
+{\setbox0=\hbox{$\displaystyle\relax$}}%
+% fontdimen6 has the width of 1em (a quad).
+\@IEEEtrantmpdimenA=\fontdimen6\textfont2\relax%
+% identify the glue value based on the first token
+% we discard anything after the first
+\if!\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=-0.16667\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if,\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.16667\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if:\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.22222\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if;\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.27778\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if'\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=1\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if"\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=2\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if.\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.5\arraycolsep\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if/\@IEEEgrabbedfirstoken\edef#2{\the\arraycolsep}\else
+\if?\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=2\arraycolsep\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if *\@IEEEgrabbedfirstoken\edef#2{0pt plus 1fil minus 0pt}\else
+\if+\@IEEEgrabbedfirstoken\edef#2{\@IEEEeqnarraycolSEPcenter}\else
+\if-\@IEEEgrabbedfirstoken\edef#2{\@IEEEeqnarraycolSEPzero}\else
+\edef#2{\@IEEEeqnarraycolSEPzero}%
+\@IEEEclspkgerror{Invalid predefined inter-column glue type "#1" in\MessageBreak
+column specifications. Using a default value of\MessageBreak
+0pt instead}%
+{Only !,:;'"./?*+ and - are valid predefined glue types in the\MessageBreak 
+IEEEeqnarray column specifications.}\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi}
+
+
+
+% process a numerical digit from the column specification
+% and look up the corresponding user defined glue value
+% can transform current type from n to g or a as the user defined glue is acquired
+\def\@IEEEprocessNcol#1{\if\@IEEEBPprevtype g%
+\@IEEEclspkgerror{Back-to-back inter-column glue specifiers in column\MessageBreak
+specifications. Ignoring consecutive glue specifiers\MessageBreak
+after the first}%
+{You cannot have two or more glue types next to each other\MessageBreak 
+in the IEEEeqnarray column specifications.}%
+\let\@IEEEBPcurtype=a% abort this glue, future digits will be discarded
+\@IEEEBPcurnum=0\relax%
+\else% if we previously aborted a glue
+\if\@IEEEBPprevtype a\@IEEEBPcurnum=0\let\@IEEEBPcurtype=a%maintain digit abortion
+\else%acquire this number
+% save the previous type before the numerical digits started
+\if\@IEEEBPprevtype n\else\let\@IEEEBPprevsavedtype=\@IEEEBPprevtype\fi%
+\multiply\@IEEEBPcurnum by 10\relax%
+\advance\@IEEEBPcurnum by #1\relax% add in number, \relax is needed to stop TeX's number scan
+\if\@IEEEBPnexttype n\else%close acquisition
+\expandafter\ifx\csname @IEEEeqnarraycolSEPDEF\expandafter\romannumeral\number\@IEEEBPcurnum\endcsname\@IEEEeqnarraycolisdefined%
+\edef\@IEEEBPcurglue{\csname @IEEEeqnarraycolSEP\expandafter\romannumeral\number\@IEEEBPcurnum\endcsname}%
+\else%user glue not defined
+\@IEEEclspkgerror{Invalid user defined inter-column glue type "\number\@IEEEBPcurnum" in\MessageBreak
+column specifications. Using a default value of\MessageBreak
+0pt instead}%
+{You must define all IEEEeqnarray numerical inter-column glue types via\MessageBreak
+\string\IEEEeqnarraydefcolsep \space before they are used in column specifications.}%
+\edef\@IEEEBPcurglue{\@IEEEeqnarraycolSEPzero}%
+\fi% glue defined or not
+\let\@IEEEBPcurtype=g% change the type to reflect the acquired glue
+\let\@IEEEBPprevtype=\@IEEEBPprevsavedtype% restore the prev type before this number glue
+\@IEEEBPcurnum=0\relax%ready for next acquisition
+\fi%close acquisition, get glue
+\fi%discard or acquire number
+\fi%prevtype glue or not
+}
+
+
+% process an acquired glue
+% add any acquired column/glue pair to the preamble
+\def\@IEEEprocessGcol{\if\@IEEEBPprevtype a\let\@IEEEBPcurtype=a%maintain previous glue abortions
+\else
+% if this is the start glue, save it, but do nothing else 
+% as this is not used in the preamble, but before
+\if\@IEEEBPprevtype s\edef\@IEEEBPstartglue{\@IEEEBPcurglue}%
+\else%not the start glue
+\if\@IEEEBPprevtype g%ignore if back to back glues
+\@IEEEclspkgerror{Back-to-back inter-column glue specifiers in column\MessageBreak
+specifications. Ignoring consecutive glue specifiers\MessageBreak
+after the first}%
+{You cannot have two or more glue types next to each other\MessageBreak 
+in the IEEEeqnarray column specifications.}%
+\let\@IEEEBPcurtype=a% abort this glue
+\else% not a back to back glue
+\if\@IEEEBPprevtype c\relax% if the previoustype was a col, add column/glue pair to preamble
+\ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi
+\toks0={##}%
+% make preamble advance col counter if this environment needs this
+\if@advanceIEEEeqncolcnt\@IEEEappendtoksA{\global\advance\@IEEEeqncolcnt by 1\relax}\fi
+% insert the column defintion into the preamble, being careful not to expand
+% the column definition
+\@IEEEappendtoksA{\tabskip=\@IEEEBPcurglue}%
+\@IEEEappendNOEXPANDtoksA{\begingroup\csname @IEEEeqnarraycolPRE}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname}%
+\@IEEEappendtoksA{\the\toks0}%
+\@IEEEappendNOEXPANDtoksA{\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\csname @IEEEeqnarraycolPOST}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\endgroup}%
+\advance\@IEEEeqnnumcols by 1\relax%one more column in the preamble
+\else% error: non-start glue with no pending column
+\@IEEEclspkgerror{Inter-column glue specifier without a prior column\MessageBreak
+type in the column specifications. Ignoring this glue\MessageBreak 
+specifier}%
+{Except for the first and last positions, glue can be placed only\MessageBreak
+between column types.}%
+\let\@IEEEBPcurtype=a% abort this glue
+\fi% previous was a column
+\fi% back-to-back glues
+\fi% is start column glue
+\fi% prev type not a
+}
+
+
+% process an acquired letter referenced column and, if necessary, add it to the preamble
+\def\@IEEEprocessCcol{\if\@IEEEBPnexttype g\else
+\if\@IEEEBPnexttype n\else
+% we have a column followed by something other than a glue (or numeral glue)
+% so we must add this column to the preamble now
+\ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi%col separator for those after the first
+\if\@IEEEBPnexttype e\@IEEEappendtoksA{\tabskip=\@IEEEBPendglue\relax}\else%put in end glue
+\@IEEEappendtoksA{\tabskip=\@IEEEeqnarraycolSEPdefaultmid\relax}\fi% or default mid glue
+\toks0={##}%
+% make preamble advance col counter if this environment needs this
+\if@advanceIEEEeqncolcnt\@IEEEappendtoksA{\global\advance\@IEEEeqncolcnt by 1\relax}\fi
+% insert the column definition into the preamble, being careful not to expand
+% the column definition
+\@IEEEappendNOEXPANDtoksA{\begingroup\csname @IEEEeqnarraycolPRE}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname}%
+\@IEEEappendtoksA{\the\toks0}%
+\@IEEEappendNOEXPANDtoksA{\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\csname @IEEEeqnarraycolPOST}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\endgroup}%
+\advance\@IEEEeqnnumcols by 1\relax%one more column in the preamble
+\fi%next type not numeral
+\fi%next type not glue
+}
+
+
+%%
+%% END OF IEEEeqnarry DEFINITIONS
+%%
+
+
+
+
+% set up the running headings, this complex because of all the different
+% modes IEEEtran supports
+\if@twoside
+ \ifCLASSOPTIONtechnote
+   \def\ps@headings{%
+       \def\@oddhead{\hbox{}\scriptsize\leftmark \hfil \thepage}
+       \def\@evenhead{\scriptsize\thepage \hfil \leftmark\hbox{}}
+       \ifCLASSOPTIONdraftcls
+            \ifCLASSOPTIONdraftclsnofoot
+               \def\@oddfoot{}\def\@evenfoot{}%
+            \else
+               \def\@oddfoot{\scriptsize\@date\hfil DRAFT}
+               \def\@evenfoot{\scriptsize DRAFT\hfil\@date}
+            \fi
+       \else
+            \def\@oddfoot{}\def\@evenfoot{}
+       \fi}
+ \else % not a technote
+   \def\ps@headings{%
+       \ifCLASSOPTIONconference
+        \def\@oddhead{}
+        \def\@evenhead{}
+       \else
+        \def\@oddhead{\hbox{}\scriptsize\rightmark \hfil \thepage}
+        \def\@evenhead{\scriptsize\thepage \hfil \leftmark\hbox{}}
+       \fi
+       \ifCLASSOPTIONdraftcls
+            \def\@oddhead{\hbox{}\scriptsize\rightmark \hfil \thepage}
+            \def\@evenhead{\scriptsize\thepage \hfil \leftmark\hbox{}}
+            \ifCLASSOPTIONdraftclsnofoot
+               \def\@oddfoot{}\def\@evenfoot{}%
+            \else
+               \def\@oddfoot{\scriptsize\@date\hfil DRAFT}
+               \def\@evenfoot{\scriptsize DRAFT\hfil\@date}
+            \fi
+       \else
+            \def\@oddfoot{}\def\@evenfoot{}%
+       \fi}
+ \fi
+\else % single side
+\def\ps@headings{%
+    \ifCLASSOPTIONconference
+     \def\@oddhead{}
+     \def\@evenhead{}
+    \else
+     \def\@oddhead{\hbox{}\scriptsize\leftmark \hfil \thepage}
+     \def\@evenhead{}
+    \fi
+    \ifCLASSOPTIONdraftcls
+          \def\@oddhead{\hbox{}\scriptsize\leftmark \hfil \thepage}
+          \def\@evenhead{}
+          \ifCLASSOPTIONdraftclsnofoot
+             \def\@oddfoot{}
+          \else
+             \def\@oddfoot{\scriptsize \@date \hfil DRAFT}
+          \fi
+    \else
+         \def\@oddfoot{}
+    \fi
+    \def\@evenfoot{}}
+\fi
+
+
+% title page style
+\def\ps@IEEEtitlepagestyle{\def\@oddfoot{}\def\@evenfoot{}%
+\ifCLASSOPTIONconference
+   \def\@oddhead{}%
+   \def\@evenhead{}%
+\else
+   \def\@oddhead{\hbox{}\scriptsize\leftmark \hfil \thepage}%
+   \def\@evenhead{\scriptsize\thepage \hfil \leftmark\hbox{}}%
+\fi
+\ifCLASSOPTIONdraftcls
+   \def\@oddhead{\hbox{}\scriptsize\leftmark \hfil \thepage}%
+   \def\@evenhead{\scriptsize\thepage \hfil \leftmark\hbox{}}%
+   \ifCLASSOPTIONdraftclsnofoot\else
+      \def\@oddfoot{\scriptsize \@date\hfil DRAFT}%
+      \def\@evenfoot{\scriptsize DRAFT\hfil \@date}%
+   \fi
+\else
+   % all non-draft mode footers
+   \if@IEEEusingpubid
+      % for title pages that are using a pubid
+      % do not repeat pubid if using peer review option
+      \ifCLASSOPTIONpeerreview
+      \else
+         \footskip 0pt%
+         \ifCLASSOPTIONcompsoc
+           \def\@oddfoot{\hss\normalfont\scriptsize\raisebox{-1.5\@IEEEnormalsizeunitybaselineskip}[0ex][0ex]{\@IEEEpubid}\hss}%
+           \def\@evenfoot{\hss\normalfont\scriptsize\raisebox{-1.5\@IEEEnormalsizeunitybaselineskip}[0ex][0ex]{\@IEEEpubid}\hss}%
+         \else
+           \def\@oddfoot{\hss\normalfont\footnotesize\raisebox{1.5ex}[1.5ex]{\@IEEEpubid}\hss}%
+           \def\@evenfoot{\hss\normalfont\footnotesize\raisebox{1.5ex}[1.5ex]{\@IEEEpubid}\hss}%
+         \fi
+      \fi
+   \fi
+\fi}
+
+
+% peer review cover page style
+\def\ps@IEEEpeerreviewcoverpagestyle{%
+\def\@oddhead{}\def\@evenhead{}%
+\def\@oddfoot{}\def\@evenfoot{}%
+\ifCLASSOPTIONdraftcls
+   \ifCLASSOPTIONdraftclsnofoot\else
+      \def\@oddfoot{\scriptsize \@date\hfil DRAFT}%
+      \def\@evenfoot{\scriptsize DRAFT\hfil \@date}%
+   \fi
+\else
+   % non-draft mode footers
+   \if@IEEEusingpubid
+      \footskip 0pt%
+      \ifCLASSOPTIONcompsoc
+        \def\@oddfoot{\hss\normalfont\scriptsize\raisebox{-1.5\@IEEEnormalsizeunitybaselineskip}[0ex][0ex]{\@IEEEpubid}\hss}%
+        \def\@evenfoot{\hss\normalfont\scriptsize\raisebox{-1.5\@IEEEnormalsizeunitybaselineskip}[0ex][0ex]{\@IEEEpubid}\hss}%
+      \else
+        \def\@oddfoot{\hss\normalfont\footnotesize\raisebox{1.5ex}[1.5ex]{\@IEEEpubid}\hss}%
+        \def\@evenfoot{\hss\normalfont\footnotesize\raisebox{1.5ex}[1.5ex]{\@IEEEpubid}\hss}%
+      \fi
+   \fi
+\fi}
+
+
+% start with empty headings
+\def\rightmark{}\def\leftmark{}
+
+
+%% Defines the command for putting the header. \footernote{TEXT} is the same
+%% as \markboth{TEXT}{TEXT}. 
+%% Note that all the text is forced into uppercase, if you have some text
+%% that needs to be in lower case, for instance et. al., then either manually
+%% set \leftmark and \rightmark or use \MakeLowercase{et. al.} within the
+%% arguments to \markboth.
+\def\markboth#1#2{\def\leftmark{\@IEEEcompsoconly{\sffamily}\MakeUppercase{#1}}%
+\def\rightmark{\@IEEEcompsoconly{\sffamily}\MakeUppercase{#2}}}
+\def\footernote#1{\markboth{#1}{#1}}
+
+\def\today{\ifcase\month\or
+    January\or February\or March\or April\or May\or June\or
+    July\or August\or September\or October\or November\or December\fi
+    \space\number\day, \number\year}
+
+
+
+
+%% CITATION AND BIBLIOGRAPHY COMMANDS
+%% 
+%% V1.6 no longer supports the older, nonstandard \shortcite and \citename setup stuff
+% 
+% 
+% Modify Latex2e \@citex to separate citations with "], ["
+\def\@citex[#1]#2{%
+  \let\@citea\@empty
+  \@cite{\@for\@citeb:=#2\do
+    {\@citea\def\@citea{], [}%
+     \edef\@citeb{\expandafter\@firstofone\@citeb\@empty}%
+     \if@filesw\immediate\write\@auxout{\string\citation{\@citeb}}\fi
+     \@ifundefined{b@\@citeb}{\mbox{\reset@font\bfseries ?}%
+       \G@refundefinedtrue
+       \@latex@warning
+         {Citation `\@citeb' on page \thepage \space undefined}}%
+       {\hbox{\csname b@\@citeb\endcsname}}}}{#1}}
+
+% V1.6 we create hooks for the optional use of Donald Arseneau's
+% cite.sty package. cite.sty is "smart" and will notice that the
+% following format controls are already defined and will not
+% redefine them. The result will be the proper sorting of the
+% citation numbers and auto detection of 3 or more entry "ranges" -
+% all in IEEE style:  [1], [2], [5]--[7], [12]
+% This also allows for an optional note, i.e., \cite[mynote]{..}.
+% If the \cite with note has more than one reference, the note will
+% be applied to the last of the listed references. It is generally
+% desired that if a note is given, only one reference is listed in
+% that \cite.
+% Thanks to Mr. Arseneau for providing the required format arguments
+% to produce the IEEE style.
+\def\citepunct{], [}
+\def\citedash{]--[}
+
+% V1.7 default to using same font for urls made by url.sty
+\AtBeginDocument{\csname url@samestyle\endcsname}
+
+% V1.6 class files should always provide these
+\def\newblock{\hskip .11em\@plus.33em\@minus.07em}
+\let\@openbib@code\@empty
+
+
+% Provide support for the control entries of IEEEtran.bst V1.00 and later.
+% V1.7 optional argument allows for a different aux file to be specified in
+% order to handle multiple bibliographies. For example, with multibib.sty:
+% \newcites{sec}{Secondary Literature}
+% \bstctlcite[@auxoutsec]{BSTcontrolhak}
+\def\bstctlcite{\@ifnextchar[{\@bstctlcite}{\@bstctlcite[@auxout]}}
+\def\@bstctlcite[#1]#2{\@bsphack
+  \@for\@citeb:=#2\do{%
+    \edef\@citeb{\expandafter\@firstofone\@citeb}%
+    \if@filesw\immediate\write\csname #1\endcsname{\string\citation{\@citeb}}\fi}%
+  \@esphack}
+
+% V1.6 provide a way for a user to execute a command just before 
+% a given reference number - used to insert a \newpage to balance
+% the columns on the last page
+\edef\@IEEEtriggerrefnum{0}   % the default of zero means that
+                              % the command is not executed
+\def\@IEEEtriggercmd{\newpage}
+
+% allow the user to alter the triggered command
+\long\def\IEEEtriggercmd#1{\long\def\@IEEEtriggercmd{#1}}
+
+% allow user a way to specify the reference number just before the
+% command is executed
+\def\IEEEtriggeratref#1{\@IEEEtrantmpcountA=#1%
+\edef\@IEEEtriggerrefnum{\the\@IEEEtrantmpcountA}}%
+
+% trigger command at the given reference
+\def\@IEEEbibitemprefix{\@IEEEtrantmpcountA=\@IEEEtriggerrefnum\relax%
+\advance\@IEEEtrantmpcountA by -1\relax%
+\ifnum\c@enumiv=\@IEEEtrantmpcountA\relax\@IEEEtriggercmd\relax\fi}
+
+
+\def\@biblabel#1{[#1]}
+
+% compsoc journals left align the reference numbers
+\@IEEEcompsocnotconfonly{\def\@biblabel#1{[#1]\hfill}}
+
+% controls bib item spacing
+\def\IEEEbibitemsep{2.5pt plus .5pt}
+
+\@IEEEcompsocconfonly{\def\IEEEbibitemsep{1\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip}}
+
+
+\def\thebibliography#1{\section*{\refname}%
+    \addcontentsline{toc}{section}{\refname}%
+    % V1.6 add some rubber space here and provide a command trigger
+    \footnotesize\@IEEEcompsocconfonly{\small}\vskip 0.3\baselineskip plus 0.1\baselineskip minus 0.1\baselineskip%
+    \list{\@biblabel{\@arabic\c@enumiv}}%
+    {\settowidth\labelwidth{\@biblabel{#1}}%
+    \leftmargin\labelwidth
+    \labelsep 1em
+    \advance\leftmargin\labelsep\relax
+    \itemsep \IEEEbibitemsep\relax
+    \usecounter{enumiv}%
+    \let\p@enumiv\@empty
+    \renewcommand\theenumiv{\@arabic\c@enumiv}}%
+    \let\@IEEElatexbibitem\bibitem%
+    \def\bibitem{\@IEEEbibitemprefix\@IEEElatexbibitem}%
+\def\newblock{\hskip .11em plus .33em minus .07em}%
+% originally:
+%   \sloppy\clubpenalty4000\widowpenalty4000%
+% by adding the \interlinepenalty here, we make it more
+% difficult, but not impossible, for LaTeX to break within a reference.
+% IEEE almost never breaks a reference (but they do it more often with
+% technotes). You may get an underfull vbox warning around the bibliography, 
+% but the final result will be much more like what IEEE will publish. 
+% MDS 11/2000
+\ifCLASSOPTIONtechnote\sloppy\clubpenalty4000\widowpenalty4000\interlinepenalty100%
+\else\sloppy\clubpenalty4000\widowpenalty4000\interlinepenalty500\fi%
+    \sfcode`\.=1000\relax}
+\let\endthebibliography=\endlist
+
+
+
+
+% TITLE PAGE COMMANDS
+% 
+% 
+% \IEEEmembership is used to produce the sublargesize italic font used to indicate author 
+% IEEE membership. compsoc uses a large size sans slant font
+\def\IEEEmembership#1{{\@IEEEnotcompsoconly{\sublargesize}\normalfont\@IEEEcompsoconly{\sffamily}\textit{#1}}}
+ 
+
+% \IEEEauthorrefmark{} produces a footnote type symbol to indicate author affiliation.
+% When given an argument of 1 to 9, \IEEEauthorrefmark{} follows the standard LaTeX footnote
+% symbol sequence convention. However, for arguments 10 and above, \IEEEauthorrefmark{} 
+% reverts to using lower case roman numerals, so it cannot overflow. Do note that you 
+% cannot use \footnotemark[] in place of \IEEEauthorrefmark{} within \author as the footnote
+% symbols will have been turned off to prevent \thanks from creating footnote marks.
+% \IEEEauthorrefmark{} produces a symbol that appears to LaTeX as having zero vertical
+% height - this allows for a more compact line packing, but the user must ensure that
+% the interline spacing is large enough to prevent \IEEEauthorrefmark{} from colliding
+% with the text above.
+% V1.7 make this a robust command
+\DeclareRobustCommand*{\IEEEauthorrefmark}[1]{\raisebox{0pt}[0pt][0pt]{\textsuperscript{\footnotesize\ensuremath{\ifcase#1\or *\or \dagger\or \ddagger\or%
+    \mathsection\or \mathparagraph\or \|\or **\or \dagger\dagger%
+    \or \ddagger\ddagger \else\textsuperscript{\expandafter\romannumeral#1}\fi}}}}
+
+
+% FONT CONTROLS AND SPACINGS FOR CONFERENCE MODE AUTHOR NAME AND AFFILIATION BLOCKS
+% 
+% The default font styles for the author name and affiliation blocks (confmode)
+\def\@IEEEauthorblockNstyle{\normalfont\@IEEEcompsocnotconfonly{\sffamily}\sublargesize\@IEEEcompsocconfonly{\large}}
+\def\@IEEEauthorblockAstyle{\normalfont\@IEEEcompsocnotconfonly{\sffamily}\@IEEEcompsocconfonly{\itshape}\normalsize\@IEEEcompsocconfonly{\large}}
+% The default if the user does not use an author block
+\def\@IEEEauthordefaulttextstyle{\normalfont\@IEEEcompsocnotconfonly{\sffamily}\sublargesize}
+
+% spacing from title (or special paper notice) to author name blocks (confmode)
+% can be negative
+\def\@IEEEauthorblockconfadjspace{-0.25em}
+% compsoc conferences need more space here
+\@IEEEcompsocconfonly{\def\@IEEEauthorblockconfadjspace{0.75\@IEEEnormalsizeunitybaselineskip}}
+\ifCLASSOPTIONconference\def\@IEEEauthorblockconfadjspace{20pt}\fi
+
+% spacing between name and affiliation blocks (confmode)
+% This can be negative.
+% IEEE doesn't want any added spacing here, but I will leave these
+% controls in place in case they ever change their mind.
+% Personally, I like 0.75ex.
+%\def\@IEEEauthorblockNtopspace{0.75ex}
+%\def\@IEEEauthorblockAtopspace{0.75ex}
+\def\@IEEEauthorblockNtopspace{0.0ex}
+\def\@IEEEauthorblockAtopspace{0.0ex}
+% baseline spacing within name and affiliation blocks (confmode)
+% must be positive, spacings below certain values will make 
+% the position of line of text sensitive to the contents of the
+% line above it i.e., whether or not the prior line has descenders, 
+% subscripts, etc. For this reason it is a good idea to keep
+% these above 2.6ex
+\def\@IEEEauthorblockNinterlinespace{2.6ex}
+\def\@IEEEauthorblockAinterlinespace{2.75ex}
+
+% This tracks the required strut size.
+% See the \@IEEEauthorhalign command for the actual default value used.
+\def\@IEEEauthorblockXinterlinespace{2.7ex}
+
+% variables to retain font size and style across groups
+% values given here have no effect as they will be overwritten later
+\gdef\@IEEESAVESTATEfontsize{10}
+\gdef\@IEEESAVESTATEfontbaselineskip{12}
+\gdef\@IEEESAVESTATEfontencoding{OT1}
+\gdef\@IEEESAVESTATEfontfamily{ptm}
+\gdef\@IEEESAVESTATEfontseries{m}
+\gdef\@IEEESAVESTATEfontshape{n}
+
+% saves the current font attributes
+\def\@IEEEcurfontSAVE{\global\let\@IEEESAVESTATEfontsize\f@size%
+\global\let\@IEEESAVESTATEfontbaselineskip\f@baselineskip%
+\global\let\@IEEESAVESTATEfontencoding\f@encoding%
+\global\let\@IEEESAVESTATEfontfamily\f@family%
+\global\let\@IEEESAVESTATEfontseries\f@series%
+\global\let\@IEEESAVESTATEfontshape\f@shape}
+
+% restores the saved font attributes
+\def\@IEEEcurfontRESTORE{\fontsize{\@IEEESAVESTATEfontsize}{\@IEEESAVESTATEfontbaselineskip}%
+\fontencoding{\@IEEESAVESTATEfontencoding}%
+\fontfamily{\@IEEESAVESTATEfontfamily}%
+\fontseries{\@IEEESAVESTATEfontseries}%
+\fontshape{\@IEEESAVESTATEfontshape}%
+\selectfont}
+
+
+% variable to indicate if the current block is the first block in the column
+\newif\if@IEEEprevauthorblockincol   \@IEEEprevauthorblockincolfalse
+
+
+% the command places a strut with height and depth = \@IEEEauthorblockXinterlinespace
+% we use this technique to have complete manual control over the spacing of the lines
+% within the halign environment.
+% We set the below baseline portion at 30%, the above
+% baseline portion at 70% of the total length.
+% Responds to changes in the document's \baselinestretch
+\def\@IEEEauthorstrutrule{\@IEEEtrantmpdimenA\@IEEEauthorblockXinterlinespace%
+\@IEEEtrantmpdimenA=\baselinestretch\@IEEEtrantmpdimenA%
+\rule[-0.3\@IEEEtrantmpdimenA]{0pt}{\@IEEEtrantmpdimenA}}
+
+
+% blocks to hold the authors' names and affilations. 
+% Makes formatting easy for conferences
+%
+% use real definitions in conference mode
+% name block
+\def\IEEEauthorblockN#1{\relax\@IEEEauthorblockNstyle% set the default text style
+\gdef\@IEEEauthorblockXinterlinespace{0pt}% disable strut for spacer row
+% the \expandafter hides the \cr in conditional tex, see the array.sty docs
+% for details, probably not needed here as the \cr is in a macro
+% do a spacer row if needed
+\if@IEEEprevauthorblockincol\expandafter\@IEEEauthorblockNtopspaceline\fi
+\global\@IEEEprevauthorblockincoltrue% we now have a block in this column
+%restore the correct strut value
+\gdef\@IEEEauthorblockXinterlinespace{\@IEEEauthorblockNinterlinespace}%
+% input the author names
+#1%
+% end the row if the user did not already
+\crcr}
+% spacer row for names
+\def\@IEEEauthorblockNtopspaceline{\cr\noalign{\vskip\@IEEEauthorblockNtopspace}}
+%
+% affiliation block
+\def\IEEEauthorblockA#1{\relax\@IEEEauthorblockAstyle% set the default text style
+\gdef\@IEEEauthorblockXinterlinespace{0pt}%disable strut for spacer row
+% the \expandafter hides the \cr in conditional tex, see the array.sty docs
+% for details, probably not needed here as the \cr is in a macro
+% do a spacer row if needed
+\if@IEEEprevauthorblockincol\expandafter\@IEEEauthorblockAtopspaceline\fi
+\global\@IEEEprevauthorblockincoltrue% we now have a block in this column
+%restore the correct strut value
+\gdef\@IEEEauthorblockXinterlinespace{\@IEEEauthorblockAinterlinespace}%
+% input the author affiliations
+#1%
+% end the row if the user did not already
+\crcr}
+% spacer row for affiliations
+\def\@IEEEauthorblockAtopspaceline{\cr\noalign{\vskip\@IEEEauthorblockAtopspace}}
+
+
+% allow papers to compile even if author blocks are used in modes other
+% than conference or peerreviewca. For such cases, we provide dummy blocks.
+\ifCLASSOPTIONconference
+\else
+   \ifCLASSOPTIONpeerreviewca\else
+      % not conference or peerreviewca mode
+      \def\IEEEauthorblockN#1{#1}%
+      \def\IEEEauthorblockA#1{#1}%
+   \fi
+\fi
+
+
+
+% we provide our own halign so as not to have to depend on tabular
+\def\@IEEEauthorhalign{\@IEEEauthordefaulttextstyle% default text style
+   \lineskip=0pt\relax% disable line spacing
+   \lineskiplimit=0pt\relax%
+   \baselineskip=0pt\relax%
+   \@IEEEcurfontSAVE% save the current font
+   \mathsurround\z@\relax% no extra spacing around math
+   \let\\\@IEEEauthorhaligncr% replace newline with halign friendly one
+   \tabskip=0pt\relax% no column spacing
+   \everycr{}% ensure no problems here
+   \@IEEEprevauthorblockincolfalse% no author blocks yet
+   \def\@IEEEauthorblockXinterlinespace{2.7ex}% default interline space
+   \vtop\bgroup%vtop box
+   \halign\bgroup&\relax\hfil\@IEEEcurfontRESTORE\relax ##\relax
+   \hfil\@IEEEcurfontSAVE\@IEEEauthorstrutrule\cr}
+
+% ensure last line, exit from halign, close vbox
+\def\end@IEEEauthorhalign{\crcr\egroup\egroup}
+
+% handle bogus star form
+\def\@IEEEauthorhaligncr{{\ifnum0=`}\fi\@ifstar{\@@IEEEauthorhaligncr}{\@@IEEEauthorhaligncr}}
+
+% test and setup the optional argument to \\[]
+\def\@@IEEEauthorhaligncr{\@testopt\@@@IEEEauthorhaligncr\z@skip}
+
+% end the line and do the optional spacer
+\def\@@@IEEEauthorhaligncr[#1]{\ifnum0=`{\fi}\cr\noalign{\vskip#1\relax}}
+
+
+
+% flag to prevent multiple \and warning messages
+\newif\if@IEEEWARNand
+\@IEEEWARNandtrue
+
+% if in conference or peerreviewca modes, we support the use of \and as \author is a
+% tabular environment, otherwise we warn the user that \and is invalid
+% outside of conference or peerreviewca modes.
+\def\and{\relax} % provide a bogus \and that we will then override
+
+\renewcommand{\and}[1][\relax]{\if@IEEEWARNand\typeout{** WARNING: \noexpand\and is valid only
+                               when in conference or peerreviewca}\typeout{modes (line \the\inputlineno).}\fi\global\@IEEEWARNandfalse}
+
+\ifCLASSOPTIONconference%
+\renewcommand{\and}[1][\hfill]{\end{@IEEEauthorhalign}#1\begin{@IEEEauthorhalign}}%
+\fi
+\ifCLASSOPTIONpeerreviewca
+\renewcommand{\and}[1][\hfill]{\end{@IEEEauthorhalign}#1\begin{@IEEEauthorhalign}}%
+\fi
+
+
+% page clearing command
+% based on LaTeX2e's \cleardoublepage, but allows different page styles
+% for the inserted blank pages
+\def\@IEEEcleardoublepage#1{\clearpage\if@twoside\ifodd\c@page\else
+\hbox{}\thispagestyle{#1}\newpage\if@twocolumn\hbox{}\thispagestyle{#1}\newpage\fi\fi\fi}
+
+
+% user command to invoke the title page
+\def\maketitle{\par%
+  \begingroup%
+  \normalfont%
+  \def\thefootnote{}%  the \thanks{} mark type is empty
+  \def\footnotemark{}% and kill space from \thanks within author
+  \let\@makefnmark\relax% V1.7, must *really* kill footnotemark to remove all \textsuperscript spacing as well.
+  \footnotesize%       equal spacing between thanks lines
+  \footnotesep 0.7\baselineskip%see global setting of \footnotesep for more info
+  % V1.7 disable \thanks note indention for compsoc
+  \@IEEEcompsoconly{\long\def\@makefntext##1{\parindent 1em\noindent\hbox{\@makefnmark}##1}}%
+  \normalsize%
+  \ifCLASSOPTIONpeerreview
+     \newpage\global\@topnum\z@ \@maketitle\@IEEEstatictitlevskip\@IEEEaftertitletext%
+     \thispagestyle{IEEEpeerreviewcoverpagestyle}\@thanks%
+  \else
+     \if@twocolumn%
+        \ifCLASSOPTIONtechnote%
+           \newpage\global\@topnum\z@ \@maketitle\@IEEEstatictitlevskip\@IEEEaftertitletext%
+        \else
+           \twocolumn[\@maketitle\@IEEEstatictitlevskip\@IEEEaftertitletext]%
+        \fi
+     \else
+        \newpage\global\@topnum\z@ \@maketitle\@IEEEstatictitlevskip\@IEEEaftertitletext%
+     \fi
+     \thispagestyle{IEEEtitlepagestyle}\@thanks%
+  \fi
+  % pullup page for pubid if used.
+  \if@IEEEusingpubid
+     \enlargethispage{-\@IEEEpubidpullup}%
+  \fi 
+  \endgroup
+  \setcounter{footnote}{0}\let\maketitle\relax\let\@maketitle\relax
+  \gdef\@thanks{}%
+  % v1.6b do not clear these as we will need the title again for peer review papers
+  % \gdef\@author{}\gdef\@title{}%
+  \let\thanks\relax}
+
+
+
+% V1.7 parbox to format \@IEEEcompsoctitleabstractindextext
+\long\def\@IEEEcompsoctitleabstractindextextbox#1{\parbox{0.915\textwidth}{#1}}
+
+% formats the Title, authors names, affiliations and special paper notice
+% THIS IS A CONTROLLED SPACING COMMAND! Do not allow blank lines or unintentional
+% spaces to enter the definition - use % at the end of each line
+\def\@maketitle{\newpage
+\begingroup\centering
+\ifCLASSOPTIONtechnote% technotes
+   {\bfseries\large\@IEEEcompsoconly{\sffamily}\@title\par}\vskip 1.3em{\lineskip .5em\@IEEEcompsoconly{\sffamily}\@author
+   \@IEEEspecialpapernotice\par{\@IEEEcompsoconly{\vskip 1.5em\relax
+   \@IEEEcompsoctitleabstractindextextbox{\@IEEEcompsoctitleabstractindextext}\par
+   \hfill\@IEEEcompsocdiamondline\hfill\hbox{}\par}}}\relax
+\else% not a technote
+   \vskip0.2em{\Huge\@IEEEcompsoconly{\sffamily}\@IEEEcompsocconfonly{\normalfont\normalsize\vskip 2\@IEEEnormalsizeunitybaselineskip
+   \bfseries\Large}\@title\par}\vskip1.0em\par%
+   % V1.6 handle \author differently if in conference mode
+   \ifCLASSOPTIONconference%
+      {\@IEEEspecialpapernotice\mbox{}\vskip\@IEEEauthorblockconfadjspace%
+       \mbox{}\hfill\begin{@IEEEauthorhalign}\@author\end{@IEEEauthorhalign}\hfill\mbox{}\par}\relax
+   \else% peerreviewca, peerreview or journal
+      \ifCLASSOPTIONpeerreviewca
+         % peerreviewca handles author names just like conference mode
+         {\@IEEEcompsoconly{\sffamily}\@IEEEspecialpapernotice\mbox{}\vskip\@IEEEauthorblockconfadjspace%
+          \mbox{}\hfill\begin{@IEEEauthorhalign}\@author\end{@IEEEauthorhalign}\hfill\mbox{}\par
+          {\@IEEEcompsoconly{\vskip 1.5em\relax
+           \@IEEEcompsoctitleabstractindextextbox{\@IEEEcompsoctitleabstractindextext}\par\hfill
+           \@IEEEcompsocdiamondline\hfill\hbox{}\par}}}\relax
+      \else% journal or peerreview
+         {\lineskip.5em\@IEEEcompsoconly{\sffamily}\sublargesize\@author\@IEEEspecialpapernotice\par
+          {\@IEEEcompsoconly{\vskip 1.5em\relax
+           \@IEEEcompsoctitleabstractindextextbox{\@IEEEcompsoctitleabstractindextext}\par\hfill
+           \@IEEEcompsocdiamondline\hfill\hbox{}\par}}}\relax
+      \fi
+   \fi
+\fi\par\endgroup}
+
+
+
+% V1.7 Computer Society "diamond line" which follows index terms for nonconference papers
+\def\@IEEEcompsocdiamondline{\vrule depth 0pt height 0.5pt width 4cm\hspace{7.5pt}%
+\raisebox{-3.5pt}{\fontfamily{pzd}\fontencoding{U}\fontseries{m}\fontshape{n}\fontsize{11}{12}\selectfont\char70}%
+\hspace{7.5pt}\vrule depth 0pt height 0.5pt width 4cm\relax}
+
+% V1.7 standard LateX2e \thanks, but with \itshape under compsoc. Also make it a \long\def
+% We also need to trigger the one-shot footnote rule
+\def\@IEEEtriggeroneshotfootnoterule{\global\@IEEEenableoneshotfootnoteruletrue}
+
+
+\long\def\thanks#1{\footnotemark
+    \protected@xdef\@thanks{\@thanks
+        \protect\footnotetext[\the\c@footnote]{\@IEEEcompsoconly{\itshape
+        \protect\@IEEEtriggeroneshotfootnoterule\relax}\ignorespaces#1}}}
+\let\@thanks\@empty
+
+% V1.7 allow \author to contain \par's. This is needed to allow \thanks to contain \par.
+\long\def\author#1{\gdef\@author{#1}}
+
+
+% in addition to setting up IEEEitemize, we need to remove a baselineskip space above and
+% below it because \list's \pars introduce blank lines because of the footnote struts.
+\def\@IEEEsetupcompsocitemizelist{\def\labelitemi{$\bullet$}%
+\setlength{\IEEElabelindent}{0pt}\setlength{\parskip}{0pt}%
+\setlength{\partopsep}{0pt}\setlength{\topsep}{0.5\baselineskip}\vspace{-1\baselineskip}\relax}
+
+
+% flag for fake non-compsoc \IEEEcompsocthanksitem - prevents line break on very first item
+\newif\if@IEEEbreakcompsocthanksitem \@IEEEbreakcompsocthanksitemfalse
+
+\ifCLASSOPTIONcompsoc
+% V1.7 compsoc bullet item \thanks
+% also, we need to redefine this to destroy the argument in \@IEEEdynamictitlevspace
+\long\def\IEEEcompsocitemizethanks#1{\relax\@IEEEbreakcompsocthanksitemfalse\footnotemark
+    \protected@xdef\@thanks{\@thanks
+        \protect\footnotetext[\the\c@footnote]{\itshape\protect\@IEEEtriggeroneshotfootnoterule
+        {\let\IEEEiedlistdecl\relax\protect\begin{IEEEitemize}[\protect\@IEEEsetupcompsocitemizelist]\ignorespaces#1\relax
+        \protect\end{IEEEitemize}}\protect\vspace{-1\baselineskip}}}}
+\DeclareRobustCommand*{\IEEEcompsocthanksitem}{\item}
+\else
+% non-compsoc, allow for dual compilation via rerouting to normal \thanks
+\long\def\IEEEcompsocitemizethanks#1{\thanks{#1}}
+% redirect to "pseudo-par" \hfil\break\indent after swallowing [] from \IEEEcompsocthanksitem[]
+\DeclareRobustCommand{\IEEEcompsocthanksitem}{\@ifnextchar [{\@IEEEthanksswallowoptionalarg}%
+{\@IEEEthanksswallowoptionalarg[\relax]}}
+% be sure and break only after first item, be sure and ignore spaces after optional argument
+\def\@IEEEthanksswallowoptionalarg[#1]{\relax\if@IEEEbreakcompsocthanksitem\hfil\break
+\indent\fi\@IEEEbreakcompsocthanksitemtrue\ignorespaces}
+\fi
+
+
+% V1.6b define the \IEEEpeerreviewmaketitle as needed
+\ifCLASSOPTIONpeerreview
+\def\IEEEpeerreviewmaketitle{\@IEEEcleardoublepage{empty}%
+\ifCLASSOPTIONtwocolumn
+\twocolumn[\@IEEEpeerreviewmaketitle\@IEEEdynamictitlevspace]
+\else
+\newpage\@IEEEpeerreviewmaketitle\@IEEEstatictitlevskip
+\fi
+\thispagestyle{IEEEtitlepagestyle}}
+\else
+% \IEEEpeerreviewmaketitle does nothing if peer review option has not been selected
+\def\IEEEpeerreviewmaketitle{\relax}
+\fi
+
+% peerreview formats the repeated title like the title in journal papers.
+\def\@IEEEpeerreviewmaketitle{\begin{center}\@IEEEcompsoconly{\sffamily}%
+\normalfont\normalsize\vskip0.2em{\Huge\@title\par}\vskip1.0em\par
+\end{center}}
+
+
+
+% V1.6 
+% this is a static rubber spacer between the title/authors and the main text
+% used for single column text, or when the title appears in the first column
+% of two column text (technotes). 
+\def\@IEEEstatictitlevskip{{\normalfont\normalsize
+% adjust spacing to next text
+% v1.6b handle peer review papers
+\ifCLASSOPTIONpeerreview
+% for peer review papers, the same value is used for both title pages
+% regardless of the other paper modes
+   \vskip 1\baselineskip plus 0.375\baselineskip minus 0.1875\baselineskip
+\else
+   \ifCLASSOPTIONconference% conference
+      \vskip 0.6\baselineskip
+   \else%
+      \ifCLASSOPTIONtechnote% technote
+         \vskip 1\baselineskip plus 0.375\baselineskip minus 0.1875\baselineskip%
+      \else% journal uses more space
+         \vskip 2.5\baselineskip plus 0.75\baselineskip minus 0.375\baselineskip%
+      \fi
+   \fi
+\fi}}
+
+
+% V1.6
+% This is a dynamically determined rigid spacer between the title/authors 
+% and the main text. This is used only for single column titles over two 
+% column text (most common)
+% This is bit tricky because we have to ensure that the textheight of the
+% main text is an integer multiple of \baselineskip
+% otherwise underfull vbox problems may develop in the second column of the
+% text on the titlepage
+% The possible use of \IEEEpubid must also be taken into account.
+\def\@IEEEdynamictitlevspace{{%
+    % we run within a group so that all the macros can be forgotten when we are done
+    \long\def\thanks##1{\relax}%don't allow \thanks to run when we evaluate the vbox height
+    \long\def\IEEEcompsocitemizethanks##1{\relax}%don't allow \IEEEcompsocitemizethanks to run when we evaluate the vbox height
+    \normalfont\normalsize% we declare more descriptive variable names
+    \let\@IEEEmaintextheight=\@IEEEtrantmpdimenA%height of the main text columns
+    \let\@IEEEINTmaintextheight=\@IEEEtrantmpdimenB%height of the main text columns with integer # lines
+    % set the nominal and minimum values for the title spacer
+    % the dynamic algorithm will not allow the spacer size to
+    % become less than \@IEEEMINtitlevspace - instead it will be
+    % lengthened
+    % default to journal values
+    \def\@IEEENORMtitlevspace{2.5\baselineskip}%
+    \def\@IEEEMINtitlevspace{2\baselineskip}%
+    % conferences and technotes need tighter spacing
+    \ifCLASSOPTIONconference%conference
+     \def\@IEEENORMtitlevspace{1\baselineskip}%
+     \def\@IEEEMINtitlevspace{0.75\baselineskip}%
+    \fi
+    \ifCLASSOPTIONtechnote%technote
+      \def\@IEEENORMtitlevspace{1\baselineskip}%
+      \def\@IEEEMINtitlevspace{0.75\baselineskip}%
+    \fi%
+    % get the height that the title will take up
+    \ifCLASSOPTIONpeerreview
+       \settoheight{\@IEEEmaintextheight}{\vbox{\hsize\textwidth \@IEEEpeerreviewmaketitle}}%
+    \else
+       \settoheight{\@IEEEmaintextheight}{\vbox{\hsize\textwidth \@maketitle}}%
+    \fi
+    \@IEEEmaintextheight=-\@IEEEmaintextheight% title takes away from maintext, so reverse sign
+    % add the height of the page textheight
+    \advance\@IEEEmaintextheight by \textheight%
+    % correct for title pages using pubid
+    \ifCLASSOPTIONpeerreview\else
+       % peerreview papers use the pubid on the cover page only.
+       % And the cover page uses a static spacer.
+       \if@IEEEusingpubid\advance\@IEEEmaintextheight by -\@IEEEpubidpullup\fi
+    \fi%
+    % subtract off the nominal value of the title bottom spacer
+    \advance\@IEEEmaintextheight by -\@IEEENORMtitlevspace%
+    % \topskip takes away some too
+    \advance\@IEEEmaintextheight by -\topskip%
+    % calculate the column height of the main text for lines
+    % now we calculate the main text height as if holding
+    % an integer number of \normalsize lines after the first
+    % and discard any excess fractional remainder
+    % we subtracted the first line, because the first line
+    % is placed \topskip into the maintext, not \baselineskip like the
+    % rest of the lines.
+    \@IEEEINTmaintextheight=\@IEEEmaintextheight%
+    \divide\@IEEEINTmaintextheight  by \baselineskip%
+    \multiply\@IEEEINTmaintextheight  by \baselineskip%
+    % now we calculate how much the title spacer height will
+    % have to be reduced from nominal (\@IEEEREDUCEmaintextheight is always
+    % a positive value) so that the maintext area will contain an integer
+    % number of normal size lines
+    % we change variable names here (to avoid confusion) as we no longer
+    % need \@IEEEINTmaintextheight and can reuse its dimen register
+    \let\@IEEEREDUCEmaintextheight=\@IEEEINTmaintextheight%
+    \advance\@IEEEREDUCEmaintextheight by -\@IEEEmaintextheight%
+    \advance\@IEEEREDUCEmaintextheight by \baselineskip%
+    % this is the calculated height of the spacer
+    % we change variable names here (to avoid confusion) as we no longer
+    % need \@IEEEmaintextheight and can reuse its dimen register
+    \let\@IEEECOMPENSATElen=\@IEEEmaintextheight%
+    \@IEEECOMPENSATElen=\@IEEENORMtitlevspace% set the nominal value
+    % we go with the reduced length if it is smaller than an increase
+    \ifdim\@IEEEREDUCEmaintextheight < 0.5\baselineskip\relax%
+     \advance\@IEEECOMPENSATElen by -\@IEEEREDUCEmaintextheight%
+     % if the resulting spacer is too small back out and go with an increase instead
+     \ifdim\@IEEECOMPENSATElen<\@IEEEMINtitlevspace\relax%
+      \advance\@IEEECOMPENSATElen by \baselineskip%
+     \fi%
+    \else%
+     % go with an increase because it is closer to the nominal than a decrease
+     \advance\@IEEECOMPENSATElen by -\@IEEEREDUCEmaintextheight%
+     \advance\@IEEECOMPENSATElen by \baselineskip%
+    \fi%
+    % set the calculated rigid spacer
+    \vspace{\@IEEECOMPENSATElen}}}
+
+
+
+% V1.6
+% we allow the user access to the last part of the title area
+% useful in emergencies such as when a different spacing is needed
+% This text is NOT compensated for in the dynamic sizer.
+\let\@IEEEaftertitletext=\relax
+\long\def\IEEEaftertitletext#1{\def\@IEEEaftertitletext{#1}}
+
+% V1.7 provide a way for users to enter abstract and keywords
+% into the onecolumn title are. This text is compensated for
+% in the dynamic sizer.
+\let\@IEEEcompsoctitleabstractindextext=\relax
+\long\def\IEEEcompsoctitleabstractindextext#1{\def\@IEEEcompsoctitleabstractindextext{#1}}
+% V1.7 provide a way for users to get the \@IEEEcompsoctitleabstractindextext if
+% not in compsoc journal mode - this way abstract and keywords can be placed
+% in their conventional position if not in compsoc mode.
+\def\IEEEdisplaynotcompsoctitleabstractindextext{%
+\ifCLASSOPTIONcompsoc% display if compsoc conf
+\ifCLASSOPTIONconference\@IEEEcompsoctitleabstractindextext\fi
+\else% or if not compsoc
+\@IEEEcompsoctitleabstractindextext\fi}
+
+
+% command to allow alteration of baselinestretch, but only if the current
+% baselineskip is unity. Used to tweak the compsoc abstract and keywords line spacing.
+\def\@IEEEtweakunitybaselinestretch#1{{\def\baselinestretch{1}\selectfont
+\global\@tempskipa\baselineskip}\ifnum\@tempskipa=\baselineskip%
+\def\baselinestretch{#1}\selectfont\fi\relax}
+
+
+% abstract and keywords are in \small, except 
+% for 9pt docs in which they are in \footnotesize
+% Because 9pt docs use an 8pt footnotesize, \small
+% becomes a rather awkward 8.5pt
+\def\@IEEEabskeysecsize{\small}
+\ifx\CLASSOPTIONpt\@IEEEptsizenine
+ \def\@IEEEabskeysecsize{\footnotesize}
+\fi
+
+% compsoc journals use \footnotesize, compsoc conferences use normalsize
+\@IEEEcompsoconly{\def\@IEEEabskeysecsize{\footnotesize}}
+\@IEEEcompsocconfonly{\def\@IEEEabskeysecsize{\normalsize}}
+
+
+
+
+% V1.6 have abstract and keywords strip leading spaces, pars and newlines
+% so that spacing is more tightly controlled.
+\def\abstract{\normalfont
+    \if@twocolumn
+      \par\@IEEEabskeysecsize\bfseries\leavevmode\kern-1pt\textit{\abstractname}---\relax
+    \else
+      \begin{center}\vspace{-1.78ex}\@IEEEabskeysecsize\textbf{\abstractname}\end{center}\quotation\@IEEEabskeysecsize
+    \fi\@IEEEgobbleleadPARNLSP}
+% V1.6 IEEE wants only 1 pica from end of abstract to introduction heading when in 
+% conference mode (the heading already has this much above it)
+\def\endabstract{\relax\ifCLASSOPTIONconference\vspace{0ex}\else\vspace{1.34ex}\fi\par\if@twocolumn\else\endquotation\fi
+    \normalfont\normalsize}
+
+\def\IEEEkeywords{\normalfont
+    \if@twocolumn
+      \@IEEEabskeysecsize\bfseries\leavevmode\kern-1pt\textit{\IEEEkeywordsname}---\relax
+    \else
+      \begin{center}\@IEEEabskeysecsize\textbf{\IEEEkeywordsname}\end{center}\quotation\@IEEEabskeysecsize
+    \fi\itshape\@IEEEgobbleleadPARNLSP}
+\def\endIEEEkeywords{\relax\ifCLASSOPTIONtechnote\vspace{1.34ex}\else\vspace{0.5ex}\fi
+    \par\if@twocolumn\else\endquotation\fi%
+    \normalfont\normalsize}
+
+% V1.7 compsoc keywords index terms
+\ifCLASSOPTIONcompsoc
+  \ifCLASSOPTIONconference% compsoc conference
+\def\abstract{\normalfont
+      \begin{center}\@IEEEabskeysecsize\textbf{\large\abstractname}\end{center}\vskip 0.5\baselineskip plus 0.1\baselineskip minus 0.1\baselineskip
+      \if@twocolumn\else\quotation\fi\itshape\@IEEEabskeysecsize%
+      \par\@IEEEgobbleleadPARNLSP}
+\def\IEEEkeywords{\normalfont\vskip 1.5\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip
+      \begin{center}\@IEEEabskeysecsize\textbf{\large\IEEEkeywordsname}\end{center}\vskip 0.5\baselineskip plus 0.1\baselineskip minus 0.1\baselineskip
+      \if@twocolumn\else\quotation\fi\itshape\@IEEEabskeysecsize%
+      \par\@IEEEgobbleleadPARNLSP}
+  \else% compsoc not conference
+\def\abstract{\normalfont\@IEEEtweakunitybaselinestretch{1.15}\sffamily
+    \if@twocolumn
+      \@IEEEabskeysecsize\noindent\textbf{\abstractname}---\relax
+    \else
+      \begin{center}\vspace{-1.78ex}\@IEEEabskeysecsize\textbf{\abstractname}\end{center}\quotation\@IEEEabskeysecsize%
+    \fi\@IEEEgobbleleadPARNLSP}
+\def\IEEEkeywords{\normalfont\@IEEEtweakunitybaselinestretch{1.15}\sffamily
+    \if@twocolumn
+      \@IEEEabskeysecsize\vskip 0.5\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip\noindent
+      \textbf{\IEEEkeywordsname}---\relax
+    \else
+      \begin{center}\@IEEEabskeysecsize\textbf{\IEEEkeywordsname}\end{center}\quotation\@IEEEabskeysecsize%
+    \fi\@IEEEgobbleleadPARNLSP}
+  \fi
+\fi
+
+
+
+% gobbles all leading \, \\ and \par, upon finding first token that
+% is not a \ , \\ or a \par, it ceases and returns that token
+% 
+% used to strip leading \, \\ and \par from the input
+% so that such things in the beginning of an environment will not
+% affect the formatting of the text
+\long\def\@IEEEgobbleleadPARNLSP#1{\let\@IEEEswallowthistoken=0%
+\let\@IEEEgobbleleadPARNLSPtoken#1%
+\let\@IEEEgobbleleadPARtoken=\par%
+\let\@IEEEgobbleleadNLtoken=\\%
+\let\@IEEEgobbleleadSPtoken=\ %
+\def\@IEEEgobbleleadSPMACRO{\ }%
+\ifx\@IEEEgobbleleadPARNLSPtoken\@IEEEgobbleleadPARtoken%
+\let\@IEEEswallowthistoken=1%
+\fi%
+\ifx\@IEEEgobbleleadPARNLSPtoken\@IEEEgobbleleadNLtoken%
+\let\@IEEEswallowthistoken=1%
+\fi%
+\ifx\@IEEEgobbleleadPARNLSPtoken\@IEEEgobbleleadSPtoken%
+\let\@IEEEswallowthistoken=1%
+\fi%
+% a control space will come in as a macro
+% when it is the last one on a line
+\ifx\@IEEEgobbleleadPARNLSPtoken\@IEEEgobbleleadSPMACRO%
+\let\@IEEEswallowthistoken=1%
+\fi%
+% if we have to swallow this token, do so and taste the next one
+% else spit it out and stop gobbling
+\ifx\@IEEEswallowthistoken 1\let\@IEEEnextgobbleleadPARNLSP=\@IEEEgobbleleadPARNLSP\else%
+\let\@IEEEnextgobbleleadPARNLSP=#1\fi%
+\@IEEEnextgobbleleadPARNLSP}%
+
+
+
+
+% TITLING OF SECTIONS
+\def\@IEEEsectpunct{:\ \,}  % Punctuation after run-in section heading  (headings which are
+                            % part of the paragraphs), need little bit more than a single space
+                            % spacing from section number to title
+% compsoc conferences use regular period/space punctuation
+\ifCLASSOPTIONcompsoc
+\ifCLASSOPTIONconference
+\def\@IEEEsectpunct{.\ }
+\fi\fi
+
+\def\@seccntformat#1{\hb@xt@ 1.4em{\csname the#1dis\endcsname\hss\relax}}
+\def\@seccntformatinl#1{\hb@xt@ 1.1em{\csname the#1dis\endcsname\hss\relax}}
+\def\@seccntformatch#1{\csname the#1dis\endcsname\hskip 1em\relax}
+
+\ifCLASSOPTIONcompsoc
+% compsoc journals need extra spacing
+\ifCLASSOPTIONconference\else
+\def\@seccntformat#1{\csname the#1dis\endcsname\hskip 1em\relax}
+\fi\fi
+
+%v1.7 put {} after #6 to allow for some types of user font control
+%and use \@@par rather than \par
+\def\@sect#1#2#3#4#5#6[#7]#8{%
+  \ifnum #2>\c@secnumdepth
+     \let\@svsec\@empty
+  \else
+     \refstepcounter{#1}%
+     % load section label and spacer into \@svsec
+     \ifnum #2=1
+        \protected@edef\@svsec{\@seccntformatch{#1}\relax}%
+     \else
+        \ifnum #2>2
+           \protected@edef\@svsec{\@seccntformatinl{#1}\relax}%
+        \else
+           \protected@edef\@svsec{\@seccntformat{#1}\relax}%
+        \fi
+     \fi
+  \fi%
+  \@tempskipa #5\relax
+  \ifdim \@tempskipa>\z@% tempskipa determines whether is treated as a high
+     \begingroup #6{\relax% or low level heading
+      \noindent % subsections are NOT indented
+       % print top level headings. \@svsec is label, #8 is heading title
+       % IEEE does not block indent the section title text, it flows like normal
+       {\hskip #3\relax\@svsec}{\interlinepenalty \@M #8\@@par}}%
+     \endgroup
+     \addcontentsline{toc}{#1}{\ifnum #2>\c@secnumdepth\relax\else
+               \protect\numberline{\csname the#1\endcsname}\fi#7}%
+  \else % printout low level headings
+     % svsechd seems to swallow the trailing space, protect it with \mbox{}
+     % got rid of sectionmark stuff
+     \def\@svsechd{#6{\hskip #3\relax\@svsec #8\@IEEEsectpunct\mbox{}}%
+     \addcontentsline{toc}{#1}{\ifnum #2>\c@secnumdepth\relax\else
+               \protect\numberline{\csname the#1\endcsname}\fi#7}}%
+  \fi%skip down
+  \@xsect{#5}}
+
+
+% section* handler
+%v1.7 put {} after #4 to allow for some types of user font control
+%and use \@@par rather than \par
+\def\@ssect#1#2#3#4#5{\@tempskipa #3\relax
+  \ifdim \@tempskipa>\z@
+     %\begingroup #4\@hangfrom{\hskip #1}{\interlinepenalty \@M #5\par}\endgroup
+     % IEEE does not block indent the section title text, it flows like normal
+     \begingroup \noindent #4{\relax{\hskip #1}{\interlinepenalty \@M #5\@@par}}\endgroup
+  % svsechd swallows the trailing space, protect it with \mbox{}
+  \else \def\@svsechd{#4{\hskip #1\relax #5\@IEEEsectpunct\mbox{}}}\fi
+  \@xsect{#3}}
+
+
+%% SECTION heading spacing and font
+%%
+% arguments are: #1 - sectiontype name
+% (for \@sect)   #2 - section level
+%                #3 - section heading indent
+%                #4 - top separation (absolute value used, neg indicates not to indent main text)
+%                     If negative, make stretch parts negative too!
+%                #5 - (absolute value used) positive: bottom separation after heading,
+%                      negative: amount to indent main text after heading
+%                Both #4 and #5 negative means to indent main text and use negative top separation
+%                #6 - font control
+% You've got to have \normalfont\normalsize in the font specs below to prevent
+% trouble when you do something like:
+% \section{Note}{\ttfamily TT-TEXT} is known to ... 
+% IEEE sometimes REALLY stretches the area before a section
+% heading by up to about 0.5in. However, it may not be a good
+% idea to let LaTeX have quite this much rubber.
+\ifCLASSOPTIONconference%
+% IEEE wants section heading spacing to decrease for conference mode
+\def\section{\@startsection{section}{1}{\z@}{1.5ex plus 1.5ex minus 0.5ex}%
+{1sp}{\normalfont\normalsize\centering\scshape}}%
+\def\subsection{\@startsection{subsection}{2}{\z@}{1.5ex plus 1.5ex minus 0.5ex}%
+{1sp}{\normalfont\normalsize\itshape}}%
+\else % for journals
+\def\section{\@startsection{section}{1}{\z@}{3.0ex plus 1.5ex minus 1.5ex}% V1.6 3.0ex from 3.5ex
+{0.7ex plus 1ex minus 0ex}{\normalfont\normalsize\centering\scshape}}%
+\def\subsection{\@startsection{subsection}{2}{\z@}{3.5ex plus 1.5ex minus 1.5ex}%
+{0.7ex plus .5ex minus 0ex}{\normalfont\normalsize\itshape}}%
+\fi
+
+% for both journals and conferences
+% decided to put in a little rubber above the section, might help somebody
+\def\subsubsection{\@startsection{subsubsection}{3}{\parindent}{0ex plus 0.1ex minus 0.1ex}%
+{0ex}{\normalfont\normalsize\itshape}}%
+\def\paragraph{\@startsection{paragraph}{4}{2\parindent}{0ex plus 0.1ex minus 0.1ex}%
+{0ex}{\normalfont\normalsize\itshape}}%
+
+
+% compsoc
+\ifCLASSOPTIONcompsoc
+\ifCLASSOPTIONconference
+% compsoc conference
+\def\section{\@startsection{section}{1}{\z@}{1\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip}%
+{1\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip}{\normalfont\large\bfseries}}%
+\def\subsection{\@startsection{subsection}{2}{\z@}{1\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip}%
+{1\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip}{\normalfont\sublargesize\bfseries}}%
+\def\subsubsection{\@startsection{subsubsection}{3}{\z@}{1\baselineskip plus 0.25\baselineskip minus 0.25\baselineskip}%
+{0ex}{\normalfont\normalsize\bfseries}}%
+\def\paragraph{\@startsection{paragraph}{4}{2\parindent}{0ex plus 0.1ex minus 0.1ex}%
+{0ex}{\normalfont\normalsize}}%
+\else% compsoc journals
+% use negative top separation as compsoc journals do not indent paragraphs after section titles
+\def\section{\@startsection{section}{1}{\z@}{-3ex plus -2ex minus -1.5ex}%
+{0.7ex plus 1ex minus 0ex}{\normalfont\large\sffamily\bfseries\scshape}}%
+% Note that subsection and smaller may not be correct for the Computer Society,
+% I have to look up an example.
+\def\subsection{\@startsection{subsection}{2}{\z@}{-3.5ex plus -1.5ex minus -1.5ex}%
+{0.7ex plus .5ex minus 0ex}{\normalfont\normalsize\sffamily\bfseries}}%
+\def\subsubsection{\@startsection{subsubsection}{3}{\z@}{-2.5ex plus -1ex minus -1ex}%
+{0.5ex plus 0.5ex minus 0ex}{\normalfont\normalsize\sffamily\itshape}}%
+\def\paragraph{\@startsection{paragraph}{4}{2\parindent}{-0ex plus -0.1ex minus -0.1ex}%
+{0ex}{\normalfont\normalsize}}%
+\fi\fi
+
+
+
+
+%% ENVIRONMENTS
+% "box" symbols at end of proofs
+\def\IEEEQEDclosed{\mbox{\rule[0pt]{1.3ex}{1.3ex}}} % for a filled box
+% V1.6 some journals use an open box instead that will just fit around a closed one
+\def\IEEEQEDopen{{\setlength{\fboxsep}{0pt}\setlength{\fboxrule}{0.2pt}\fbox{\rule[0pt]{0pt}{1.3ex}\rule[0pt]{1.3ex}{0pt}}}}
+\ifCLASSOPTIONcompsoc
+\def\IEEEQED{\IEEEQEDopen}   % default to open for compsoc
+\else
+\def\IEEEQED{\IEEEQEDclosed} % otherwise default to closed
+\fi
+
+% v1.7 name change to avoid namespace collision with amsthm. Also add support
+% for an optional argument.
+\def\IEEEproof{\@ifnextchar[{\@IEEEproof}{\@IEEEproof[\IEEEproofname]}}
+\def\@IEEEproof[#1]{\par\noindent\hspace{2em}{\itshape #1: }}
+\def\endIEEEproof{\hspace*{\fill}~\IEEEQED\par}
+
+
+%\itemindent is set to \z@ by list, so define new temporary variable
+\newdimen\@IEEEtmpitemindent
+\def\@begintheorem#1#2{\@IEEEtmpitemindent\itemindent\topsep 0pt\rmfamily\trivlist%
+    \item[\hskip \labelsep{\indent\itshape #1\ #2:}]\itemindent\@IEEEtmpitemindent}
+\def\@opargbegintheorem#1#2#3{\@IEEEtmpitemindent\itemindent\topsep 0pt\rmfamily \trivlist%
+% V1.6 IEEE is back to using () around theorem names which are also in italics
+% Thanks to Christian Peel for reporting this.
+    \item[\hskip\labelsep{\indent\itshape #1\ #2\ (#3):}]\itemindent\@IEEEtmpitemindent}
+% V1.7 remove bogus \unskip that caused equations in theorems to collide with
+% lines below.
+\def\@endtheorem{\endtrivlist}
+
+% V1.6
+% display command for the section the theorem is in - so that \thesection
+% is not used as this will be in Roman numerals when we want arabic.
+% LaTeX2e uses \def\@thmcounter#1{\noexpand\arabic{#1}} for the theorem number
+% (second part) display and \def\@thmcountersep{.} as a separator.
+% V1.7 intercept calls to the section counter and reroute to \@IEEEthmcounterinsection
+% to allow \appendix(ices} to override as needed.
+%
+% special handler for sections, allows appendix(ices) to override
+\gdef\@IEEEthmcounterinsection#1{\arabic{#1}}
+% string macro
+\edef\@IEEEstringsection{section}
+
+% redefine the #1#2[#3] form of newtheorem to use a hook to \@IEEEthmcounterinsection
+% if section in_counter is used
+\def\@xnthm#1#2[#3]{%
+  \expandafter\@ifdefinable\csname #1\endcsname
+    {\@definecounter{#1}\@newctr{#1}[#3]%
+     \edef\@IEEEstringtmp{#3}
+     \ifx\@IEEEstringtmp\@IEEEstringsection
+     \expandafter\xdef\csname the#1\endcsname{%
+     \noexpand\@IEEEthmcounterinsection{#3}\@thmcountersep
+          \@thmcounter{#1}}%
+     \else
+     \expandafter\xdef\csname the#1\endcsname{%
+       \expandafter\noexpand\csname the#3\endcsname \@thmcountersep
+          \@thmcounter{#1}}%
+     \fi
+     \global\@namedef{#1}{\@thm{#1}{#2}}%
+     \global\@namedef{end#1}{\@endtheorem}}}
+
+
+
+%% SET UP THE DEFAULT PAGESTYLE
+\ps@headings
+\pagenumbering{arabic}
+
+% normally the page counter starts at 1
+\setcounter{page}{1}
+% however, for peerreview the cover sheet is page 0 or page -1
+% (for duplex printing)
+\ifCLASSOPTIONpeerreview
+   \if@twoside
+      \setcounter{page}{-1}
+   \else
+      \setcounter{page}{0}
+   \fi
+\fi
+
+% standard book class behavior - let bottom line float up and down as
+% needed when single sided
+\ifCLASSOPTIONtwoside\else\raggedbottom\fi
+% if two column - turn on twocolumn, allow word spacings to stretch more and
+% enforce a rigid position for the last lines
+\ifCLASSOPTIONtwocolumn
+% the peer review option delays invoking twocolumn
+   \ifCLASSOPTIONpeerreview\else
+      \twocolumn
+   \fi
+\sloppy 
+\flushbottom
+\fi
+
+
+
+
+% \APPENDIX and \APPENDICES definitions
+
+% This is the \@ifmtarg command from the LaTeX ifmtarg package
+% by Peter Wilson (CUA) and Donald Arseneau
+% \@ifmtarg is used to determine if an argument to a command
+% is present or not.
+% For instance:
+% \@ifmtarg{#1}{\typeout{empty}}{\typeout{has something}}
+% \@ifmtarg is used with our redefined \section command if
+% \appendices is invoked.
+% The command \section will behave slightly differently depending
+% on whether the user specifies a title: 
+% \section{My appendix title}
+% or not:
+% \section{}
+% This way, we can eliminate the blank lines where the title
+% would be, and the unneeded : after Appendix in the table of
+% contents 
+\begingroup
+\catcode`\Q=3
+\long\gdef\@ifmtarg#1{\@xifmtarg#1QQ\@secondoftwo\@firstoftwo\@nil}
+\long\gdef\@xifmtarg#1#2Q#3#4#5\@nil{#4}
+\endgroup
+% end of \@ifmtarg defs
+
+
+% V1.7
+% command that allows the one time saving of the original definition
+% of section to \@IEEEappendixsavesection for \appendix or \appendices 
+% we don't save \section here as it may be redefined later by other
+% packages (hyperref.sty, etc.)
+\def\@IEEEsaveoriginalsectiononce{\let\@IEEEappendixsavesection\section
+\let\@IEEEsaveoriginalsectiononce\relax}
+
+% neat trick to grab and process the argument from \section{argument}
+% we process differently if the user invoked \section{} with no
+% argument (title)
+% note we reroute the call to the old \section*
+\def\@IEEEprocessthesectionargument#1{%
+\@ifmtarg{#1}{%
+\@IEEEappendixsavesection*{\appendixname~\thesectiondis}%
+\addcontentsline{toc}{section}{\appendixname~\thesection}}{%
+\@IEEEappendixsavesection*{\appendixname~\thesectiondis \\* #1}%
+\addcontentsline{toc}{section}{\appendixname~\thesection: #1}}}
+
+% we use this if the user calls \section{} after
+% \appendix-- which has no meaning. So, we ignore the
+% command and its argument. Then, warn the user.
+\def\@IEEEdestroythesectionargument#1{\typeout{** WARNING: Ignoring useless
+\protect\section\space in Appendix (line \the\inputlineno).}}
+
+
+% remember \thesection forms will be displayed in \ref calls
+% and in the Table of Contents.
+% The \sectiondis form is used in the actual heading itself
+
+% appendix command for one single appendix
+% normally has no heading. However, if you want a 
+% heading, you can do so via the optional argument:
+% \appendix[Optional Heading]
+\def\appendix{\relax}
+\renewcommand{\appendix}[1][]{\@IEEEsaveoriginalsectiononce\par
+    % v1.6 keep hyperref's identifiers unique
+    \gdef\theHsection{Appendix.A}%
+    % v1.6 adjust hyperref's string name for the section
+    \xdef\Hy@chapapp{appendix}%
+    \setcounter{section}{0}%
+    \setcounter{subsection}{0}%
+    \setcounter{subsubsection}{0}%
+    \setcounter{paragraph}{0}%
+    \gdef\thesection{A}%
+    \gdef\thesectiondis{}% 
+    \gdef\thesubsection{\Alph{subsection}}%
+    \gdef\@IEEEthmcounterinsection##1{A}
+    \refstepcounter{section}% update the \ref counter
+    \@ifmtarg{#1}{\@IEEEappendixsavesection*{\appendixname}%
+                  \addcontentsline{toc}{section}{\appendixname}}{%
+             \@IEEEappendixsavesection*{\appendixname~\\* #1}%
+             \addcontentsline{toc}{section}{\appendixname: #1}}%
+    % redefine \section command for appendix
+    % leave \section* as is
+    \def\section{\@ifstar{\@IEEEappendixsavesection*}{%
+                    \@IEEEdestroythesectionargument}}% throw out the argument
+                                                     % of the normal form
+}
+
+
+
+% appendices command for multiple appendices
+% user then calls \section with an argument (possibly empty) to
+% declare the individual appendices
+\def\appendices{\@IEEEsaveoriginalsectiononce\par
+    % v1.6 keep hyperref's identifiers unique
+    \gdef\theHsection{Appendix.\Alph{section}}%
+    % v1.6 adjust hyperref's string name for the section
+    \xdef\Hy@chapapp{appendix}%
+    \setcounter{section}{-1}% we want \refstepcounter to use section 0
+    \setcounter{subsection}{0}%
+    \setcounter{subsubsection}{0}%
+    \setcounter{paragraph}{0}%
+    \ifCLASSOPTIONromanappendices%
+    \gdef\thesection{\Roman{section}}%
+    \gdef\thesectiondis{\Roman{section}}%
+    \@IEEEcompsocconfonly{\gdef\thesectiondis{\Roman{section}.}}%
+    \gdef\@IEEEthmcounterinsection##1{A\arabic{##1}}
+    \else%
+    \gdef\thesection{\Alph{section}}%
+    \gdef\thesectiondis{\Alph{section}}%
+    \@IEEEcompsocconfonly{\gdef\thesectiondis{\Alph{section}.}}%
+    \gdef\@IEEEthmcounterinsection##1{\Alph{##1}}
+    \fi%
+    \refstepcounter{section}% update the \ref counter
+    \setcounter{section}{0}% NEXT \section will be the FIRST appendix
+    % redefine \section command for appendices
+    % leave \section* as is
+    \def\section{\@ifstar{\@IEEEappendixsavesection*}{% process the *-form
+                    \refstepcounter{section}% or is a new section so,
+                    \@IEEEprocessthesectionargument}}% process the argument 
+                                                 % of the normal form
+}
+
+
+
+% \IEEEPARstart
+% Definition for the big two line drop cap letter at the beginning of the
+% first paragraph of journal papers. The first argument is the first letter
+% of the first word, the second argument is the remaining letters of the
+% first word which will be rendered in upper case.
+% In V1.6 this has been completely rewritten to:
+% 
+% 1. no longer have problems when the user begins an environment
+%    within the paragraph that uses \IEEEPARstart.
+% 2. auto-detect and use the current font family
+% 3. revise handling of the space at the end of the first word so that
+%    interword glue will now work as normal.
+% 4. produce correctly aligned edges for the (two) indented lines.
+% 
+% We generalize things via control macros - playing with these is fun too.
+% 
+% V1.7 added more control macros to make it easy for IEEEtrantools.sty users
+% to change the font style.
+% 
+% the number of lines that are indented to clear it
+% may need to increase if using decenders
+\def\@IEEEPARstartDROPLINES{2}
+% minimum number of lines left on a page to allow a \@IEEEPARstart
+% Does not take into consideration rubber shrink, so it tends to
+% be overly cautious
+\def\@IEEEPARstartMINPAGELINES{2}
+% V1.7 the height of the drop cap is adjusted to match the height of this text
+% in the current font (when \IEEEPARstart is called).
+\def\@IEEEPARstartHEIGHTTEXT{T}
+% the depth the letter is lowered below the baseline
+% the height (and size) of the letter is determined by the sum
+% of this value and the height of the \@IEEEPARstartHEIGHTTEXT in the current
+% font. It is a good idea to set this value in terms of the baselineskip
+% so that it can respond to changes therein.
+\def\@IEEEPARstartDROPDEPTH{1.1\baselineskip}
+% V1.7 the font the drop cap will be rendered in,
+% can take zero or one argument.
+\def\@IEEEPARstartFONTSTYLE{\bfseries}
+% V1.7 any additional, non-font related commands needed to modify
+% the drop cap letter, can take zero or one argument.
+\def\@IEEEPARstartCAPSTYLE{\MakeUppercase}
+% V1.7 the font that will be used to render the rest of the word,
+% can take zero or one argument.
+\def\@IEEEPARstartWORDFONTSTYLE{\relax}
+% V1.7 any additional, non-font related commands needed to modify
+% the rest of the word, can take zero or one argument.
+\def\@IEEEPARstartWORDCAPSTYLE{\MakeUppercase}
+% This is the horizontal separation distance from the drop letter to the main text.
+% Lengths that depend on the font (e.g., ex, em, etc.) will be referenced
+% to the font that is active when \IEEEPARstart is called. 
+\def\@IEEEPARstartSEP{0.15em}
+% V1.7 horizontal offset applied to the left of the drop cap.
+\def\@IEEEPARstartHOFFSET{0em}
+% V1.7 Italic correction command applied at the end of the drop cap.
+\def\@IEEEPARstartITLCORRECT{\/}
+
+% V1.7 compoc uses nonbold drop cap and small caps word style
+\ifCLASSOPTIONcompsoc
+\def\@IEEEPARstartFONTSTYLE{\mdseries}
+\def\@IEEEPARstartWORDFONTSTYLE{\scshape}
+\def\@IEEEPARstartWORDCAPSTYLE{\relax}
+\fi
+
+% definition of \IEEEPARstart
+% THIS IS A CONTROLLED SPACING AREA, DO NOT ALLOW SPACES WITHIN THESE LINES
+% 
+% The token \@IEEEPARstartfont will be globally defined after the first use
+% of \IEEEPARstart and will be a font command which creates the big letter
+% The first argument is the first letter of the first word and the second
+% argument is the rest of the first word(s).
+\def\IEEEPARstart#1#2{\par{%
+% if this page does not have enough space, break it and lets start
+% on a new one
+\@IEEEtranneedspace{\@IEEEPARstartMINPAGELINES\baselineskip}{\relax}%
+% V1.7 move this up here in case user uses \textbf for \@IEEEPARstartFONTSTYLE
+% which uses command \leavevmode which causes an unwanted \indent to be issued
+\noindent
+% calculate the desired height of the big letter
+% it extends from the top of \@IEEEPARstartHEIGHTTEXT in the current font
+% down to \@IEEEPARstartDROPDEPTH below the current baseline
+\settoheight{\@IEEEtrantmpdimenA}{\@IEEEPARstartHEIGHTTEXT}%
+\addtolength{\@IEEEtrantmpdimenA}{\@IEEEPARstartDROPDEPTH}%
+% extract the name of the current font in bold
+% and place it in \@IEEEPARstartFONTNAME
+\def\@IEEEPARstartGETFIRSTWORD##1 ##2\relax{##1}%
+{\@IEEEPARstartFONTSTYLE{\selectfont\edef\@IEEEPARstartFONTNAMESPACE{\fontname\font\space}%
+\xdef\@IEEEPARstartFONTNAME{\expandafter\@IEEEPARstartGETFIRSTWORD\@IEEEPARstartFONTNAMESPACE\relax}}}%
+% define a font based on this name with a point size equal to the desired
+% height of the drop letter
+\font\@IEEEPARstartsubfont\@IEEEPARstartFONTNAME\space at \@IEEEtrantmpdimenA\relax%
+% save this value as a counter (integer) value (sp points)
+\@IEEEtrantmpcountA=\@IEEEtrantmpdimenA%
+% now get the height of the actual letter produced by this font size
+\settoheight{\@IEEEtrantmpdimenB}{\@IEEEPARstartsubfont\@IEEEPARstartCAPSTYLE{#1}}%
+% If something bogus happens like the first argument is empty or the
+% current font is strange, do not allow a zero height.
+\ifdim\@IEEEtrantmpdimenB=0pt\relax%
+\typeout{** WARNING: IEEEPARstart drop letter has zero height! (line \the\inputlineno)}%
+\typeout{ Forcing the drop letter font size to 10pt.}%
+\@IEEEtrantmpdimenB=10pt%
+\fi%
+% and store it as a counter
+\@IEEEtrantmpcountB=\@IEEEtrantmpdimenB%
+% Since a font size doesn't exactly correspond to the height of the capital
+% letters in that font, the actual height of the letter, \@IEEEtrantmpcountB,
+% will be less than that desired, \@IEEEtrantmpcountA
+% we need to raise the font size, \@IEEEtrantmpdimenA 
+% by \@IEEEtrantmpcountA / \@IEEEtrantmpcountB
+% But, TeX doesn't have floating point division, so we have to use integer
+% division. Hence the use of the counters.
+% We need to reduce the denominator so that the loss of the remainder will
+% have minimal affect on the accuracy of the result
+\divide\@IEEEtrantmpcountB by 200%
+\divide\@IEEEtrantmpcountA by \@IEEEtrantmpcountB%
+% Then reequalize things when we use TeX's ability to multiply by
+% floating point values
+\@IEEEtrantmpdimenB=0.005\@IEEEtrantmpdimenA%
+\multiply\@IEEEtrantmpdimenB by \@IEEEtrantmpcountA%
+% \@IEEEPARstartfont is globaly set to the calculated font of the big letter
+% We need to carry this out of the local calculation area to to create the
+% big letter.
+\global\font\@IEEEPARstartfont\@IEEEPARstartFONTNAME\space at \@IEEEtrantmpdimenB%
+% Now set \@IEEEtrantmpdimenA to the width of the big letter
+% We need to carry this out of the local calculation area to set the
+% hanging indent
+\settowidth{\global\@IEEEtrantmpdimenA}{\@IEEEPARstartfont
+\@IEEEPARstartCAPSTYLE{#1\@IEEEPARstartITLCORRECT}}}%
+% end of the isolated calculation environment
+% add in the extra clearance we want
+\advance\@IEEEtrantmpdimenA by \@IEEEPARstartSEP\relax%
+% add in the optional offset
+\advance\@IEEEtrantmpdimenA by \@IEEEPARstartHOFFSET\relax%
+% V1.7 don't allow negative offsets to produce negative hanging indents
+\@IEEEtrantmpdimenB\@IEEEtrantmpdimenA
+\ifnum\@IEEEtrantmpdimenB < 0 \@IEEEtrantmpdimenB 0pt\fi
+% \@IEEEtrantmpdimenA has the width of the big letter plus the
+% separation space and \@IEEEPARstartfont is the font we need to use
+% Now, we make the letter and issue the hanging indent command
+% The letter is placed in a box of zero width and height so that other
+% text won't be displaced by it.
+\hangindent\@IEEEtrantmpdimenB\hangafter=-\@IEEEPARstartDROPLINES%
+\makebox[0pt][l]{\hspace{-\@IEEEtrantmpdimenA}%
+\raisebox{-\@IEEEPARstartDROPDEPTH}[0pt][0pt]{\hspace{\@IEEEPARstartHOFFSET}%
+\@IEEEPARstartfont\@IEEEPARstartCAPSTYLE{#1\@IEEEPARstartITLCORRECT}%
+\hspace{\@IEEEPARstartSEP}}}%
+{\@IEEEPARstartWORDFONTSTYLE{\@IEEEPARstartWORDCAPSTYLE{\selectfont#2}}}}
+
+
+
+
+
+
+% determines if the space remaining on a given page is equal to or greater
+% than the specified space of argument one
+% if not, execute argument two (only if the remaining space is greater than zero)
+% and issue a \newpage
+% 
+% example: \@IEEEtranneedspace{2in}{\vfill}
+% 
+% Does not take into consideration rubber shrinkage, so it tends to
+% be overly cautious
+% Based on an example posted by Donald Arseneau
+% Note this macro uses \@IEEEtrantmpdimenB internally for calculations,
+% so DO NOT PASS \@IEEEtrantmpdimenB to this routine
+% if you need a dimen register, import with \@IEEEtrantmpdimenA instead
+\def\@IEEEtranneedspace#1#2{\penalty-100\begingroup%shield temp variable
+\@IEEEtrantmpdimenB\pagegoal\advance\@IEEEtrantmpdimenB-\pagetotal% space left
+\ifdim #1>\@IEEEtrantmpdimenB\relax% not enough space left
+\ifdim\@IEEEtrantmpdimenB>\z@\relax #2\fi%
+\newpage%
+\fi\endgroup}
+
+
+
+% IEEEbiography ENVIRONMENT
+% Allows user to enter biography leaving place for picture (adapts to font size)
+% As of V1.5, a new optional argument allows you to have a real graphic!
+% V1.5 and later also fixes the "colliding biographies" which could happen when a 
+% biography's text was shorter than the space for the photo.
+% MDS 7/2001
+% V1.6 prevent multiple biographies from making multiple TOC entries
+\newif\if@IEEEbiographyTOCentrynotmade
+\global\@IEEEbiographyTOCentrynotmadetrue
+
+% biography counter so hyperref can jump directly to the biographies
+% and not just the previous section
+\newcounter{IEEEbiography}
+\setcounter{IEEEbiography}{0}
+
+% photo area size
+\def\@IEEEBIOphotowidth{1.0in}    % width of the biography photo area
+\def\@IEEEBIOphotodepth{1.25in}   % depth (height) of the biography photo area
+% area cleared for photo
+\def\@IEEEBIOhangwidth{1.14in}    % width cleared for the biography photo area
+\def\@IEEEBIOhangdepth{1.25in}    % depth cleared for the biography photo area
+                                  % actual depth will be a multiple of 
+                                  % \baselineskip, rounded up
+\def\@IEEEBIOskipN{4\baselineskip}% nominal value of the vskip above the biography
+
+\newenvironment{IEEEbiography}[2][]{\normalfont\@IEEEcompsoconly{\sffamily}\footnotesize%
+\unitlength 1in\parskip=0pt\par\parindent 1em\interlinepenalty500%
+% we need enough space to support the hanging indent
+% the nominal value of the spacer
+% and one extra line for good measure
+\@IEEEtrantmpdimenA=\@IEEEBIOhangdepth%
+\advance\@IEEEtrantmpdimenA by \@IEEEBIOskipN%
+\advance\@IEEEtrantmpdimenA by 1\baselineskip%
+% if this page does not have enough space, break it and lets start
+% with a new one
+\@IEEEtranneedspace{\@IEEEtrantmpdimenA}{\relax}%
+% nominal spacer can strech, not shrink use 1fil so user can out stretch with \vfill
+\vskip \@IEEEBIOskipN plus 1fil minus 0\baselineskip%
+% the default box for where the photo goes
+\def\@IEEEtempbiographybox{{\setlength{\fboxsep}{0pt}\framebox{%
+\begin{minipage}[b][\@IEEEBIOphotodepth][c]{\@IEEEBIOphotowidth}\centering PLACE\\ PHOTO\\ HERE \end{minipage}}}}%
+%
+% detect if the optional argument was supplied, this requires the
+% \@ifmtarg command as defined in the appendix section above
+% and if so, override the default box with what they want
+\@ifmtarg{#1}{\relax}{\def\@IEEEtempbiographybox{\mbox{\begin{minipage}[b][\@IEEEBIOphotodepth][c]{\@IEEEBIOphotowidth}%
+\centering%
+#1%
+\end{minipage}}}}% end if optional argument supplied
+% Make an entry into the table of contents only if we have not done so before
+\if@IEEEbiographyTOCentrynotmade%
+% link labels to the biography counter so hyperref will jump
+% to the biography, not the previous section
+\setcounter{IEEEbiography}{-1}%
+\refstepcounter{IEEEbiography}%
+\addcontentsline{toc}{section}{Biographies}%
+\global\@IEEEbiographyTOCentrynotmadefalse%
+\fi%
+% one more biography
+\refstepcounter{IEEEbiography}%
+% Make an entry for this name into the table of contents 
+\addcontentsline{toc}{subsection}{#2}%
+% V1.6 properly handle if a new paragraph should occur while the
+% hanging indent is still active. Do this by redefining \par so
+% that it will not start a new paragraph. (But it will appear to the
+% user as if it did.) Also, strip any leading pars, newlines, or spaces.
+\let\@IEEEBIOORGparCMD=\par% save the original \par command
+\edef\par{\hfil\break\indent}% the new \par will not be a "real" \par
+\settoheight{\@IEEEtrantmpdimenA}{\@IEEEtempbiographybox}% get height of biography box
+\@IEEEtrantmpdimenB=\@IEEEBIOhangdepth%
+\@IEEEtrantmpcountA=\@IEEEtrantmpdimenB% countA has the hang depth
+\divide\@IEEEtrantmpcountA by \baselineskip%  calculates lines needed to produce the hang depth
+\advance\@IEEEtrantmpcountA by 1% ensure we overestimate
+% set the hanging indent
+\hangindent\@IEEEBIOhangwidth%
+\hangafter-\@IEEEtrantmpcountA%
+% reference the top of the photo area to the top of a capital T
+\settoheight{\@IEEEtrantmpdimenB}{\mbox{T}}%
+% set the photo box, give it zero width and height so as not to disturb anything
+\noindent\makebox[0pt][l]{\hspace{-\@IEEEBIOhangwidth}\raisebox{\@IEEEtrantmpdimenB}[0pt][0pt]{%
+\raisebox{-\@IEEEBIOphotodepth}[0pt][0pt]{\@IEEEtempbiographybox}}}%
+% now place the author name and begin the bio text
+\noindent\textbf{#2\ }\@IEEEgobbleleadPARNLSP}{\relax\let\par=\@IEEEBIOORGparCMD\par%
+% 7/2001 V1.5 detect when the biography text is shorter than the photo area
+% and pad the unused area - preventing a collision from the next biography entry
+% MDS
+\ifnum \prevgraf <\@IEEEtrantmpcountA\relax% detect when the biography text is shorter than the photo
+    \advance\@IEEEtrantmpcountA by -\prevgraf% calculate how many lines we need to pad
+    \advance\@IEEEtrantmpcountA by -1\relax% we compensate for the fact that we indented an extra line
+    \@IEEEtrantmpdimenA=\baselineskip% calculate the length of the padding
+    \multiply\@IEEEtrantmpdimenA by \@IEEEtrantmpcountA%
+    \noindent\rule{0pt}{\@IEEEtrantmpdimenA}% insert an invisible support strut
+\fi%
+\par\normalfont}
+
+
+
+% V1.6
+% added biography without a photo environment
+\newenvironment{IEEEbiographynophoto}[1]{%
+% Make an entry into the table of contents only if we have not done so before
+\if@IEEEbiographyTOCentrynotmade%
+% link labels to the biography counter so hyperref will jump
+% to the biography, not the previous section
+\setcounter{IEEEbiography}{-1}%
+\refstepcounter{IEEEbiography}%
+\addcontentsline{toc}{section}{Biographies}%
+\global\@IEEEbiographyTOCentrynotmadefalse%
+\fi%
+% one more biography
+\refstepcounter{IEEEbiography}%
+% Make an entry for this name into the table of contents 
+\addcontentsline{toc}{subsection}{#1}%
+\normalfont\@IEEEcompsoconly{\sffamily}\footnotesize\interlinepenalty500%
+\vskip 4\baselineskip plus 1fil minus 0\baselineskip%
+\parskip=0pt\par%
+\noindent\textbf{#1\ }\@IEEEgobbleleadPARNLSP}{\relax\par\normalfont}
+
+
+% provide the user with some old font commands
+% got this from article.cls
+\DeclareOldFontCommand{\rm}{\normalfont\rmfamily}{\mathrm}
+\DeclareOldFontCommand{\sf}{\normalfont\sffamily}{\mathsf}
+\DeclareOldFontCommand{\tt}{\normalfont\ttfamily}{\mathtt}
+\DeclareOldFontCommand{\bf}{\normalfont\bfseries}{\mathbf}
+\DeclareOldFontCommand{\it}{\normalfont\itshape}{\mathit}
+\DeclareOldFontCommand{\sl}{\normalfont\slshape}{\@nomath\sl}
+\DeclareOldFontCommand{\sc}{\normalfont\scshape}{\@nomath\sc}
+\DeclareRobustCommand*\cal{\@fontswitch\relax\mathcal}
+\DeclareRobustCommand*\mit{\@fontswitch\relax\mathnormal}
+
+
+% SPECIAL PAPER NOTICE COMMANDS
+% 
+% holds the special notice text
+\def\@IEEEspecialpapernotice{\relax}
+ 
+% for special papers, like invited papers, the user can do:
+% \IEEEspecialpapernotice{(Invited Paper)} before \maketitle
+\def\IEEEspecialpapernotice#1{\ifCLASSOPTIONconference%
+\def\@IEEEspecialpapernotice{{\Large#1\vspace*{1em}}}%
+\else%
+\def\@IEEEspecialpapernotice{{\\*[1.5ex]\sublargesize\textit{#1}}\vspace*{-2ex}}%
+\fi}
+
+
+
+
+% PUBLISHER ID COMMANDS
+% to insert a publisher's ID footer
+% V1.6 \IEEEpubid has been changed so that the change in page size and style
+% occurs in \maketitle. \IEEEpubid must now be issued prior to \maketitle
+% use \IEEEpubidadjcol as before - in the second column of the title page
+% These changes allow \maketitle to take the reduced page height into
+% consideration when dynamically setting the space between the author 
+% names and the maintext.
+%
+% the amount the main text is pulled up to make room for the
+% publisher's ID footer
+% IEEE uses about 1.3\baselineskip for journals, 
+% dynamic title spacing will clean up the fraction
+\def\@IEEEpubidpullup{1.3\baselineskip}
+\ifCLASSOPTIONtechnote
+% for technotes it must be an integer of baselineskip as there can be no
+% dynamic title spacing for two column mode technotes (the title is in the
+% in first column) and we should maintain an integer number of lines in the
+% second column
+% There are some examples (such as older issues of "Transactions on
+% Information Theory") in which IEEE really pulls the text off the ID for
+% technotes - about 0.55in (or 4\baselineskip). We'll use 2\baselineskip
+% and call it even.
+\def\@IEEEpubidpullup{2\baselineskip}
+\fi
+
+% V1.7 compsoc does not use a pullup
+\ifCLASSOPTIONcompsoc
+\def\@IEEEpubidpullup{0pt}
+\fi
+
+% holds the ID text
+\def\@IEEEpubid{\relax}
+
+% flag so \maketitle can tell if \IEEEpubid was called
+\newif\if@IEEEusingpubid
+\global\@IEEEusingpubidfalse
+% issue this command in the page to have the ID at the bottom
+% V1.6 use before \maketitle
+\def\IEEEpubid#1{\def\@IEEEpubid{#1}\global\@IEEEusingpubidtrue}
+
+
+% command which will pull up (shorten) the column it is executed in
+% to make room for the publisher ID. Place in the second column of
+% the title page when using \IEEEpubid
+% Is smart enough not to do anything when in single column text or
+% if the user hasn't called \IEEEpubid
+% currently needed in for the second column of a page with the
+% publisher ID. If not needed in future releases, please provide this
+% command and define it as \relax for backward compatibility
+% v1.6b do not allow command to operate if the peer review option has been 
+% selected because \IEEEpubidadjcol will not be on the cover page.
+% V1.7 do nothing if compsoc
+\def\IEEEpubidadjcol{\ifCLASSOPTIONcompsoc\else\ifCLASSOPTIONpeerreview\else
+\if@twocolumn\if@IEEEusingpubid\enlargethispage{-\@IEEEpubidpullup}\fi\fi\fi\fi}
+
+% Special thanks to Peter Wilson, Daniel Luecking, and the other
+% gurus at comp.text.tex, for helping me to understand how best to
+% implement the IEEEpubid command in LaTeX.
+
+
+
+%% Lockout some commands under various conditions
+
+% general purpose bit bucket
+\newsavebox{\@IEEEtranrubishbin}
+
+% flags to prevent multiple warning messages
+\newif\if@IEEEWARNthanks
+\newif\if@IEEEWARNIEEEPARstart
+\newif\if@IEEEWARNIEEEbiography
+\newif\if@IEEEWARNIEEEbiographynophoto
+\newif\if@IEEEWARNIEEEpubid
+\newif\if@IEEEWARNIEEEpubidadjcol
+\newif\if@IEEEWARNIEEEmembership
+\newif\if@IEEEWARNIEEEaftertitletext
+\@IEEEWARNthankstrue
+\@IEEEWARNIEEEPARstarttrue
+\@IEEEWARNIEEEbiographytrue
+\@IEEEWARNIEEEbiographynophototrue
+\@IEEEWARNIEEEpubidtrue
+\@IEEEWARNIEEEpubidadjcoltrue
+\@IEEEWARNIEEEmembershiptrue
+\@IEEEWARNIEEEaftertitletexttrue
+
+
+%% Lockout some commands when in various modes, but allow them to be restored if needed
+%%
+% save commands which might be locked out
+% so that the user can later restore them if needed
+\let\@IEEESAVECMDthanks\thanks
+\let\@IEEESAVECMDIEEEPARstart\IEEEPARstart
+\let\@IEEESAVECMDIEEEbiography\IEEEbiography
+\let\@IEEESAVECMDendIEEEbiography\endIEEEbiography
+\let\@IEEESAVECMDIEEEbiographynophoto\IEEEbiographynophoto
+\let\@IEEESAVECMDendIEEEbiographynophoto\endIEEEbiographynophoto
+\let\@IEEESAVECMDIEEEpubid\IEEEpubid
+\let\@IEEESAVECMDIEEEpubidadjcol\IEEEpubidadjcol
+\let\@IEEESAVECMDIEEEmembership\IEEEmembership
+\let\@IEEESAVECMDIEEEaftertitletext\IEEEaftertitletext
+
+
+% disable \IEEEPARstart when in draft mode
+% This may have originally been done because the pre-V1.6 drop letter
+% algorithm had problems with a non-unity baselinestretch
+% At any rate, it seems too formal to have a drop letter in a draft
+% paper.
+\ifCLASSOPTIONdraftcls
+\def\IEEEPARstart#1#2{#1#2\if@IEEEWARNIEEEPARstart\typeout{** ATTENTION: \noexpand\IEEEPARstart
+ is disabled in draft mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEPARstartfalse}
+\fi
+% and for technotes
+\ifCLASSOPTIONtechnote
+\def\IEEEPARstart#1#2{#1#2\if@IEEEWARNIEEEPARstart\typeout{** WARNING: \noexpand\IEEEPARstart
+ is locked out for technotes (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEPARstartfalse}
+\fi
+
+
+% lockout unneeded commands when in conference mode
+\ifCLASSOPTIONconference
+% when locked out, \thanks, \IEEEbiography, \IEEEbiographynophoto, \IEEEpubid,
+% \IEEEmembership and \IEEEaftertitletext will all swallow their given text. 
+% \IEEEPARstart will output a normal character instead
+% warn the user about these commands only once to prevent the console screen
+% from filling up with redundant messages
+\def\thanks#1{\if@IEEEWARNthanks\typeout{** WARNING: \noexpand\thanks
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNthanksfalse}
+\def\IEEEPARstart#1#2{#1#2\if@IEEEWARNIEEEPARstart\typeout{** WARNING: \noexpand\IEEEPARstart
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEPARstartfalse}
+
+
+% LaTeX treats environments and commands with optional arguments differently.
+% the actual ("internal") command is stored as \\commandname 
+% (accessed via \csname\string\commandname\endcsname )
+% the "external" command \commandname is a macro with code to determine
+% whether or not the optional argument is presented and to provide the 
+% default if it is absent. So, in order to save and restore such a command
+% we would have to save and restore \\commandname as well. But, if LaTeX
+% ever changes the way it names the internal names, the trick would break.
+% Instead let us just define a new environment so that the internal
+% name can be left undisturbed.
+\newenvironment{@IEEEbogusbiography}[2][]{\if@IEEEWARNIEEEbiography\typeout{** WARNING: \noexpand\IEEEbiography
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEbiographyfalse%
+\setbox\@IEEEtranrubishbin\vbox\bgroup}{\egroup\relax}
+% and make biography point to our bogus biography
+\let\IEEEbiography=\@IEEEbogusbiography
+\let\endIEEEbiography=\end@IEEEbogusbiography
+
+\renewenvironment{IEEEbiographynophoto}[1]{\if@IEEEWARNIEEEbiographynophoto\typeout{** WARNING: \noexpand\IEEEbiographynophoto
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEbiographynophotofalse%
+\setbox\@IEEEtranrubishbin\vbox\bgroup}{\egroup\relax}
+
+\def\IEEEpubid#1{\if@IEEEWARNIEEEpubid\typeout{** WARNING: \noexpand\IEEEpubid 
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEpubidfalse}
+\def\IEEEpubidadjcol{\if@IEEEWARNIEEEpubidadjcol\typeout{** WARNING: \noexpand\IEEEpubidadjcol
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEpubidadjcolfalse}
+\def\IEEEmembership#1{\if@IEEEWARNIEEEmembership\typeout{** WARNING: \noexpand\IEEEmembership
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEmembershipfalse}
+\def\IEEEaftertitletext#1{\if@IEEEWARNIEEEaftertitletext\typeout{** WARNING: \noexpand\IEEEaftertitletext
+ is locked out when in conference mode (line \the\inputlineno).}\fi\global\@IEEEWARNIEEEaftertitletextfalse}
+\fi
+
+
+% provide a way to restore the commands that are locked out
+\def\IEEEoverridecommandlockouts{%
+\typeout{** ATTENTION: Overriding command lockouts (line \the\inputlineno).}%
+\let\thanks\@IEEESAVECMDthanks%
+\let\IEEEPARstart\@IEEESAVECMDIEEEPARstart%
+\let\IEEEbiography\@IEEESAVECMDIEEEbiography%
+\let\endIEEEbiography\@IEEESAVECMDendIEEEbiography%
+\let\IEEEbiographynophoto\@IEEESAVECMDIEEEbiographynophoto%
+\let\endIEEEbiographynophoto\@IEEESAVECMDendIEEEbiographynophoto%
+\let\IEEEpubid\@IEEESAVECMDIEEEpubid%
+\let\IEEEpubidadjcol\@IEEESAVECMDIEEEpubidadjcol%
+\let\IEEEmembership\@IEEESAVECMDIEEEmembership%
+\let\IEEEaftertitletext\@IEEESAVECMDIEEEaftertitletext}
+
+
+
+% need a backslash character for typeout output
+{\catcode`\|=0 \catcode`\\=12
+|xdef|@IEEEbackslash{\}}
+
+
+% hook to allow easy disabling of all legacy warnings
+\def\@IEEElegacywarn#1#2{\typeout{** ATTENTION: \@IEEEbackslash #1 is deprecated (line \the\inputlineno).
+Use \@IEEEbackslash #2 instead.}}
+
+
+% provide for legacy commands
+\def\authorblockA{\@IEEElegacywarn{authorblockA}{IEEEauthorblockA}\IEEEauthorblockA}
+\def\authorblockN{\@IEEElegacywarn{authorblockN}{IEEEauthorblockN}\IEEEauthorblockN}
+\def\authorrefmark{\@IEEElegacywarn{authorrefmark}{IEEEauthorrefmark}\IEEEauthorrefmark}
+\def\PARstart{\@IEEElegacywarn{PARstart}{IEEEPARstart}\IEEEPARstart}
+\def\pubid{\@IEEElegacywarn{pubid}{IEEEpubid}\IEEEpubid}
+\def\pubidadjcol{\@IEEElegacywarn{pubidadjcol}{IEEEpubidadjcol}\IEEEpubidadjcol}
+\def\QED{\@IEEElegacywarn{QED}{IEEEQED}\IEEEQED}
+\def\QEDclosed{\@IEEElegacywarn{QEDclosed}{IEEEQEDclosed}\IEEEQEDclosed}
+\def\QEDopen{\@IEEElegacywarn{QEDopen}{IEEEQEDopen}\IEEEQEDopen}
+\def\specialpapernotice{\@IEEElegacywarn{specialpapernotice}{IEEEspecialpapernotice}\IEEEspecialpapernotice}
+
+
+
+% provide for legacy environments
+\def\biography{\@IEEElegacywarn{biography}{IEEEbiography}\IEEEbiography}
+\def\biographynophoto{\@IEEElegacywarn{biographynophoto}{IEEEbiographynophoto}\IEEEbiographynophoto}
+\def\keywords{\@IEEElegacywarn{keywords}{IEEEkeywords}\IEEEkeywords}
+\def\endbiography{\endIEEEbiography}
+\def\endbiographynophoto{\endIEEEbiographynophoto}
+\def\endkeywords{\endIEEEkeywords}
+
+
+% provide for legacy IED commands/lengths when possible
+\let\labelindent\IEEElabelindent
+\def\calcleftmargin{\@IEEElegacywarn{calcleftmargin}{IEEEcalcleftmargin}\IEEEcalcleftmargin}
+\def\setlabelwidth{\@IEEElegacywarn{setlabelwidth}{IEEEsetlabelwidth}\IEEEsetlabelwidth}
+\def\usemathlabelsep{\@IEEElegacywarn{usemathlabelsep}{IEEEusemathlabelsep}\IEEEusemathlabelsep}
+\def\iedlabeljustifyc{\@IEEElegacywarn{iedlabeljustifyc}{IEEEiedlabeljustifyc}\IEEEiedlabeljustifyc}
+\def\iedlabeljustifyl{\@IEEElegacywarn{iedlabeljustifyl}{IEEEiedlabeljustifyl}\IEEEiedlabeljustifyl}
+\def\iedlabeljustifyr{\@IEEElegacywarn{iedlabeljustifyr}{IEEEiedlabeljustifyr}\IEEEiedlabeljustifyr}
+
+
+
+% let \proof use the IEEEtran version even after amsthm is loaded
+% \proof is now deprecated in favor of \IEEEproof
+\AtBeginDocument{\def\proof{\@IEEElegacywarn{proof}{IEEEproof}\IEEEproof}\def\endproof{\endIEEEproof}}
+
+% V1.7 \overrideIEEEmargins is no longer supported.
+\def\overrideIEEEmargins{%
+\typeout{** WARNING: \string\overrideIEEEmargins \space no longer supported (line \the\inputlineno).}%
+\typeout{** Use the \string\CLASSINPUTinnersidemargin, \string\CLASSINPUToutersidemargin \space controls instead.}}
+
+
+\endinput
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%% End of IEEEtran.cls  %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% That's all folks!
+

--- a/ieee/IEEEtranS.bst
+++ b/ieee/IEEEtranS.bst
@@ -1,0 +1,2607 @@
+%%
+%% IEEEtranS.bst
+%% BibTeX Bibliography Style file
+%% Sorting version of IEEEtran.bst
+%% *** Not for normal IEEE work ***
+%% Version 1.12 (2007/01/11)
+%% 
+%% Copyright (c) 2003-2007 Michael Shell
+%% 
+%% Original starting code base and algorithms obtained from the output of
+%% Patrick W. Daly's makebst package as well as from prior versions of
+%% IEEE BibTeX styles:
+%% 
+%% 1. Howard Trickey and Oren Patashnik's ieeetr.bst  (1985/1988)
+%% 2. Silvano Balemi and Richard H. Roy's IEEEbib.bst (1993)
+%% 
+%% Added sorting code is from plain.bst.
+%% 
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and/or
+%% http://www.ieee.org/
+%% 
+%% For use with BibTeX version 0.99a or later
+%%
+%% This is a numerical citation style.
+%% 
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEabrv.bib, IEEEfull.bib, IEEEexample.bib,
+%%                    IEEEtran.bst, IEEEtranS.bst, IEEEtranSA.bst,
+%%                    IEEEtranN.bst, IEEEtranSN.bst, IEEEtran_bst_HOWTO.pdf
+%%*************************************************************************
+%
+%
+% Changelog:
+%
+% 1.10 (2002/09/27) Initial release
+%
+% 1.11 (2003/04/02)
+%  1. Fixed bug with URLs containing underscores when using url.sty. Thanks
+%     to Ming Kin Lai for reporting this.
+%
+% 1.12 (2007/01/11)
+%  1. Fixed bug with unwanted comma before "et al." when an entry contained
+%     more than two author names. Thanks to Pallav Gupta for reporting this.
+%  2. Fixed bug with anomalous closing quote in tech reports that have a
+%     type, but without a number or address. Thanks to Mehrdad Mirreza for
+%     reporting this.
+%  3. Use braces in \providecommand in begin.bib to better support
+%     latex2html. TeX style length assignments OK with recent versions
+%     of latex2html - 1.71 (2002/2/1) or later is strongly recommended.
+%     Use of the language field still causes trouble with latex2html.
+%     Thanks to Federico Beffa for reporting this.
+%  4. Added IEEEtran.bst ID and version comment string to .bbl output.
+%  5. Provide a \BIBdecl hook that allows the user to execute commands
+%     just prior to the first entry.
+%  6. Use default urlstyle (is using url.sty) of "same" rather than rm to
+%     better work with a wider variety of bibliography styles.
+%  7. Changed month abbreviations from Sept., July and June to Sep., Jul.,
+%     and Jun., respectively, as IEEE now does. Thanks to Moritz Borgmann
+%     for reporting this.
+%  8. Control entry types should not be considered when calculating longest
+%     label width.
+%  9. Added alias www for electronic/online.
+% 10. Added CTLname_url_prefix control entry type.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% DEFAULTS FOR THE CONTROLS OF THE BST STYLE %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% These are the defaults for the user adjustable controls. The values used
+% here can be overridden by the user via IEEEtranBSTCTL entry type.
+
+% NOTE: The recommended LaTeX command to invoke a control entry type is:
+% 
+%\makeatletter
+%\def\bstctlcite{\@ifnextchar[{\@bstctlcite}{\@bstctlcite[@auxout]}}
+%\def\@bstctlcite[#1]#2{\@bsphack
+%  \@for\@citeb:=#2\do{%
+%    \edef\@citeb{\expandafter\@firstofone\@citeb}%
+%    \if@filesw\immediate\write\csname #1\endcsname{\string\citation{\@citeb}}\fi}%
+%  \@esphack}
+%\makeatother
+%
+% It is called at the start of the document, before the first \cite, like:
+% \bstctlcite{IEEEexample:BSTcontrol}
+%
+% IEEEtran.cls V1.6 and later does provide this command.
+
+
+
+% #0 turns off the display of the number for articles.
+% #1 enables
+FUNCTION {default.is.use.number.for.article} { #1 }
+
+
+% #0 turns off the display of the paper and type fields in @inproceedings.
+% #1 enables
+FUNCTION {default.is.use.paper} { #1 }
+
+
+% #0 turns off the forced use of "et al."
+% #1 enables
+FUNCTION {default.is.forced.et.al} { #0 }
+
+% The maximum number of names that can be present beyond which an "et al."
+% usage is forced. Be sure that num.names.shown.with.forced.et.al (below)
+% is not greater than this value!
+% Note: There are many instances of references in IEEE journals which have
+% a very large number of authors as well as instances in which "et al." is
+% used profusely.
+FUNCTION {default.max.num.names.before.forced.et.al} { #10 }
+
+% The number of names that will be shown with a forced "et al.".
+% Must be less than or equal to max.num.names.before.forced.et.al
+FUNCTION {default.num.names.shown.with.forced.et.al} { #1 }
+
+
+% #0 turns off the alternate interword spacing for entries with URLs.
+% #1 enables
+FUNCTION {default.is.use.alt.interword.spacing} { #1 }
+
+% If alternate interword spacing for entries with URLs is enabled, this is
+% the interword spacing stretch factor that will be used. For example, the
+% default "4" here means that the interword spacing in entries with URLs can
+% stretch to four times normal. Does not have to be an integer. Note that
+% the value specified here can be overridden by the user in their LaTeX
+% code via a command such as: 
+% "\providecommand\BIBentryALTinterwordstretchfactor{1.5}" in addition to
+% that via the IEEEtranBSTCTL entry type.
+FUNCTION {default.ALTinterwordstretchfactor} { "4" }
+
+
+% #0 turns off the "dashification" of repeated (i.e., identical to those
+% of the previous entry) names. IEEE normally does this.
+% #1 enables
+FUNCTION {default.is.dash.repeated.names} { #1 }
+
+
+% The default name format control string.
+FUNCTION {default.name.format.string}{ "{f.~}{vv~}{ll}{, jj}" }
+
+
+% The default LaTeX font command for the names.
+FUNCTION {default.name.latex.cmd}{ "" }
+
+
+% The default URL prefix.
+FUNCTION {default.name.url.prefix}{ "[Online]. Available:" }
+
+
+% Other controls that cannot be accessed via IEEEtranBSTCTL entry type.
+
+% #0 turns off the terminal startup banner/completed message so as to
+% operate more quietly.
+% #1 enables
+FUNCTION {is.print.banners.to.terminal} { #1 }
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% FILE VERSION AND BANNER %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION{bst.file.version} { "1.12" }
+FUNCTION{bst.file.date} { "2007/01/11" }
+FUNCTION{bst.file.website} { "http://www.michaelshell.org/tex/ieeetran/bibtex/" }
+
+FUNCTION {banner.message}
+{ is.print.banners.to.terminal
+     { "-- IEEEtranS.bst version" " " * bst.file.version *
+       " (" * bst.file.date * ") " * "by Michael Shell." *
+       top$
+       "-- " bst.file.website *
+       top$
+       "-- See the " quote$ * "IEEEtran_bst_HOWTO.pdf" * quote$ * " manual for usage information." *
+       top$
+       "** Sorting version - not for normal IEEE work."
+       top$
+     }
+     { skip$ }
+   if$
+}
+
+FUNCTION {completed.message}
+{ is.print.banners.to.terminal
+     { ""
+       top$
+       "Done."
+       top$
+     }
+     { skip$ }
+   if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% STRING CONSTANTS %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {bbl.and}{ "and" }
+FUNCTION {bbl.etal}{ "et~al." }
+FUNCTION {bbl.editors}{ "eds." }
+FUNCTION {bbl.editor}{ "ed." }
+FUNCTION {bbl.edition}{ "ed." }
+FUNCTION {bbl.volume}{ "vol." }
+FUNCTION {bbl.of}{ "of" }
+FUNCTION {bbl.number}{ "no." }
+FUNCTION {bbl.in}{ "in" }
+FUNCTION {bbl.pages}{ "pp." }
+FUNCTION {bbl.page}{ "p." }
+FUNCTION {bbl.chapter}{ "ch." }
+FUNCTION {bbl.paper}{ "paper" }
+FUNCTION {bbl.part}{ "pt." }
+FUNCTION {bbl.patent}{ "Patent" }
+FUNCTION {bbl.patentUS}{ "U.S." }
+FUNCTION {bbl.revision}{ "Rev." }
+FUNCTION {bbl.series}{ "ser." }
+FUNCTION {bbl.standard}{ "Std." }
+FUNCTION {bbl.techrep}{ "Tech. Rep." }
+FUNCTION {bbl.mthesis}{ "Master's thesis" }
+FUNCTION {bbl.phdthesis}{ "Ph.D. dissertation" }
+FUNCTION {bbl.st}{ "st" }
+FUNCTION {bbl.nd}{ "nd" }
+FUNCTION {bbl.rd}{ "rd" }
+FUNCTION {bbl.th}{ "th" }
+
+
+% This is the LaTeX spacer that is used when a larger than normal space
+% is called for (such as just before the address:publisher).
+FUNCTION {large.space} { "\hskip 1em plus 0.5em minus 0.4em\relax " }
+
+% The LaTeX code for dashes that are used to represent repeated names.
+% Note: Some older IEEE journals used something like
+% "\rule{0.275in}{0.5pt}\," which is fairly thick and runs right along
+% the baseline. However, IEEE now uses a thinner, above baseline,
+% six dash long sequence.
+FUNCTION {repeated.name.dashes} { "------" }
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% PREDEFINED STRING MACROS %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+MACRO {jan} {"Jan."}
+MACRO {feb} {"Feb."}
+MACRO {mar} {"Mar."}
+MACRO {apr} {"Apr."}
+MACRO {may} {"May"}
+MACRO {jun} {"Jun."}
+MACRO {jul} {"Jul."}
+MACRO {aug} {"Aug."}
+MACRO {sep} {"Sep."}
+MACRO {oct} {"Oct."}
+MACRO {nov} {"Nov."}
+MACRO {dec} {"Dec."}
+
+
+
+%%%%%%%%%%%%%%%%%%
+%% ENTRY FIELDS %%
+%%%%%%%%%%%%%%%%%%
+
+ENTRY
+  { address
+    assignee
+    author
+    booktitle
+    chapter
+    day
+    dayfiled
+    edition
+    editor
+    howpublished
+    institution
+    intype
+    journal
+    key
+    language
+    month
+    monthfiled
+    nationality
+    note
+    number
+    organization
+    pages
+    paper
+    publisher
+    school
+    series
+    revision
+    title
+    type
+    url
+    volume
+    year
+    yearfiled
+    CTLuse_article_number
+    CTLuse_paper
+    CTLuse_forced_etal
+    CTLmax_names_forced_etal
+    CTLnames_show_etal
+    CTLuse_alt_spacing
+    CTLalt_stretch_factor
+    CTLdash_repeated_names
+    CTLname_format_string
+    CTLname_latex_cmd
+    CTLname_url_prefix
+  }
+  {}
+  { label }
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%
+%% INTEGER VARIABLES %%
+%%%%%%%%%%%%%%%%%%%%%%%
+
+INTEGERS { prev.status.punct this.status.punct punct.std
+           punct.no punct.comma punct.period 
+           prev.status.space this.status.space space.std
+           space.no space.normal space.large
+           prev.status.quote this.status.quote quote.std
+           quote.no quote.close
+           prev.status.nline this.status.nline nline.std
+           nline.no nline.newblock 
+           status.cap cap.std
+           cap.no cap.yes}
+
+INTEGERS { longest.label.width multiresult nameptr namesleft number.label numnames }
+
+INTEGERS { is.use.number.for.article
+           is.use.paper
+           is.forced.et.al
+           max.num.names.before.forced.et.al
+           num.names.shown.with.forced.et.al
+           is.use.alt.interword.spacing
+           is.dash.repeated.names}
+
+
+%%%%%%%%%%%%%%%%%%%%%%
+%% STRING VARIABLES %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+STRINGS { bibinfo
+          longest.label
+          oldname
+          s
+          t
+          ALTinterwordstretchfactor
+          name.format.string
+          name.latex.cmd
+          name.url.prefix}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%
+%% LOW LEVEL FUNCTIONS %%
+%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {initialize.controls}
+{ default.is.use.number.for.article 'is.use.number.for.article :=
+  default.is.use.paper 'is.use.paper :=
+  default.is.forced.et.al 'is.forced.et.al :=
+  default.max.num.names.before.forced.et.al 'max.num.names.before.forced.et.al :=
+  default.num.names.shown.with.forced.et.al 'num.names.shown.with.forced.et.al :=
+  default.is.use.alt.interword.spacing 'is.use.alt.interword.spacing :=
+  default.is.dash.repeated.names 'is.dash.repeated.names :=
+  default.ALTinterwordstretchfactor 'ALTinterwordstretchfactor :=
+  default.name.format.string 'name.format.string :=
+  default.name.latex.cmd 'name.latex.cmd :=
+  default.name.url.prefix 'name.url.prefix :=
+}
+
+
+% This IEEEtran.bst features a very powerful and flexible mechanism for
+% controlling the capitalization, punctuation, spacing, quotation, and
+% newlines of the formatted entry fields. (Note: IEEEtran.bst does not need
+% or use the newline/newblock feature, but it has been implemented for
+% possible future use.) The output states of IEEEtran.bst consist of
+% multiple independent attributes and, as such, can be thought of as being
+% vectors, rather than the simple scalar values ("before.all", 
+% "mid.sentence", etc.) used in most other .bst files.
+% 
+% The more flexible and complex design used here was motivated in part by
+% IEEE's rather unusual bibliography style. For example, IEEE ends the
+% previous field item with a period and large space prior to the publisher
+% address; the @electronic entry types use periods as inter-item punctuation
+% rather than the commas used by the other entry types; and URLs are never
+% followed by periods even though they are the last item in the entry.
+% Although it is possible to accommodate these features with the conventional
+% output state system, the seemingly endless exceptions make for convoluted,
+% unreliable and difficult to maintain code.
+%
+% IEEEtran.bst's output state system can be easily understood via a simple
+% illustration of two most recently formatted entry fields (on the stack):
+%
+%               CURRENT_ITEM
+%               "PREVIOUS_ITEM
+%
+% which, in this example, is to eventually appear in the bibliography as:
+% 
+%               "PREVIOUS_ITEM," CURRENT_ITEM
+%
+% It is the job of the output routine to take the previous item off of the
+% stack (while leaving the current item at the top of the stack), apply its
+% trailing punctuation (including closing quote marks) and spacing, and then
+% to write the result to BibTeX's output buffer:
+% 
+%               "PREVIOUS_ITEM," 
+% 
+% Punctuation (and spacing) between items is often determined by both of the
+% items rather than just the first one. The presence of quotation marks
+% further complicates the situation because, in standard English, trailing
+% punctuation marks are supposed to be contained within the quotes.
+% 
+% IEEEtran.bst maintains two output state (aka "status") vectors which
+% correspond to the previous and current (aka "this") items. Each vector
+% consists of several independent attributes which track punctuation,
+% spacing, quotation, and newlines. Capitalization status is handled by a
+% separate scalar because the format routines, not the output routine,
+% handle capitalization and, therefore, there is no need to maintain the
+% capitalization attribute for both the "previous" and "this" items.
+% 
+% When a format routine adds a new item, it copies the current output status
+% vector to the previous output status vector and (usually) resets the
+% current (this) output status vector to a "standard status" vector. Using a
+% "standard status" vector in this way allows us to redefine what we mean by
+% "standard status" at the start of each entry handler and reuse the same
+% format routines under the various inter-item separation schemes. For
+% example, the standard status vector for the @book entry type may use
+% commas for item separators, while the @electronic type may use periods,
+% yet both entry handlers exploit many of the exact same format routines.
+% 
+% Because format routines have write access to the output status vector of
+% the previous item, they can override the punctuation choices of the
+% previous format routine! Therefore, it becomes trivial to implement rules
+% such as "Always use a period and a large space before the publisher." By
+% pushing the generation of the closing quote mark to the output routine, we
+% avoid all the problems caused by having to close a quote before having all
+% the information required to determine what the punctuation should be.
+%
+% The IEEEtran.bst output state system can easily be expanded if needed.
+% For instance, it is easy to add a "space.tie" attribute value if the
+% bibliography rules mandate that two items have to be joined with an
+% unbreakable space. 
+
+FUNCTION {initialize.status.constants}
+{ #0 'punct.no :=
+  #1 'punct.comma :=
+  #2 'punct.period :=
+  #0 'space.no := 
+  #1 'space.normal :=
+  #2 'space.large :=
+  #0 'quote.no :=
+  #1 'quote.close :=
+  #0 'cap.no :=
+  #1 'cap.yes :=
+  #0 'nline.no :=
+  #1 'nline.newblock :=
+}
+
+FUNCTION {std.status.using.comma}
+{ punct.comma 'punct.std :=
+  space.normal 'space.std :=
+  quote.no 'quote.std :=
+  nline.no 'nline.std :=
+  cap.no 'cap.std :=
+}
+
+FUNCTION {std.status.using.period}
+{ punct.period 'punct.std :=
+  space.normal 'space.std :=
+  quote.no 'quote.std :=
+  nline.no 'nline.std :=
+  cap.yes 'cap.std :=
+}
+
+FUNCTION {initialize.prev.this.status}
+{ punct.no 'prev.status.punct :=
+  space.no 'prev.status.space :=
+  quote.no 'prev.status.quote :=
+  nline.no 'prev.status.nline :=
+  punct.no 'this.status.punct :=
+  space.no 'this.status.space :=
+  quote.no 'this.status.quote :=
+  nline.no 'this.status.nline :=
+  cap.yes 'status.cap :=
+}
+
+FUNCTION {this.status.std}
+{ punct.std 'this.status.punct :=
+  space.std 'this.status.space :=
+  quote.std 'this.status.quote :=
+  nline.std 'this.status.nline :=
+}
+
+FUNCTION {cap.status.std}{ cap.std 'status.cap := }
+
+FUNCTION {this.to.prev.status}
+{ this.status.punct 'prev.status.punct :=
+  this.status.space 'prev.status.space :=
+  this.status.quote 'prev.status.quote :=
+  this.status.nline 'prev.status.nline :=
+}
+
+
+FUNCTION {not}
+{   { #0 }
+    { #1 }
+  if$
+}
+
+FUNCTION {and}
+{   { skip$ }
+    { pop$ #0 }
+  if$
+}
+
+FUNCTION {or}
+{   { pop$ #1 }
+    { skip$ }
+  if$
+}
+
+
+% convert the strings "yes" or "no" to #1 or #0 respectively
+FUNCTION {yes.no.to.int}
+{ "l" change.case$ duplicate$
+    "yes" =
+    { pop$  #1 }
+    { duplicate$ "no" =
+        { pop$ #0 }
+        { "unknown boolean " quote$ * swap$ * quote$ *
+          " in " * cite$ * warning$
+          #0
+        }
+      if$
+    }
+  if$
+}
+
+
+% pushes true if the single char string on the stack is in the
+% range of "0" to "9"
+FUNCTION {is.num}
+{ chr.to.int$
+  duplicate$ "0" chr.to.int$ < not
+  swap$ "9" chr.to.int$ > not and
+}
+
+% multiplies the integer on the stack by a factor of 10
+FUNCTION {bump.int.mag}
+{ #0 'multiresult :=
+    { duplicate$ #0 > }
+    { #1 -
+      multiresult #10 +
+      'multiresult :=
+    }
+  while$
+pop$
+multiresult
+}
+
+% converts a single character string on the stack to an integer
+FUNCTION {char.to.integer}
+{ duplicate$ 
+  is.num
+    { chr.to.int$ "0" chr.to.int$ - }
+    {"noninteger character " quote$ * swap$ * quote$ *
+          " in integer field of " * cite$ * warning$
+    #0
+    }
+  if$
+}
+
+% converts a string on the stack to an integer
+FUNCTION {string.to.integer}
+{ duplicate$ text.length$ 'namesleft :=
+  #1 'nameptr :=
+  #0 'numnames :=
+    { nameptr namesleft > not }
+    { duplicate$ nameptr #1 substring$
+      char.to.integer numnames bump.int.mag +
+      'numnames :=
+      nameptr #1 +
+      'nameptr :=
+    }
+  while$
+pop$
+numnames
+}
+
+
+
+
+% The output routines write out the *next* to the top (previous) item on the
+% stack, adding punctuation and such as needed. Since IEEEtran.bst maintains
+% the output status for the top two items on the stack, these output
+% routines have to consider the previous output status (which corresponds to
+% the item that is being output). Full independent control of punctuation,
+% closing quote marks, spacing, and newblock is provided.
+% 
+% "output.nonnull" does not check for the presence of a previous empty
+% item.
+% 
+% "output" does check for the presence of a previous empty item and will
+% remove an empty item rather than outputing it.
+% 
+% "output.warn" is like "output", but will issue a warning if it detects
+% an empty item.
+
+FUNCTION {output.nonnull}
+{ swap$
+  prev.status.punct punct.comma =
+     { "," * }
+     { skip$ }
+   if$
+  prev.status.punct punct.period =
+     { add.period$ }
+     { skip$ }
+   if$ 
+  prev.status.quote quote.close =
+     { "''" * }
+     { skip$ }
+   if$
+  prev.status.space space.normal =
+     { " " * }
+     { skip$ }
+   if$
+  prev.status.space space.large =
+     { large.space * }
+     { skip$ }
+   if$
+  write$
+  prev.status.nline nline.newblock =
+     { newline$ "\newblock " write$ }
+     { skip$ }
+   if$
+}
+
+FUNCTION {output}
+{ duplicate$ empty$
+    'pop$
+    'output.nonnull
+  if$
+}
+
+FUNCTION {output.warn}
+{ 't :=
+  duplicate$ empty$
+    { pop$ "empty " t * " in " * cite$ * warning$ }
+    'output.nonnull
+  if$
+}
+
+% "fin.entry" is the output routine that handles the last item of the entry
+% (which will be on the top of the stack when "fin.entry" is called).
+
+FUNCTION {fin.entry}
+{ this.status.punct punct.no =
+     { skip$ }
+     { add.period$ }
+   if$
+   this.status.quote quote.close =
+     { "''" * }
+     { skip$ }
+   if$
+write$
+newline$
+}
+
+
+FUNCTION {is.last.char.not.punct}
+{ duplicate$
+   "}" * add.period$
+   #-1 #1 substring$ "." =
+}
+
+FUNCTION {is.multiple.pages}
+{ 't :=
+  #0 'multiresult :=
+    { multiresult not
+      t empty$ not
+      and
+    }
+    { t #1 #1 substring$
+      duplicate$ "-" =
+      swap$ duplicate$ "," =
+      swap$ "+" =
+      or or
+        { #1 'multiresult := }
+        { t #2 global.max$ substring$ 't := }
+      if$
+    }
+  while$
+  multiresult
+}
+
+FUNCTION {capitalize}{ "u" change.case$ "t" change.case$ }
+
+FUNCTION {emphasize}
+{ duplicate$ empty$
+    { pop$ "" }
+    { "\emph{" swap$ * "}" * }
+  if$
+}
+
+FUNCTION {do.name.latex.cmd}
+{ name.latex.cmd
+  empty$
+    { skip$ }
+    { name.latex.cmd "{" * swap$ * "}" * }
+  if$
+}
+
+% IEEEtran.bst uses its own \BIBforeignlanguage command which directly
+% invokes the TeX hyphenation patterns without the need of the Babel
+% package. Babel does a lot more than switch hyphenation patterns and
+% its loading can cause unintended effects in many class files (such as
+% IEEEtran.cls).
+FUNCTION {select.language}
+{ duplicate$ empty$ 'pop$
+    { language empty$ 'skip$
+        { "\BIBforeignlanguage{" language * "}{" * swap$ * "}" * }
+      if$
+    }
+  if$
+}
+
+FUNCTION {tie.or.space.prefix}
+{ duplicate$ text.length$ #3 <
+    { "~" }
+    { " " }
+  if$
+  swap$
+}
+
+FUNCTION {get.bbl.editor}
+{ editor num.names$ #1 > 'bbl.editors 'bbl.editor if$ }
+
+FUNCTION {space.word}{ " " swap$ * " " * }
+
+
+% Field Conditioners, Converters, Checkers and External Interfaces
+
+FUNCTION {empty.field.to.null.string}
+{ duplicate$ empty$
+    { pop$ "" }
+    { skip$ }
+  if$
+}
+
+FUNCTION {either.or.check}
+{ empty$
+    { pop$ }
+    { "can't use both " swap$ * " fields in " * cite$ * warning$ }
+  if$
+}
+
+FUNCTION {empty.entry.warn}
+{ author empty$ title empty$ howpublished empty$
+  month empty$ year empty$ note empty$ url empty$
+  and and and and and and
+    { "all relevant fields are empty in " cite$ * warning$ }
+    'skip$
+  if$
+}
+
+
+% The bibinfo system provides a way for the electronic parsing/acquisition
+% of a bibliography's contents as is done by ReVTeX. For example, a field
+% could be entered into the bibliography as:
+% \bibinfo{volume}{2}
+% Only the "2" would show up in the document, but the LaTeX \bibinfo command
+% could do additional things with the information. IEEEtran.bst does provide
+% a \bibinfo command via "\providecommand{\bibinfo}[2]{#2}". However, it is
+% currently not used as the bogus bibinfo functions defined here output the
+% entry values directly without the \bibinfo wrapper. The bibinfo functions
+% themselves (and the calls to them) are retained for possible future use.
+% 
+% bibinfo.check avoids acting on missing fields while bibinfo.warn will
+% issue a warning message if a missing field is detected. Prior to calling
+% the bibinfo functions, the user should push the field value and then its
+% name string, in that order.
+
+FUNCTION {bibinfo.check}
+{ swap$ duplicate$ missing$
+    { pop$ pop$ "" }
+    { duplicate$ empty$
+        { swap$ pop$ }
+        { swap$ pop$ }
+      if$
+    }
+  if$
+}
+
+FUNCTION {bibinfo.warn}
+{ swap$ duplicate$ missing$
+    { swap$ "missing " swap$ * " in " * cite$ * warning$ pop$ "" }
+    { duplicate$ empty$
+        { swap$ "empty " swap$ * " in " * cite$ * warning$ }
+        { swap$ pop$ }
+      if$
+    }
+  if$
+}
+
+
+% IEEE separates large numbers with more than 4 digits into groups of
+% three. IEEE uses a small space to separate these number groups. 
+% Typical applications include patent and page numbers.
+
+% number of consecutive digits required to trigger the group separation.
+FUNCTION {large.number.trigger}{ #5 }
+
+% For numbers longer than the trigger, this is the blocksize of the groups.
+% The blocksize must be less than the trigger threshold, and 2 * blocksize
+% must be greater than the trigger threshold (can't do more than one
+% separation on the initial trigger).
+FUNCTION {large.number.blocksize}{ #3 }
+
+% What is actually inserted between the number groups.
+FUNCTION {large.number.separator}{ "\," }
+
+% So as to save on integer variables by reusing existing ones, numnames
+% holds the current number of consecutive digits read and nameptr holds
+% the number that will trigger an inserted space.
+FUNCTION {large.number.separate}
+{ 't :=
+  ""
+  #0 'numnames :=
+  large.number.trigger 'nameptr :=
+  { t empty$ not }
+  { t #-1 #1 substring$ is.num
+      { numnames #1 + 'numnames := }
+      { #0 'numnames := 
+        large.number.trigger 'nameptr :=
+      }
+    if$
+    t #-1 #1 substring$ swap$ *
+    t #-2 global.max$ substring$ 't :=
+    numnames nameptr =
+      { duplicate$ #1 nameptr large.number.blocksize - substring$ swap$
+        nameptr large.number.blocksize - #1 + global.max$ substring$
+        large.number.separator swap$ * *
+        nameptr large.number.blocksize - 'numnames :=
+        large.number.blocksize #1 + 'nameptr :=
+      }
+      { skip$ }
+    if$
+  }
+  while$
+}
+
+% Converts all single dashes "-" to double dashes "--".
+FUNCTION {n.dashify}
+{ large.number.separate
+  't :=
+  ""
+    { t empty$ not }
+    { t #1 #1 substring$ "-" =
+        { t #1 #2 substring$ "--" = not
+            { "--" *
+              t #2 global.max$ substring$ 't :=
+            }
+            {   { t #1 #1 substring$ "-" = }
+                { "-" *
+                  t #2 global.max$ substring$ 't :=
+                }
+              while$
+            }
+          if$
+        }
+        { t #1 #1 substring$ *
+          t #2 global.max$ substring$ 't :=
+        }
+      if$
+    }
+  while$
+}
+
+
+% This function detects entries with names that are identical to that of
+% the previous entry and replaces the repeated names with dashes (if the
+% "is.dash.repeated.names" user control is nonzero).
+FUNCTION {name.or.dash}
+{ 's :=
+   oldname empty$
+     { s 'oldname := s }
+     { s oldname =
+         { is.dash.repeated.names
+              { repeated.name.dashes }
+              { s 'oldname := s }
+            if$
+         }
+         { s 'oldname := s }
+       if$
+     }
+   if$
+}
+
+% Converts the number string on the top of the stack to
+% "numerical ordinal form" (e.g., "7" to "7th"). There is
+% no artificial limit to the upper bound of the numbers as the
+% least significant digit always determines the ordinal form.
+FUNCTION {num.to.ordinal}
+{ duplicate$ #-1 #1 substring$ "1" =
+     { bbl.st * }
+     { duplicate$ #-1 #1 substring$ "2" =
+         { bbl.nd * }
+         { duplicate$ #-1 #1 substring$ "3" =
+             { bbl.rd * }
+             { bbl.th * }
+           if$
+         }
+       if$
+     }
+   if$
+}
+
+% If the string on the top of the stack begins with a number,
+% (e.g., 11th) then replace the string with the leading number
+% it contains. Otherwise retain the string as-is. s holds the
+% extracted number, t holds the part of the string that remains
+% to be scanned.
+FUNCTION {extract.num}
+{ duplicate$ 't :=
+  "" 's :=
+  { t empty$ not }
+  { t #1 #1 substring$
+    t #2 global.max$ substring$ 't :=
+    duplicate$ is.num
+      { s swap$ * 's := }
+      { pop$ "" 't := }
+    if$
+  }
+  while$
+  s empty$
+    'skip$
+    { pop$ s }
+  if$
+}
+
+% Converts the word number string on the top of the stack to
+% Arabic string form. Will be successful up to "tenth".
+FUNCTION {word.to.num}
+{ duplicate$ "l" change.case$ 's :=
+  s "first" =
+    { pop$ "1" }
+    { skip$ }
+  if$
+  s "second" =
+    { pop$ "2" }
+    { skip$ }
+  if$
+  s "third" =
+    { pop$ "3" }
+    { skip$ }
+  if$
+  s "fourth" =
+    { pop$ "4" }
+    { skip$ }
+  if$
+  s "fifth" =
+    { pop$ "5" }
+    { skip$ }
+  if$
+  s "sixth" =
+    { pop$ "6" }
+    { skip$ }
+  if$
+  s "seventh" =
+    { pop$ "7" }
+    { skip$ }
+  if$
+  s "eighth" =
+    { pop$ "8" }
+    { skip$ }
+  if$
+  s "ninth" =
+    { pop$ "9" }
+    { skip$ }
+  if$
+  s "tenth" =
+    { pop$ "10" }
+    { skip$ }
+  if$
+}
+
+
+% Converts the string on the top of the stack to numerical
+% ordinal (e.g., "11th") form.
+FUNCTION {convert.edition}
+{ duplicate$ empty$ 'skip$
+    { duplicate$ #1 #1 substring$ is.num
+        { extract.num
+          num.to.ordinal
+        }
+        { word.to.num
+          duplicate$ #1 #1 substring$ is.num
+            { num.to.ordinal }
+            { "edition ordinal word " quote$ * edition * quote$ *
+              " may be too high (or improper) for conversion" * " in " * cite$ * warning$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% LATEX BIBLIOGRAPHY CODE %%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {start.entry}
+{ newline$
+  "\bibitem{" write$
+  cite$ write$
+  "}" write$
+  newline$
+  ""
+  initialize.prev.this.status
+}
+
+% Here we write out all the LaTeX code that we will need. The most involved
+% code sequences are those that control the alternate interword spacing and
+% foreign language hyphenation patterns. The heavy use of \providecommand
+% gives users a way to override the defaults. Special thanks to Javier Bezos,
+% Johannes Braams, Robin Fairbairns, Heiko Oberdiek, Donald Arseneau and all
+% the other gurus on comp.text.tex for their help and advice on the topic of
+% \selectlanguage, Babel and BibTeX.
+FUNCTION {begin.bib}
+{ "% Generated by IEEEtranS.bst, version: " bst.file.version * " (" * bst.file.date * ")" *
+  write$ newline$
+  preamble$ empty$ 'skip$
+    { preamble$ write$ newline$ }
+  if$
+  "\begin{thebibliography}{"  longest.label  * "}" *
+  write$ newline$
+  "\providecommand{\url}[1]{#1}"
+  write$ newline$
+  "\csname url@samestyle\endcsname"
+  write$ newline$
+  "\providecommand{\newblock}{\relax}"
+  write$ newline$
+  "\providecommand{\bibinfo}[2]{#2}"
+  write$ newline$
+  "\providecommand{\BIBentrySTDinterwordspacing}{\spaceskip=0pt\relax}"
+  write$ newline$
+  "\providecommand{\BIBentryALTinterwordstretchfactor}{"
+  ALTinterwordstretchfactor * "}" *
+  write$ newline$
+  "\providecommand{\BIBentryALTinterwordspacing}{\spaceskip=\fontdimen2\font plus "
+  write$ newline$
+  "\BIBentryALTinterwordstretchfactor\fontdimen3\font minus \fontdimen4\font\relax}"
+  write$ newline$
+  "\providecommand{\BIBforeignlanguage}[2]{{%"
+  write$ newline$
+  "\expandafter\ifx\csname l@#1\endcsname\relax"
+  write$ newline$
+  "\typeout{** WARNING: IEEEtranS.bst: No hyphenation pattern has been}%"
+  write$ newline$
+  "\typeout{** loaded for the language `#1'. Using the pattern for}%"
+  write$ newline$
+  "\typeout{** the default language instead.}%"
+  write$ newline$
+  "\else"
+  write$ newline$
+  "\language=\csname l@#1\endcsname"
+  write$ newline$
+  "\fi"
+  write$ newline$
+  "#2}}"
+  write$ newline$
+  "\providecommand{\BIBdecl}{\relax}"
+  write$ newline$
+  "\BIBdecl"
+  write$ newline$
+}
+
+FUNCTION {end.bib}
+{ newline$ "\end{thebibliography}" write$ newline$ }
+
+FUNCTION {if.url.alt.interword.spacing}
+{ is.use.alt.interword.spacing 
+     {url empty$ 'skip$ {"\BIBentryALTinterwordspacing" write$ newline$} if$}
+     { skip$ }
+   if$
+}
+
+FUNCTION {if.url.std.interword.spacing}
+{ is.use.alt.interword.spacing 
+     {url empty$ 'skip$ {"\BIBentrySTDinterwordspacing" write$ newline$} if$}
+     { skip$ }
+   if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%
+%% LONGEST LABEL PASS %%
+%%%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {initialize.longest.label}
+{ "" 'longest.label :=
+  #1 'number.label :=
+  #0 'longest.label.width :=
+}
+
+FUNCTION {longest.label.pass}
+{ type$ "ieeetranbstctl" =
+    { skip$ }
+    { number.label int.to.str$ 'label :=
+      number.label #1 + 'number.label :=
+      label width$ longest.label.width >
+        { label 'longest.label :=
+          label width$ 'longest.label.width :=
+        }
+        { skip$ }
+      if$
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%%
+%% FORMAT HANDLERS %%
+%%%%%%%%%%%%%%%%%%%%%
+
+%% Lower Level Formats (used by higher level formats)
+
+FUNCTION {format.address.org.or.pub.date}
+{ 't :=
+  ""
+  year empty$
+    { "empty year in " cite$ * warning$ }
+    { skip$ }
+  if$
+  address empty$ t empty$ and
+  year empty$ and month empty$ and
+    { skip$ }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      address "address" bibinfo.check *
+      t empty$
+        { skip$ }
+        { punct.period 'prev.status.punct :=
+          space.large 'prev.status.space :=
+          address empty$
+            { skip$ }
+            { ": " * }
+          if$
+          t *
+        }
+      if$
+      year empty$ month empty$ and
+        { skip$ }
+        { t empty$ address empty$ and
+            { skip$ }
+            { ", " * }
+          if$
+          month empty$
+            { year empty$
+                { skip$ }
+                { year "year" bibinfo.check * }
+              if$
+            }
+            { month "month" bibinfo.check *
+              year empty$
+                 { skip$ }
+                 { " " * year "year" bibinfo.check * }
+              if$
+            }
+          if$
+        }
+      if$
+    }
+  if$
+}
+
+
+FUNCTION {format.names}
+{ 'bibinfo :=
+  duplicate$ empty$ 'skip$ {
+  this.to.prev.status
+  this.status.std
+  's :=
+  "" 't :=
+  #1 'nameptr :=
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { s nameptr
+      name.format.string
+      format.name$
+      bibinfo bibinfo.check
+      't :=
+      nameptr #1 >
+        { nameptr num.names.shown.with.forced.et.al #1 + =
+          numnames max.num.names.before.forced.et.al >
+          is.forced.et.al and and
+            { "others" 't :=
+              #1 'namesleft :=
+            }
+            { skip$ }
+          if$
+          namesleft #1 >
+            { ", " * t do.name.latex.cmd * }
+            { s nameptr "{ll}" format.name$ duplicate$ "others" =
+                { 't := }
+                { pop$ }
+              if$
+              t "others" =
+                { " " * bbl.etal emphasize * }
+                { numnames #2 >
+                    { "," * }
+                    { skip$ }
+                  if$
+                  bbl.and
+                  space.word * t do.name.latex.cmd *
+                }
+              if$
+            }
+          if$
+        }
+        { t do.name.latex.cmd }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+  cap.status.std
+  } if$
+}
+
+
+
+
+%% Higher Level Formats
+
+%% addresses/locations
+
+FUNCTION {format.address}
+{ address duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% author/editor names
+
+FUNCTION {format.authors}{ author "author" format.names }
+
+FUNCTION {format.editors}
+{ editor "editor" format.names duplicate$ empty$ 'skip$
+    { ", " *
+      get.bbl.editor
+      capitalize
+      *
+    }
+  if$
+}
+
+
+
+%% date
+
+FUNCTION {format.date}
+{
+  month "month" bibinfo.check duplicate$ empty$
+  year  "year" bibinfo.check duplicate$ empty$
+    { swap$ 'skip$
+        { this.to.prev.status
+          this.status.std
+          cap.status.std
+         "there's a month but no year in " cite$ * warning$ }
+      if$
+      *
+    }
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      swap$ 'skip$
+        {
+          swap$
+          " " * swap$
+        }
+      if$
+      *
+    }
+  if$
+}
+
+FUNCTION {format.date.electronic}
+{ month "month" bibinfo.check duplicate$ empty$
+  year  "year" bibinfo.check duplicate$ empty$
+    { swap$ 
+        { pop$ }
+        { "there's a month but no year in " cite$ * warning$
+        pop$ ")" * "(" swap$ *
+        this.to.prev.status
+        punct.no 'this.status.punct :=
+        space.normal 'this.status.space :=
+        quote.no 'this.status.quote :=
+        cap.yes  'status.cap :=
+        }
+      if$
+    }
+    { swap$ 
+        { swap$ pop$ ")" * "(" swap$ * }
+        { "(" swap$ * ", " * swap$ * ")" * }
+      if$
+    this.to.prev.status
+    punct.no 'this.status.punct :=
+    space.normal 'this.status.space :=
+    quote.no 'this.status.quote :=
+    cap.yes  'status.cap :=
+    }
+  if$
+}
+
+
+
+%% edition/title
+
+% Note: IEEE considers the edition to be closely associated with
+% the title of a book. So, in IEEEtran.bst the edition is normally handled 
+% within the formatting of the title. The format.edition function is 
+% retained here for possible future use.
+FUNCTION {format.edition}
+{ edition duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      convert.edition
+      status.cap
+        { "t" }
+        { "l" }
+      if$ change.case$
+      "edition" bibinfo.check
+      "~" * bbl.edition *
+      cap.status.std
+    }
+  if$
+}
+
+% This is used to format the booktitle of a conference proceedings.
+% Here we use the "intype" field to provide the user a way to 
+% override the word "in" (e.g., with things like "presented at")
+% Use of intype stops the emphasis of the booktitle to indicate that
+% we no longer mean the written conference proceedings, but the
+% conference itself.
+FUNCTION {format.in.booktitle}
+{ booktitle "booktitle" bibinfo.check duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      select.language
+      intype missing$
+        { emphasize
+          bbl.in " " *
+        }
+        { intype " " * }
+      if$
+      swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+% This is used to format the booktitle of collection.
+% Here the "intype" field is not supported, but "edition" is.
+FUNCTION {format.in.booktitle.edition}
+{ booktitle "booktitle" bibinfo.check duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      select.language
+      emphasize
+      edition empty$ 'skip$
+        { ", " *
+          edition
+          convert.edition
+          "l" change.case$
+          * "~" * bbl.edition *
+        }
+      if$
+      bbl.in " " * swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.article.title}
+{ title duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      "t" change.case$
+    }
+  if$
+  "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    { quote.close 'this.status.quote :=
+      is.last.char.not.punct
+        { punct.std 'this.status.punct := }
+        { punct.no 'this.status.punct := }
+      if$
+      select.language
+      "``" swap$ *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.article.title.electronic}
+{ title duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      "t" change.case$ 
+    }
+  if$
+  "title" bibinfo.check
+  duplicate$ empty$ 
+    { skip$ } 
+    { select.language }
+  if$
+}
+
+FUNCTION {format.book.title.edition}
+{ title "title" bibinfo.check
+  duplicate$ empty$
+    { "empty title in " cite$ * warning$ }
+    { this.to.prev.status
+      this.status.std
+      select.language
+      emphasize
+      edition empty$ 'skip$
+        { ", " *
+          edition
+          convert.edition
+          status.cap
+            { "t" }
+            { "l" }
+          if$
+          change.case$
+          * "~" * bbl.edition *
+        }
+      if$
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.book.title}
+{ title "title" bibinfo.check
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      select.language
+      emphasize
+    }
+  if$
+}
+
+
+
+%% journal
+
+FUNCTION {format.journal}
+{ journal duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+      select.language
+      emphasize
+    }
+  if$
+}
+
+
+
+%% how published
+
+FUNCTION {format.howpublished}
+{ howpublished duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% institutions/organization/publishers/school
+
+FUNCTION {format.institution}
+{ institution duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.organization}
+{ organization duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.address.publisher.date}
+{ publisher "publisher" bibinfo.warn format.address.org.or.pub.date }
+
+FUNCTION {format.address.publisher.date.nowarn}
+{ publisher "publisher" bibinfo.check format.address.org.or.pub.date }
+
+FUNCTION {format.address.organization.date}
+{ organization "organization" bibinfo.check format.address.org.or.pub.date }
+
+FUNCTION {format.school}
+{ school duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% volume/number/series/chapter/pages
+
+FUNCTION {format.volume}
+{ volume empty.field.to.null.string
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      bbl.volume 
+      status.cap
+        { capitalize }
+        { skip$ }
+      if$
+      swap$ tie.or.space.prefix
+      "volume" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.number}
+{ number empty.field.to.null.string
+  duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      status.cap
+         { bbl.number capitalize }
+         { bbl.number }
+       if$
+      swap$ tie.or.space.prefix
+      "number" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+FUNCTION {format.number.if.use.for.article}
+{ is.use.number.for.article 
+     { format.number }
+     { "" }
+   if$
+}
+
+% IEEE does not seem to tie the series so closely with the volume
+% and number as is done in other bibliography styles. Instead the
+% series is treated somewhat like an extension of the title.
+FUNCTION {format.series}
+{ series empty$ 
+   { "" }
+   { this.to.prev.status
+     this.status.std
+     bbl.series " " *
+     series "series" bibinfo.check *
+     cap.status.std
+   }
+ if$
+}
+
+
+FUNCTION {format.chapter}
+{ chapter empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      type empty$
+        { bbl.chapter }
+        { type "l" change.case$
+          "type" bibinfo.check
+        }
+      if$
+      chapter tie.or.space.prefix
+      "chapter" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+% The intended use of format.paper is for paper numbers of inproceedings.
+% The paper type can be overridden via the type field.
+% We allow the type to be displayed even if the paper number is absent
+% for things like "postdeadline paper"
+FUNCTION {format.paper}
+{ is.use.paper
+     { paper empty$
+        { type empty$
+            { "" }
+            { this.to.prev.status
+              this.status.std
+              type "type" bibinfo.check
+              cap.status.std
+            }
+          if$
+        }
+        { this.to.prev.status
+          this.status.std
+          type empty$
+            { bbl.paper }
+            { type "type" bibinfo.check }
+          if$
+          " " * paper
+          "paper" bibinfo.check
+          *
+          cap.status.std
+        }
+      if$
+     }
+     { "" } 
+   if$
+}
+
+
+FUNCTION {format.pages}
+{ pages duplicate$ empty$ 'skip$
+    { this.to.prev.status
+      this.status.std
+      duplicate$ is.multiple.pages
+        {
+          bbl.pages swap$
+          n.dashify
+        }
+        {
+          bbl.page swap$
+        }
+      if$
+      tie.or.space.prefix
+      "pages" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+
+%% technical report number
+
+FUNCTION {format.tech.report.number}
+{ number "number" bibinfo.check
+  this.to.prev.status
+  this.status.std
+  cap.status.std
+  type duplicate$ empty$
+    { pop$ 
+      bbl.techrep
+    }
+    { skip$ }
+  if$
+  "type" bibinfo.check 
+  swap$ duplicate$ empty$
+    { pop$ }
+    { tie.or.space.prefix * * }
+  if$
+}
+
+
+
+%% note
+
+FUNCTION {format.note}
+{ note empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      punct.period 'this.status.punct :=
+      note #1 #1 substring$
+      duplicate$ "{" =
+        { skip$ }
+        { status.cap
+          { "u" }
+          { "l" }
+        if$
+        change.case$
+        }
+      if$
+      note #2 global.max$ substring$ * "note" bibinfo.check
+      cap.yes  'status.cap :=
+    }
+  if$
+}
+
+
+
+%% patent
+
+FUNCTION {format.patent.date}
+{ this.to.prev.status
+  this.status.std
+  year empty$
+    { monthfiled duplicate$ empty$
+        { "monthfiled" bibinfo.check pop$ "" }
+        { "monthfiled" bibinfo.check }
+      if$
+      dayfiled duplicate$ empty$
+        { "dayfiled" bibinfo.check pop$ "" * }
+        { "dayfiled" bibinfo.check 
+          monthfiled empty$ 
+             { "dayfiled without a monthfiled in " cite$ * warning$
+               * 
+             }
+             { " " swap$ * * }
+           if$
+        }
+      if$
+      yearfiled empty$
+        { "no year or yearfiled in " cite$ * warning$ }
+        { yearfiled "yearfiled" bibinfo.check 
+          swap$
+          duplicate$ empty$
+             { pop$ }
+             { ", " * swap$ * }
+           if$
+        }
+      if$
+    }
+    { month duplicate$ empty$
+        { "month" bibinfo.check pop$ "" }
+        { "month" bibinfo.check }
+      if$
+      day duplicate$ empty$
+        { "day" bibinfo.check pop$ "" * }
+        { "day" bibinfo.check 
+          month empty$ 
+             { "day without a month in " cite$ * warning$
+               * 
+             }
+             { " " swap$ * * }
+           if$
+        }
+      if$
+      year "year" bibinfo.check 
+      swap$
+      duplicate$ empty$
+        { pop$ }
+        { ", " * swap$ * }
+      if$
+    }
+  if$
+  cap.status.std
+}
+
+FUNCTION {format.patent.nationality.type.number}
+{ this.to.prev.status
+  this.status.std
+  nationality duplicate$ empty$
+    { "nationality" bibinfo.warn pop$ "" }
+    { "nationality" bibinfo.check
+      duplicate$ "l" change.case$ "united states" =
+        { pop$ bbl.patentUS }
+        { skip$ }
+      if$
+      " " *
+    }
+  if$
+  type empty$
+    { bbl.patent "type" bibinfo.check }
+    { type "type" bibinfo.check }
+  if$  
+  *
+  number duplicate$ empty$
+    { "number" bibinfo.warn pop$ }
+    { "number" bibinfo.check
+      large.number.separate
+      swap$ " " * swap$ *
+    }
+  if$ 
+  cap.status.std
+}
+
+
+
+%% standard
+
+FUNCTION {format.organization.institution.standard.type.number}
+{ this.to.prev.status
+  this.status.std
+  organization duplicate$ empty$
+    { pop$ 
+      institution duplicate$ empty$
+        { "institution" bibinfo.warn }
+        { "institution" bibinfo.warn " " * }
+      if$
+    }
+    { "organization" bibinfo.warn " " * }
+  if$
+  type empty$
+    { bbl.standard "type" bibinfo.check }
+    { type "type" bibinfo.check }
+  if$  
+  *
+  number duplicate$ empty$
+    { "number" bibinfo.check pop$ }
+    { "number" bibinfo.check
+      large.number.separate
+      swap$ " " * swap$ *
+    }
+  if$ 
+  cap.status.std
+}
+
+FUNCTION {format.revision}
+{ revision empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      bbl.revision
+      revision tie.or.space.prefix
+      "revision" bibinfo.check
+      * *
+      cap.status.std
+    }
+  if$
+}
+
+
+%% thesis
+
+FUNCTION {format.master.thesis.type}
+{ this.to.prev.status
+  this.status.std
+  type empty$
+    {
+      bbl.mthesis
+    }
+    { 
+      type "type" bibinfo.check
+    }
+  if$
+cap.status.std
+}
+
+FUNCTION {format.phd.thesis.type}
+{ this.to.prev.status
+  this.status.std
+  type empty$
+    {
+      bbl.phdthesis
+    }
+    { 
+      type "type" bibinfo.check
+    }
+  if$
+cap.status.std
+}
+
+
+
+%% URL
+
+FUNCTION {format.url}
+{ url empty$
+    { "" }
+    { this.to.prev.status
+      this.status.std
+      cap.yes 'status.cap :=
+      name.url.prefix " " *
+      "\url{" * url * "}" *
+      punct.no 'this.status.punct :=
+      punct.period 'prev.status.punct :=
+      space.normal 'this.status.space :=
+      space.normal 'prev.status.space :=
+      quote.no 'this.status.quote :=
+    }
+  if$
+}
+
+
+
+
+%%%%%%%%%%%%%%%%%%%%
+%% ENTRY HANDLERS %%
+%%%%%%%%%%%%%%%%%%%%
+
+
+% Note: In many journals, IEEE (or the authors) tend not to show the number
+% for articles, so the display of the number is controlled here by the
+% switch "is.use.number.for.article"
+FUNCTION {article}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.journal "journal" bibinfo.check "journal" output.warn
+  format.volume output
+  format.number.if.use.for.article output
+  format.pages output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {book}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  author empty$
+    { format.editors "author and editor" output.warn }
+    { format.authors output.nonnull }
+  if$
+  name.or.dash
+  format.book.title.edition output
+  format.series output
+  author empty$
+    { skip$ }
+    { format.editors output }
+  if$
+  format.address.publisher.date output
+  format.volume output
+  format.number output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {booklet}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {electronic}
+{ std.status.using.period
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.date.electronic output
+  format.article.title.electronic output
+  format.howpublished "howpublished" bibinfo.check output
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+}
+
+FUNCTION {inbook}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  author empty$
+    { format.editors "author and editor" output.warn }
+    { format.authors output.nonnull }
+  if$
+  name.or.dash
+  format.book.title.edition output
+  format.series output
+  format.address.publisher.date output
+  format.volume output
+  format.number output
+  format.chapter output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {incollection}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.in.booktitle.edition "booktitle" output.warn
+  format.series output
+  format.editors output
+  format.address.publisher.date.nowarn output
+  format.volume output
+  format.number output
+  format.chapter output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {inproceedings}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.in.booktitle "booktitle" output.warn
+  format.series output
+  format.editors output
+  format.volume output
+  format.number output
+  publisher empty$
+    { format.address.organization.date output }
+    { format.organization "organization" bibinfo.check output
+      format.address.publisher.date output
+    }
+  if$
+  format.paper output
+  format.pages output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {manual}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.book.title.edition "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {mastersthesis}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.master.thesis.type output.nonnull
+  format.school "school" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {misc}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title output
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization "organization" bibinfo.check output
+  format.address "address" bibinfo.check output
+  format.pages output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+}
+
+FUNCTION {patent}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.article.title output
+  format.patent.nationality.type.number output
+  format.patent.date output
+  format.note output
+  format.url output
+  fin.entry
+  empty.entry.warn
+  if.url.std.interword.spacing
+}
+
+FUNCTION {periodical}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.editors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.series output
+  format.volume output
+  format.number output
+  format.organization "organization" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {phdthesis}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.phd.thesis.type output.nonnull
+  format.school "school" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {proceedings}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.editors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.series output
+  format.volume output
+  format.number output
+  publisher empty$
+    { format.address.organization.date output }
+    { format.organization "organization" bibinfo.check output
+      format.address.publisher.date output
+    }
+  if$
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {standard}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors output
+  name.or.dash
+  format.book.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.organization.institution.standard.type.number output
+  format.revision output
+  format.date output
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {techreport}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.howpublished "howpublished" bibinfo.check output 
+  format.institution "institution" bibinfo.warn output
+  format.address "address" bibinfo.check output
+  format.tech.report.number output.nonnull
+  format.date "year" output.warn
+  format.note output
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+FUNCTION {unpublished}
+{ std.status.using.comma
+  start.entry
+  if.url.alt.interword.spacing
+  format.authors "author" output.warn
+  name.or.dash
+  format.article.title "title" output.warn
+  format.date output
+  format.note "note" output.warn
+  format.url output
+  fin.entry
+  if.url.std.interword.spacing
+}
+
+
+% The special entry type which provides the user interface to the
+% BST controls
+FUNCTION {IEEEtranBSTCTL}
+{ is.print.banners.to.terminal
+    { "** IEEEtran BST control entry " quote$ * cite$ * quote$ * " detected." *
+      top$
+    }
+    { skip$ }
+  if$
+  CTLuse_article_number
+  empty$
+    { skip$ }
+    { CTLuse_article_number
+      yes.no.to.int
+      'is.use.number.for.article :=
+    }
+  if$
+  CTLuse_paper
+  empty$
+    { skip$ }
+    { CTLuse_paper
+      yes.no.to.int
+      'is.use.paper :=
+    }
+  if$
+  CTLuse_forced_etal
+  empty$
+    { skip$ }
+    { CTLuse_forced_etal
+      yes.no.to.int
+      'is.forced.et.al :=
+    }
+  if$
+  CTLmax_names_forced_etal
+  empty$
+    { skip$ }
+    { CTLmax_names_forced_etal
+      string.to.integer
+      'max.num.names.before.forced.et.al :=
+    }
+  if$
+  CTLnames_show_etal
+  empty$
+    { skip$ }
+    { CTLnames_show_etal
+      string.to.integer
+      'num.names.shown.with.forced.et.al :=
+    }
+  if$
+  CTLuse_alt_spacing
+  empty$
+    { skip$ }
+    { CTLuse_alt_spacing
+      yes.no.to.int
+      'is.use.alt.interword.spacing :=
+    }
+  if$
+  CTLalt_stretch_factor
+  empty$
+    { skip$ }
+    { CTLalt_stretch_factor
+      'ALTinterwordstretchfactor :=
+      "\renewcommand{\BIBentryALTinterwordstretchfactor}{"
+      ALTinterwordstretchfactor * "}" *
+      write$ newline$
+    }
+  if$
+  CTLdash_repeated_names
+  empty$
+    { skip$ }
+    { CTLdash_repeated_names
+      yes.no.to.int
+      'is.dash.repeated.names :=
+    }
+  if$
+  CTLname_format_string
+  empty$
+    { skip$ }
+    { CTLname_format_string
+      'name.format.string :=
+    }
+  if$
+  CTLname_latex_cmd
+  empty$
+    { skip$ }
+    { CTLname_latex_cmd
+      'name.latex.cmd :=
+    }
+  if$
+  CTLname_url_prefix
+  missing$
+    { skip$ }
+    { CTLname_url_prefix
+      'name.url.prefix :=
+    }
+  if$
+
+
+  num.names.shown.with.forced.et.al max.num.names.before.forced.et.al >
+    { "CTLnames_show_etal cannot be greater than CTLmax_names_forced_etal in " cite$ * warning$ 
+      max.num.names.before.forced.et.al 'num.names.shown.with.forced.et.al :=
+    }
+    { skip$ }
+  if$
+}
+
+
+%%%%%%%%%%%%%%%%%%%
+%% ENTRY ALIASES %%
+%%%%%%%%%%%%%%%%%%%
+FUNCTION {conference}{inproceedings}
+FUNCTION {online}{electronic}
+FUNCTION {internet}{electronic}
+FUNCTION {webpage}{electronic}
+FUNCTION {www}{electronic}
+FUNCTION {default.type}{misc}
+
+
+
+%%%%%%%%%%%%%%%%%%
+%% MAIN PROGRAM %%
+%%%%%%%%%%%%%%%%%%
+
+READ
+
+EXECUTE {initialize.controls}
+EXECUTE {initialize.status.constants}
+EXECUTE {banner.message}
+
+
+
+% BEGIN sort code based on that of plain.bst
+
+FUNCTION {sortify}
+{ purify$
+  "l" change.case$
+}
+
+INTEGERS { len }
+
+FUNCTION {chop.word}
+{ 's :=
+  'len :=
+  s #1 len substring$ =
+    { s len #1 + global.max$ substring$ }
+    { s }
+  if$
+}
+
+FUNCTION {sort.format.names}
+{ 's :=
+  #1 'nameptr :=
+  ""
+  s num.names$ 'numnames :=
+  numnames 'namesleft :=
+    { namesleft #0 > }
+    { nameptr #1 >
+        { "   " * }
+        { skip$ }
+      if$
+      s nameptr "{vv{ } }{ll{ }}{  ff{ }}{  jj{ }}" format.name$ 't :=
+      nameptr numnames = t "others" = and
+        { "et al" * }
+        { t sortify * }
+      if$
+      nameptr #1 + 'nameptr :=
+      namesleft #1 - 'namesleft :=
+    }
+  while$
+}
+
+FUNCTION {sort.format.title}
+{ 't :=
+  "A " #2
+    "An " #3
+      "The " #4 t chop.word
+    chop.word
+  chop.word
+  sortify
+  #1 global.max$ substring$
+}
+
+FUNCTION {author.sort}
+{ author empty$
+    { key empty$
+        { "to sort, need author or key in " cite$ * warning$ "" }
+        { key sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {author.editor.sort}
+{ author empty$
+    { editor empty$
+        { key empty$
+            { "to sort, need author, editor, or key in " cite$ * warning$ "" }
+            { key sortify }
+          if$
+        }
+        { editor sort.format.names }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {author.organization.sort}
+{ author empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need author, organization, or key in " cite$ * warning$ "" }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+FUNCTION {editor.organization.sort}
+{ editor empty$
+    { organization empty$
+        { key empty$
+            { "to sort, need editor, organization, or key in " cite$ * warning$ "" }
+            { key sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { editor sort.format.names }
+  if$
+}
+
+FUNCTION {author.organization.institution.sort}
+{ author empty$
+    { organization empty$
+        { institution empty$
+            { key empty$
+                { "to sort, need author, organization, institution or key in " cite$ * warning$ "" }
+                { key sortify }
+              if$
+            }
+            { "The " #4 institution chop.word sortify }
+          if$
+        }
+        { "The " #4 organization chop.word sortify }
+      if$
+    }
+    { author sort.format.names }
+  if$
+}
+
+
+FUNCTION {presort}
+{ type$ "ieeetranbstctl" =
+    { key empty$
+        { "_" }
+        { key sortify }
+      if$
+    }
+    { type$ "book" =
+      type$ "inbook" =
+      or 
+        { author.editor.sort }
+        { type$ "proceedings" =
+          type$ "periodical" =
+          or
+            { editor.organization.sort }
+            { type$ "manual" =
+              type$ "electronic" =
+              type$ "misc" =
+              or or
+                { author.organization.sort }
+                { type$ "standard" =
+                   { author.organization.institution.sort }
+                   { author.sort }
+                 if$ 
+                }
+              if$
+            }
+          if$
+        }
+      if$
+      "    "
+      *
+      type$ "patent" =
+        { year empty$
+          { yearfiled }
+          { year }
+        if$
+        }
+        { year }
+      if$
+      empty.field.to.null.string sortify
+      *
+      "    "
+      *
+      title empty.field.to.null.string
+      sort.format.title
+      *
+    }
+  if$
+  #1 entry.max$ substring$
+  'sort.key$ :=
+}
+
+ITERATE {presort}
+
+SORT
+
+% END sort code based on that of plain.bst
+
+
+
+EXECUTE {initialize.longest.label}
+ITERATE {longest.label.pass}
+
+EXECUTE {begin.bib}
+ITERATE {call.type$}
+EXECUTE {end.bib}
+
+EXECUTE{completed.message}
+
+
+%% That's all folks, mds.

--- a/ieee/IEEEtrantools.sty
+++ b/ieee/IEEEtrantools.sty
@@ -1,0 +1,1978 @@
+%%
+%% IEEEtrantools.sty 2012/12/27 version V1.3
+%% 
+%% 
+%% This package provides several popular and unique commands from the
+%% IEEEtran.cls class (version 1.8) file.
+%% 
+%% The provided commands include \IEEEPARstart, \IEEEitemize, \IEEEenumerate,
+%% \IEEEdescription as well as the \IEEEeqnarray, \IEEEeqnarraybox family
+%% of commands including support commands such as \IEEEstrut, the IEEEproof
+%% environment and its support commands and the \IEEEauthorrefmark command.
+%% Also provides the \bstctlcite command for the control entry types of
+%% IEEEtran.bst V1.00 and later.
+%% 
+%% IEEEtrantools.sty should not be used with IEEEtran.cls.
+%% 
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%%
+%% 
+%% Copyright (c) 2002-2012 by Michael Shell
+%%                            See: http://www.michaelshell.org/
+%%                            for current contact information.
+%%
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtrantools.sty, IEEEtrantools_doc.txt
+%%*************************************************************************
+%%
+%%
+%%
+%% Available package options (e.g., \usepackage[redeflists]{IEEEtrantools}
+%%
+%% redeflists
+%%    Causes IEEEtrantools to redefine the standard itemize, enumerate and
+%%    description (IED) list environments to their IEEE versions.
+%%    IEEEitemize, IEEEenumerate and IEEEdescription remain available in any
+%%    case. This option may not be compatible with packages that alter the
+%%    standard IED list environments.
+%%    
+%%
+%%**********************************************************************
+
+
+\ProvidesPackage{IEEEtrantools}[2012/12/27 V1.3 by Michael Shell]
+\typeout{-- See the "IEEEtrantools_doc.txt" manual for usage information.}
+\typeout{-- http://www.michaelshell.org/tex/ieeetran/tools/}
+\NeedsTeXFormat{LaTeX2e}
+
+
+% If \@IEEEeqnarray is detected, error.
+{\@ifundefined{@IEEEeqnarray}{\relax}{%
+\PackageError{IEEEtrantools}{The IEEEtrantools package is not for use\MessageBreak
+                             with classes that already provide it}%
+    {Do not load IEEEtrantools - you don't need it.}%
+}}
+
+
+% define needed flags to indicate document options
+\newif\if@IEEETOOLSredeflists
+\global\@IEEETOOLSredeflistsfalse
+
+
+% IEEEtran class scratch pad registers
+% dimen
+\newdimen\@IEEEtrantmpdimenA
+\newdimen\@IEEEtrantmpdimenB
+% count
+\newcount\@IEEEtrantmpcountA
+\newcount\@IEEEtrantmpcountB
+% token list
+\newtoks\@IEEEtrantmptoksA
+
+
+% declare the options
+\DeclareOption{redeflists}{\@IEEETOOLSredefliststrue}
+% provide legacy support for retainorgcmds which does nothing now.
+\DeclareOption{retainorgcmds}{\@IEEETOOLSredeflistsfalse}
+
+% get and process any supplied options
+\ProcessOptions
+
+
+
+% store the nominal value of jot
+\newdimen\IEEEnormaljot
+\IEEEnormaljot\jot\relax
+
+
+% Itemize, Enumerate and Description (IED) List Controls
+% ***************************
+% 
+% 
+% IEEE seems to use at least two different values by
+% which ITEMIZED list labels are indented to the right
+% For The Journal of Lightwave Technology (JLT) and The Journal
+% on Selected Areas in Communications (JSAC), they tend to use
+% an indention equal to \parindent. For Transactions on Communications
+% they tend to indent ITEMIZED lists a little more--- 1.3\parindent.
+% We'll provide both values here for you so that you can choose 
+% which one you like in your document using a command such as:
+% setlength{\IEEEilabelindent}{\IEEEilabelindentB}
+\newdimen\IEEEilabelindentA
+\IEEEilabelindentA \parindent
+
+\newdimen\IEEEilabelindentB
+\IEEEilabelindentB 1.3\parindent
+% However, we'll default to using \parindent
+% which makes more sense to me
+\newdimen\IEEEilabelindent
+\IEEEilabelindent \IEEEilabelindentA
+
+
+% This controls the default amount the enumerated list labels
+% are indented to the right.
+% Normally, this is the same as the paragraph indention
+\newdimen\IEEEelabelindent
+\IEEEelabelindent \parindent
+
+% This controls the default amount the description list labels
+% are indented to the right.
+% Normally, this is the same as the paragraph indention
+\newdimen\IEEEdlabelindent
+\IEEEdlabelindent \parindent
+
+% This is the value actually used within the IED lists.
+% The IED environments automatically set its value to
+% one of the three values above, so global changes do 
+% not have any effect
+\newdimen\IEEElabelindent
+\IEEElabelindent \parindent
+
+% The actual amount labels will be indented is
+% \IEEElabelindent multiplied by the factor below
+% corresponding to the level of nesting depth
+% This provides a means by which the user can
+% alter the effective \IEEElabelindent for deeper
+% levels
+% There may not be such a thing as correct "standard IEEE"
+% values. What IEEE actually does may depend on the specific
+% circumstances.
+% The first list level almost always has full indention.
+% The second levels I've seen have only 75% of the normal indentation
+% Three level or greater nestings are very rare. I am guessing
+% that they don't use any indentation.
+\def\IEEElabelindentfactori{1.0}   % almost always one
+\def\IEEElabelindentfactorii{0.75} % 0.0 or 1.0 may be used in some cases
+\def\IEEElabelindentfactoriii{0.0} % 0.75? 0.5? 0.0?
+\def\IEEElabelindentfactoriv{0.0}
+\def\IEEElabelindentfactorv{0.0}
+\def\IEEElabelindentfactorvi{0.0}
+
+% value actually used within IED lists, it is auto
+% set to one of the 6 values above
+% global changes here have no effect
+\def\IEEElabelindentfactor{1.0}
+
+% This controls the default spacing between the end of the IED
+% list labels and the list text, when normal text is used for
+% the labels.
+\newdimen\IEEEiednormlabelsep
+\IEEEiednormlabelsep 0.6em
+
+% This controls the default spacing between the end of the IED
+% list labels and the list text, when math symbols are used for
+% the labels (nomenclature lists). IEEE usually increases the 
+% spacing in these cases
+\newdimen\IEEEiedmathlabelsep
+\IEEEiedmathlabelsep 1.2em
+
+% This controls the extra vertical separation put above and
+% below each IED list. IEEE usually puts a little extra spacing
+% around each list. However, this spacing is barely noticeable.
+\newskip\IEEEiedtopsep
+\IEEEiedtopsep 2pt plus 1pt minus 1pt
+
+
+% This command is executed within each IED list environment
+% at the beginning of the list. You can use this to set the 
+% parameters for some/all your IED list(s) without disturbing 
+% global parameters that affect things other than lists.
+% i.e., renewcommand{\IEEEiedlistdecl}{\setlength{\labelsep}{5em}}
+% will alter the \labelsep for the next list(s) until 
+% \IEEEiedlistdecl is redefined. 
+\def\IEEEiedlistdecl{\relax}
+
+% This command provides an easy way to set \leftmargin based
+% on the \labelwidth, \labelsep and the argument \IEEElabelindent
+% Usage: \IEEEcalcleftmargin{width-to-indent-the-label}
+% output is in the \leftmargin variable, i.e., effectively:
+% \leftmargin = argument + \labelwidth + \labelsep
+% Note controlled spacing here, shield end of lines with %
+\def\IEEEcalcleftmargin#1{\setlength{\leftmargin}{#1}%
+\addtolength{\leftmargin}{\labelwidth}%
+\addtolength{\leftmargin}{\labelsep}}
+
+% This command provides an easy way to set \labelwidth to the
+% width of the given text. It is the same as
+% \settowidth{\labelwidth}{label-text}
+% and useful as a shorter alternative.
+% Typically used to set \labelwidth to be the width
+% of the longest label in the list
+\def\IEEEsetlabelwidth#1{\settowidth{\labelwidth}{#1}}
+
+% When this command is executed, IED lists will use the 
+% IEEEiedmathlabelsep label separation rather than the normal
+% spacing. To have an effect, this command must be executed via
+% the \IEEEiedlistdecl or within the option of the IED list
+% environments.
+\def\IEEEusemathlabelsep{\setlength{\labelsep}{\IEEEiedmathlabelsep}}
+
+% A flag which controls whether the IED lists automatically
+% calculate \leftmargin from \IEEElabelindent, \labelwidth and \labelsep
+% Useful if you want to specify your own \leftmargin
+% This flag must be set (\IEEEnocalcleftmargintrue or \IEEEnocalcleftmarginfalse) 
+% via the \IEEEiedlistdecl or within the option of the IED list
+% environments to have an effect.
+\newif\ifIEEEnocalcleftmargin
+\IEEEnocalcleftmarginfalse
+
+% A flag which controls whether \IEEElabelindent is multiplied by
+% the \IEEElabelindentfactor for each list level.
+% This flag must be set via the \IEEEiedlistdecl or within the option 
+% of the IED list environments to have an effect.
+\newif\ifIEEEnolabelindentfactor
+\IEEEnolabelindentfactorfalse
+
+
+% internal variable to indicate type of IED label
+% justification
+% 0 - left; 1 - center; 2 - right
+\def\@IEEEiedjustify{0}
+
+
+
+% commands to allow the user to control IED
+% label justifications. Use these commands within
+% the IED environment option or in the \IEEEiedlistdecl
+% Note that changing the normal list justifications
+% is nonstandard and IEEE may not like it if you do so!
+% I include these commands as they may be helpful to
+% those who are using these enhanced list controls for
+% other non-IEEE related LaTeX work.
+% itemize and enumerate automatically default to right
+% justification, description defaults to left.
+\def\IEEEiedlabeljustifyl{\def\@IEEEiedjustify{0}}%left
+\def\IEEEiedlabeljustifyc{\def\@IEEEiedjustify{1}}%center
+\def\IEEEiedlabeljustifyr{\def\@IEEEiedjustify{2}}%right
+
+
+
+
+% commands to save to and restore from the list parameter copies
+% this allows us to set all the list parameters within
+% the list_decl and prevent \list (and its \@list) 
+% from overriding any of our parameters
+% V1.6 use \edefs instead of dimen's to conserve dimen registers
+% Note controlled spacing here, shield end of lines with %
+\def\@IEEEsavelistparams{\edef\@IEEEiedtopsep{\the\topsep}%
+\edef\@IEEEiedlabelwidth{\the\labelwidth}%
+\edef\@IEEEiedlabelsep{\the\labelsep}%
+\edef\@IEEEiedleftmargin{\the\leftmargin}%
+\edef\@IEEEiedpartopsep{\the\partopsep}%
+\edef\@IEEEiedparsep{\the\parsep}%
+\edef\@IEEEieditemsep{\the\itemsep}%
+\edef\@IEEEiedrightmargin{\the\rightmargin}%
+\edef\@IEEEiedlistparindent{\the\listparindent}%
+\edef\@IEEEieditemindent{\the\itemindent}}
+
+% Note controlled spacing here
+\def\@IEEErestorelistparams{\topsep\@IEEEiedtopsep\relax%
+\labelwidth\@IEEEiedlabelwidth\relax%
+\labelsep\@IEEEiedlabelsep\relax%
+\leftmargin\@IEEEiedleftmargin\relax%
+\partopsep\@IEEEiedpartopsep\relax%
+\parsep\@IEEEiedparsep\relax%
+\itemsep\@IEEEieditemsep\relax%
+\rightmargin\@IEEEiedrightmargin\relax%
+\listparindent\@IEEEiedlistparindent\relax%
+\itemindent\@IEEEieditemindent\relax}
+
+
+% v1.6b provide original LaTeX IED list environments
+% note that latex.ltx defines \itemize and \enumerate, but not \description
+% which must be created by the base classes
+% save original LaTeX itemize and enumerate
+\let\LaTeXitemize\itemize
+\let\endLaTeXitemize\enditemize
+\let\LaTeXenumerate\enumerate
+\let\endLaTeXenumerate\endenumerate
+% base class should define \description
+\let\LaTeXdescription\description
+\let\endLaTeXdescription\enddescription
+
+
+% override LaTeX's default IED lists, if the user requested it
+\if@IEEETOOLSredeflists
+\def\itemize{\@IEEEitemize}
+\def\enditemize{\@endIEEEitemize}
+\def\enumerate{\@IEEEenumerate}
+\def\endenumerate{\@endIEEEenumerate}
+\def\description{\@IEEEdescription}
+\def\enddescription{\@endIEEEdescription}
+\fi
+
+
+% provide the user with the IEEE IED commands
+\def\IEEEitemize{\@IEEEitemize}
+\def\endIEEEitemize{\@endIEEEitemize}
+\def\IEEEenumerate{\@IEEEenumerate}
+\def\endIEEEenumerate{\@endIEEEenumerate}
+\def\IEEEdescription{\@IEEEdescription}
+\def\endIEEEdescription{\@endIEEEdescription}
+
+
+% V1.6 we want to keep the IEEEtran IED list definitions as our own internal
+% commands so they are protected against redefinition
+\def\@IEEEitemize{\@ifnextchar[{\@@IEEEitemize}{\@@IEEEitemize[\relax]}}
+\def\@IEEEenumerate{\@ifnextchar[{\@@IEEEenumerate}{\@@IEEEenumerate[\relax]}}
+\def\@IEEEdescription{\@ifnextchar[{\@@IEEEdescription}{\@@IEEEdescription[\relax]}}
+\def\@endIEEEitemize{\endlist}
+\def\@endIEEEenumerate{\endlist}
+\def\@endIEEEdescription{\endlist}
+
+
+% DO NOT ALLOW BLANK LINES TO BE IN THESE IED ENVIRONMENTS
+% AS THIS WILL FORCE NEW PARAGRAPHS AFTER THE IED LISTS
+% IEEEtran itemized list MDS 1/2001
+% Note controlled spacing here, shield end of lines with %
+\def\@@IEEEitemize[#1]{%
+                \ifnum\@itemdepth>3\relax\@toodeep\else%
+                \ifnum\@listdepth>5\relax\@toodeep\else%
+                \advance\@itemdepth\@ne%
+                \edef\@itemitem{labelitem\romannumeral\the\@itemdepth}%
+                % get the IEEElabelindentfactor for this level
+                \advance\@listdepth\@ne% we need to know what the level WILL be
+                \edef\IEEElabelindentfactor{\csname IEEElabelindentfactor\romannumeral\the\@listdepth\endcsname}%
+                \advance\@listdepth-\@ne% undo our increment
+                \def\@IEEEiedjustify{2}% right justified labels are default
+                % set other defaults
+                \IEEEnocalcleftmarginfalse%
+                \IEEEnolabelindentfactorfalse%
+                \topsep\IEEEiedtopsep%
+                \IEEElabelindent\IEEEilabelindent%
+                \labelsep\IEEEiednormlabelsep%
+                \partopsep 0ex%
+                \parsep 0ex%
+                \itemsep 0ex%
+                \rightmargin 0em%
+                \listparindent 0em%
+                \itemindent 0em%
+                % calculate the label width
+                % the user can override this later if
+                % they specified a \labelwidth
+                \settowidth{\labelwidth}{\csname labelitem\romannumeral\the\@itemdepth\endcsname}%
+                \@IEEEsavelistparams% save our list parameters
+                \list{\csname\@itemitem\endcsname}{%
+                \@IEEErestorelistparams% override any list{} changes
+                                       % to our globals
+                \let\makelabel\@IEEEiedmakelabel% v1.6b setup \makelabel
+                \IEEEiedlistdecl% let user alter parameters
+                #1\relax%
+                % If the user has requested not to use the
+                % IEEElabelindent factor, don't revise \IEEElabelindent
+                \ifIEEEnolabelindentfactor\relax%
+                \else\IEEElabelindent=\IEEElabelindentfactor\IEEElabelindent%
+                \fi%
+                % Unless the user has requested otherwise,
+                % calculate our left margin based
+                % on \IEEElabelindent, \labelwidth and
+                % \labelsep
+                \ifIEEEnocalcleftmargin\relax%
+                \else\IEEEcalcleftmargin{\IEEElabelindent}%
+                \fi}\fi\fi}%
+
+
+% DO NOT ALLOW BLANK LINES TO BE IN THESE IED ENVIRONMENTS
+% AS THIS WILL FORCE NEW PARAGRAPHS AFTER THE IED LISTS
+% IEEEtran enumerate list MDS 1/2001
+% Note controlled spacing here, shield end of lines with %
+\def\@@IEEEenumerate[#1]{%
+                \ifnum\@enumdepth>3\relax\@toodeep\else%
+                \ifnum\@listdepth>5\relax\@toodeep\else%
+                \advance\@enumdepth\@ne%
+                \edef\@enumctr{enum\romannumeral\the\@enumdepth}%
+                % get the IEEElabelindentfactor for this level
+                \advance\@listdepth\@ne% we need to know what the level WILL be
+                \edef\IEEElabelindentfactor{\csname IEEElabelindentfactor\romannumeral\the\@listdepth\endcsname}%
+                \advance\@listdepth-\@ne% undo our increment
+                \def\@IEEEiedjustify{2}% right justified labels are default
+                % set other defaults
+                \IEEEnocalcleftmarginfalse%
+                \IEEEnolabelindentfactorfalse%
+                \topsep\IEEEiedtopsep%
+                \IEEElabelindent\IEEEelabelindent%
+                \labelsep\IEEEiednormlabelsep%
+                \partopsep 0ex%
+                \parsep 0ex%
+                \itemsep 0ex%
+                \rightmargin 0em%
+                \listparindent 0em%
+                \itemindent 0em%
+                % calculate the label width
+                % We'll set it to the width suitable for all labels using
+                % normalfont 1) to 9)
+                % The user can override this later
+                \settowidth{\labelwidth}{9)}%
+                \@IEEEsavelistparams% save our list parameters
+                \list{\csname label\@enumctr\endcsname}{\usecounter{\@enumctr}%
+                \@IEEErestorelistparams% override any list{} changes
+                                       % to our globals
+                \let\makelabel\@IEEEiedmakelabel% v1.6b setup \makelabel
+                \IEEEiedlistdecl% let user alter parameters 
+                #1\relax%
+                % If the user has requested not to use the
+                % IEEElabelindent factor, don't revise \IEEElabelindent
+                \ifIEEEnolabelindentfactor\relax%
+                \else\IEEElabelindent=\IEEElabelindentfactor\IEEElabelindent%
+                \fi%
+                % Unless the user has requested otherwise,
+                % calculate our left margin based
+                % on \IEEElabelindent, \labelwidth and
+                % \labelsep
+                \ifIEEEnocalcleftmargin\relax%
+                \else\IEEEcalcleftmargin{\IEEElabelindent}%
+                \fi}\fi\fi}%
+
+
+% DO NOT ALLOW BLANK LINES TO BE IN THESE IED ENVIRONMENTS
+% AS THIS WILL FORCE NEW PARAGRAPHS AFTER THE IED LISTS
+% IEEEtran description list MDS 1/2001
+% Note controlled spacing here, shield end of lines with %
+\def\@@IEEEdescription[#1]{%
+                \ifnum\@listdepth>5\relax\@toodeep\else%
+                % get the IEEElabelindentfactor for this level
+                \advance\@listdepth\@ne% we need to know what the level WILL be
+                \edef\IEEElabelindentfactor{\csname IEEElabelindentfactor\romannumeral\the\@listdepth\endcsname}%
+                \advance\@listdepth-\@ne% undo our increment
+                \def\@IEEEiedjustify{0}% left justified labels are default
+                % set other defaults
+                \IEEEnocalcleftmarginfalse%
+                \IEEEnolabelindentfactorfalse%
+                \topsep\IEEEiedtopsep% 
+                \IEEElabelindent\IEEEdlabelindent%
+                % assume normal labelsep
+                \labelsep\IEEEiednormlabelsep%
+                \partopsep 0ex%
+                \parsep 0ex%
+                \itemsep 0ex%
+                \rightmargin 0em%
+                \listparindent 0em%
+                \itemindent 0em%
+                % Bogus label width in case the user forgets
+                % to set it.
+                % TIP: If you want to see what a variable's width is you
+                % can use the TeX command \showthe\width-variable to 
+                % display it on the screen during compilation 
+                % (This might be helpful to know when you need to find out
+                % which label is the widest)
+                \settowidth{\labelwidth}{Hello}%
+                \@IEEEsavelistparams% save our list parameters
+                \list{}{\@IEEErestorelistparams% override any list{} changes
+                                               % to our globals
+                \let\makelabel\@IEEEiedmakelabel% v1.6b setup \makelabel
+                \IEEEiedlistdecl% let user alter parameters 
+                #1\relax%
+                % If the user has requested not to use the
+                % labelindent factor, don't revise \IEEElabelindent
+                \ifIEEEnolabelindentfactor\relax%
+                \else\IEEElabelindent=\IEEElabelindentfactor\IEEElabelindent%
+                \fi%
+                % Unless the user has requested otherwise,
+                % calculate our left margin based
+                % on \IEEElabelindent, \labelwidth and
+                % \labelsep
+                \ifIEEEnocalcleftmargin\relax%
+                \else\IEEEcalcleftmargin{\IEEElabelindent}\relax%
+                \fi}\fi}
+
+% v1.6b we use one makelabel that does justification as needed.
+\def\@IEEEiedmakelabel#1{\relax\if\@IEEEiedjustify 0\relax
+\makebox[\labelwidth][l]{\normalfont #1}\else
+\if\@IEEEiedjustify 1\relax
+\makebox[\labelwidth][c]{\normalfont #1}\else
+\makebox[\labelwidth][r]{\normalfont #1}\fi\fi}
+
+
+
+
+
+
+
+
+
+% used only by IEEEtran's IEEEeqnarray as other packages may
+% have their own, different, implementations
+\newcounter{IEEEsubequation}[equation]
+
+% e.g., "1a" (used only by IEEEtran's IEEEeqnarray)
+\def\theIEEEsubequation{\theequation\alph{IEEEsubequation}}
+% just like LaTeX2e's \@eqnnum
+\def\theequationdis{{\normalfont \normalcolor (\theequation)}}% (1)
+% IEEEsubequation used only by IEEEtran's IEEEeqnarray
+\def\theIEEEsubequationdis{{\normalfont \normalcolor (\theIEEEsubequation)}}% (1a)
+
+
+
+
+%%
+%% START OF IEEEeqnarray DEFINITIONS
+%%
+%% Inspired by the concepts, examples, and previous works of LaTeX 
+%% coders and developers such as Donald Arseneau, Fred Bartlett, 
+%% David Carlisle, Tony Liu, Frank Mittelbach, Piet van Oostrum, 
+%% Roland Winkler and Mark Wooding.
+%% I don't make the claim that my work here is even near their calibre. ;)
+
+
+% hook to allow easy changeover to IEEEtran.cls/tools.sty error reporting
+\def\@IEEEclspkgerror{\ClassError{IEEEtran}}
+
+\newif\if@IEEEeqnarrayboxnojot% flag to indicate if the environment was called as the star form
+\@IEEEeqnarrayboxnojotfalse
+
+\newif\if@advanceIEEEeqncolcnt% tracks if the environment should advance the col counter
+% allows a way to make an \IEEEeqnarraybox that can be used within an \IEEEeqnarray
+% used by IEEEeqnarraymulticol so that it can work properly in both
+\@advanceIEEEeqncolcnttrue
+
+\newcount\@IEEEeqnnumcols % tracks how many IEEEeqnarray cols are defined
+\newcount\@IEEEeqncolcnt  % tracks how many IEEEeqnarray cols the user actually used
+
+
+% The default math style used by the columns
+\def\IEEEeqnarraymathstyle{\displaystyle}
+% The default text style used by the columns
+% default to using the current font
+\def\IEEEeqnarraytextstyle{\relax}
+
+% like the iedlistdecl but for \IEEEeqnarray
+\def\IEEEeqnarraydecl{\relax}
+\def\IEEEeqnarrayboxdecl{\relax}
+
+
+
+% V1.8 flags to indicate that equation numbering is to persist
+\newif\if@IEEEeqnumpersist%
+\@IEEEeqnumpersistfalse
+\newif\if@IEEEsubeqnumpersist%
+\@IEEEsubeqnumpersistfalse
+%
+% V1.8 flags to indicate if (sub)equation number of last line was preadvanced
+\newif\if@IEEEeqnumpreadv%
+\@IEEEeqnumpreadvfalse
+\newif\if@IEEEsubeqnumpreadv%
+\@IEEEsubeqnumpreadvfalse
+
+\newcount\@IEEEsubeqnnumrollback% saves previous value of IEEEsubequation number in case we need to restore it
+
+% \yesnumber is the opposite of \nonumber
+% a novel concept with the same def as the equationarray package
+% However, we give IEEE versions too since some LaTeX packages such as 
+% the MDWtools mathenv.sty redefine \nonumber to something else.
+% This command is intended for use in non-IEEEeqnarray math environments
+\providecommand{\yesnumber}{\global\@eqnswtrue}
+
+
+% IEEEyes/nonumber 
+% V1.8 add persistant * forms
+% These commands can alter the type of equation an IEEEeqnarray line is.
+\def\IEEEyesnumber{\@ifstar{\global\@IEEEeqnumpersisttrue\global\@IEEEsubeqnumpersistfalse\@IEEEyesnumber}{\@IEEEyesnumber}}
+
+\def\@IEEEyesnumber{\global\@eqnswtrue
+\if@IEEEeqnarrayISinner% alter counters and label only inside an IEEEeqnarray
+\ifnum\c@IEEEsubequation>0\relax
+   \stepcounter{equation}\setcounter{IEEEsubequation}{0}\gdef\@currentlabel{\p@equation\theequation}\relax
+   \gdef\@currentHref{\@IEEEtheHrefequation}% setup hyperref label
+\fi
+% even if we reached this eqn num via a preadv, it is legit now
+\global\@IEEEeqnumpreadvfalse\global\@IEEEsubeqnumpreadvfalse
+\fi}
+
+\def\IEEEnonumber{\@ifstar{\global\@IEEEeqnumpersistfalse\global\@IEEEsubeqnumpersistfalse\global\@eqnswfalse}{\global\@eqnswfalse}}
+
+
+\def\IEEEyessubnumber{\@ifstar{\global\@IEEEsubeqnumpersisttrue\@IEEEyessubnumber}{\@IEEEyessubnumber}}
+%
+\def\@IEEEyessubnumber{\if@IEEEeqnarrayISinner% alter counters and label only inside an IEEEeqnarray
+  \ifnum\c@IEEEsubequation>0\relax% if it already is a subequation, we are good to go as-is
+  \else% if we are a regular equation we have to watch out for two cases
+    \if@IEEEeqnumpreadv% if this equation is the result of a preadvance, backout and bump the sub eqnnum
+       \global\advance\c@equation\m@ne\global\c@IEEEsubequation=\@IEEEsubeqnnumrollback\addtocounter{IEEEsubequation}{1}\relax
+    \else% non-preadvanced equations just need initialization of their sub eqnnum
+       \setcounter{IEEEsubequation}{1}\relax
+    \fi
+  \fi% fi already is subequation
+  \gdef\@currentlabel{\p@IEEEsubequation\theIEEEsubequation}\relax
+  \gdef\@currentHref{\@IEEEtheHrefsubequation}% setup hyperref label
+  \global\@IEEEeqnumpreadvfalse\global\@IEEEsubeqnumpreadvfalse% no longer a preadv anymore
+  \global\@eqnswtrue
+\fi}
+
+
+\def\IEEEnosubnumber{\@ifstar{\global\@IEEEsubeqnumpersistfalse\@IEEEnosubnumber}{\@IEEEnosubnumber}}
+%
+\def\@IEEEnosubnumber{\if@IEEEeqnarrayISinner% alter counters and label only inside an IEEEeqnarray
+  \if@eqnsw % we do nothing unless we know we will display because we play with the counters here
+    % if it currently is a subequation, bump up to the next equation number and turn off the subequation
+    \ifnum\c@IEEEsubequation>0\relax\addtocounter{equation}{1}\setcounter{IEEEsubequation}{0}\relax
+    \fi
+    \global\@IEEEeqnumpreadvfalse\global\@IEEEsubeqnumpreadvfalse% no longer a preadv anymore
+    \gdef\@currentlabel{\p@equation\theequation}\relax
+    \gdef\@currentHref{\@IEEEtheHrefequation}% setup hyperref label
+  \fi
+\fi}
+
+
+
+% allows users to "push away" equations that get too close to the equation numbers
+\def\IEEEeqnarraynumspace{\hphantom{\ifnum\c@IEEEsubequation>0\relax\theIEEEsubequationdis\else\theequationdis\fi}}
+
+% provides a way to span multiple columns within IEEEeqnarray environments
+% will consider \if@advanceIEEEeqncolcnt before globally advancing the
+% column counter - so as to work within \IEEEeqnarraybox
+% usage: \IEEEeqnarraymulticol{number cols. to span}{col type}{cell text}
+\long\def\IEEEeqnarraymulticol#1#2#3{\multispan{#1}\relax
+% check if column is defined for the precolumn definition
+% We have to be careful here because TeX scans for & even within an \iffalse
+% where it does not expand macros. So, if we used only one \ifx and a #3
+% appeared in the false branch and the user inserted another alignment
+% structure that uses & in the \IEEEeqnarraymulticol{}, TeX will not see that
+% there is an inner alignment in the false branch yet still will see any &
+% there and will think that they apply to the outer alignment resulting in an
+% incomplete \ifx error.
+% So, here we use separate checks for the pre and post parts in order to keep
+% the #3 outside of all conditionals.
+\relax\expandafter\ifx\csname @IEEEeqnarraycolDEF#2\endcsname\@IEEEeqnarraycolisdefined\relax
+\csname @IEEEeqnarraycolPRE#2\endcsname
+\else% if not, error and use default type
+\@IEEEclspkgerror{Invalid column type "#2" in \string\IEEEeqnarraymulticol.\MessageBreak
+Using a default centering column instead}%
+{You must define IEEEeqnarray column types before use.}%
+\csname @IEEEeqnarraycolPRE@IEEEdefault\endcsname
+\fi
+% The ten \relax are to help prevent misleading error messages in case a user
+% accidently inserted a macro that tries to acquire additional arguments.
+#3\relax\relax\relax\relax\relax\relax\relax\relax\relax\relax
+% check if column is defined for the postcolumn definition
+\expandafter\ifx\csname @IEEEeqnarraycolDEF#2\endcsname\@IEEEeqnarraycolisdefined\relax
+\csname @IEEEeqnarraycolPOST#2\endcsname
+\else% if not, use the default type
+\csname @IEEEeqnarraycolPOST@IEEEdefault\endcsname
+\fi
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by #1\relax\fi}
+
+% like \omit, but maintains track of the column counter for \IEEEeqnarray
+\def\IEEEeqnarrayomit{\omit\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by 1\relax\fi}
+
+
+% provides a way to define a letter referenced column type
+% usage: \IEEEeqnarraydefcol{col. type letter/name}{pre insertion text}{post insertion text}
+\def\IEEEeqnarraydefcol#1#2#3{\expandafter\def\csname @IEEEeqnarraycolPRE#1\endcsname{#2}%
+\expandafter\def\csname @IEEEeqnarraycolPOST#1\endcsname{#3}%
+\expandafter\def\csname @IEEEeqnarraycolDEF#1\endcsname{1}}
+
+
+% provides a way to define a numerically referenced inter-column glue types
+% usage: \IEEEeqnarraydefcolsep{col. glue number}{glue definition}
+\def\IEEEeqnarraydefcolsep#1#2{\expandafter\def\csname @IEEEeqnarraycolSEP\romannumeral #1\endcsname{#2}%
+\expandafter\def\csname @IEEEeqnarraycolSEPDEF\romannumeral #1\endcsname{1}}
+
+
+\def\@IEEEeqnarraycolisdefined{1}% just a macro for 1, used for checking undefined column types
+
+
+% expands and appends the given argument to the \@IEEEtrantmptoksA token list
+% used to build up the \halign preamble
+\def\@IEEEappendtoksA#1{\edef\@@IEEEappendtoksA{\@IEEEtrantmptoksA={\the\@IEEEtrantmptoksA #1}}%
+\@@IEEEappendtoksA}
+
+% also appends to \@IEEEtrantmptoksA, but does not expand the argument
+% uses \toks8 as a scratchpad register
+\def\@IEEEappendNOEXPANDtoksA#1{\toks8={#1}%
+\edef\@@IEEEappendNOEXPANDtoksA{\@IEEEtrantmptoksA={\the\@IEEEtrantmptoksA\the\toks8}}%
+\@@IEEEappendNOEXPANDtoksA}
+
+% define some common column types for the user
+% math
+\IEEEeqnarraydefcol{l}{$\IEEEeqnarraymathstyle}{$\hfil}
+\IEEEeqnarraydefcol{c}{\hfil$\IEEEeqnarraymathstyle}{$\hfil}
+\IEEEeqnarraydefcol{r}{\hfil$\IEEEeqnarraymathstyle}{$}
+\IEEEeqnarraydefcol{L}{$\IEEEeqnarraymathstyle{}}{{}$\hfil}
+\IEEEeqnarraydefcol{C}{\hfil$\IEEEeqnarraymathstyle{}}{{}$\hfil}
+\IEEEeqnarraydefcol{R}{\hfil$\IEEEeqnarraymathstyle{}}{{}$}
+% text
+\IEEEeqnarraydefcol{s}{\IEEEeqnarraytextstyle}{\hfil}
+\IEEEeqnarraydefcol{t}{\hfil\IEEEeqnarraytextstyle}{\hfil}
+\IEEEeqnarraydefcol{u}{\hfil\IEEEeqnarraytextstyle}{}
+
+% vertical rules
+\IEEEeqnarraydefcol{v}{}{\vrule width\arrayrulewidth}
+\IEEEeqnarraydefcol{vv}{\vrule width\arrayrulewidth\hfil}{\hfil\vrule width\arrayrulewidth}
+\IEEEeqnarraydefcol{V}{}{\vrule width\arrayrulewidth\hskip\doublerulesep\vrule width\arrayrulewidth}
+\IEEEeqnarraydefcol{VV}{\vrule width\arrayrulewidth\hskip\doublerulesep\vrule width\arrayrulewidth\hfil}%
+{\hfil\vrule width\arrayrulewidth\hskip\doublerulesep\vrule width\arrayrulewidth}
+
+% horizontal rules
+\IEEEeqnarraydefcol{h}{}{\leaders\hrule height\arrayrulewidth\hfil}
+\IEEEeqnarraydefcol{H}{}{\leaders\vbox{\hrule width\arrayrulewidth\vskip\doublerulesep\hrule width\arrayrulewidth}\hfil}
+
+% plain
+\IEEEeqnarraydefcol{x}{}{}
+\IEEEeqnarraydefcol{X}{$}{$}
+
+% the default column type to use in the event a column type is not defined
+\IEEEeqnarraydefcol{@IEEEdefault}{\hfil$\IEEEeqnarraymathstyle}{$\hfil}
+
+
+% a zero tabskip (used for "-" col types)
+\def\@IEEEeqnarraycolSEPzero{0pt plus 0pt minus 0pt}
+% a centering tabskip (used for "+" col types)
+\def\@IEEEeqnarraycolSEPcenter{1000pt plus 0pt minus 1000pt}
+
+% top level default tabskip glues for the start, end, and inter-column
+% may be reset within environments not always at the top level, e.g., \IEEEeqnarraybox
+\edef\@IEEEeqnarraycolSEPdefaultstart{\@IEEEeqnarraycolSEPcenter}% default start glue
+\edef\@IEEEeqnarraycolSEPdefaultend{\@IEEEeqnarraycolSEPcenter}% default end glue
+\edef\@IEEEeqnarraycolSEPdefaultmid{\@IEEEeqnarraycolSEPzero}% default inter-column glue
+
+
+
+% creates a vertical rule that extends from the bottom to the top a a cell
+% Provided in case other packages redefine \vline some other way.
+% usage: \IEEEeqnarrayvrule[rule thickness]
+% If no argument is provided, \arrayrulewidth will be used for the rule thickness. 
+\newcommand\IEEEeqnarrayvrule[1][\arrayrulewidth]{\vrule\@width#1\relax}
+
+% creates a blank separator row
+% usage: \IEEEeqnarrayseprow[separation length][font size commands]
+% default is \IEEEeqnarrayseprow[0.25\normalbaselineskip][\relax]
+% blank arguments inherit the default values
+% uses \skip5 as a scratch register - calls \@IEEEeqnarraystrutsize which uses more scratch registers
+\def\IEEEeqnarrayseprow{\relax\@ifnextchar[{\@IEEEeqnarrayseprow}{\@IEEEeqnarrayseprow[0.25\normalbaselineskip]}}
+\def\@IEEEeqnarrayseprow[#1]{\relax\@ifnextchar[{\@@IEEEeqnarrayseprow[#1]}{\@@IEEEeqnarrayseprow[#1][\relax]}}
+\def\@@IEEEeqnarrayseprow[#1][#2]{\def\@IEEEeqnarrayseprowARGONE{#1}%
+\ifx\@IEEEeqnarrayseprowARGONE\@empty%
+% get the skip value, based on the font commands
+% use skip5 because \IEEEeqnarraystrutsize uses \skip0, \skip2, \skip3
+% assign within a bogus box to confine the font changes
+{\setbox0=\hbox{#2\relax\global\skip5=0.25\normalbaselineskip}}%
+\else%
+{\setbox0=\hbox{#2\relax\global\skip5=#1}}%
+\fi%
+\@IEEEeqnarrayhoptolastcolumn\IEEEeqnarraystrutsize{\skip5}{0pt}[\relax]\relax}
+
+% creates a blank separator row, but omits all the column templates
+% usage: \IEEEeqnarrayseprowcut[separation length][font size commands]
+% default is \IEEEeqnarrayseprowcut[0.25\normalbaselineskip][\relax]
+% blank arguments inherit the default values
+% uses \skip5 as a scratch register - calls \@IEEEeqnarraystrutsize which uses more scratch registers
+\def\IEEEeqnarrayseprowcut{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarrayseprowcut}{\@IEEEeqnarrayseprowcut[0.25\normalbaselineskip]}}
+\def\@IEEEeqnarrayseprowcut[#1]{\relax\@ifnextchar[{\@@IEEEeqnarrayseprowcut[#1]}{\@@IEEEeqnarrayseprowcut[#1][\relax]}}
+\def\@@IEEEeqnarrayseprowcut[#1][#2]{\def\@IEEEeqnarrayseprowARGONE{#1}%
+\ifx\@IEEEeqnarrayseprowARGONE\@empty%
+% get the skip value, based on the font commands
+% use skip5 because \IEEEeqnarraystrutsize uses \skip0, \skip2, \skip3
+% assign within a bogus box to confine the font changes
+{\setbox0=\hbox{#2\relax\global\skip5=0.25\normalbaselineskip}}%
+\else%
+{\setbox0=\hbox{#2\relax\global\skip5=#1}}%
+\fi%
+\IEEEeqnarraystrutsize{\skip5}{0pt}[\relax]\relax}
+
+
+
+% draws a single rule across all the columns optional
+% argument determines the rule width, \arrayrulewidth is the default
+% updates column counter as needed and turns off struts
+% usage: \IEEEeqnarrayrulerow[rule line thickness]
+\def\IEEEeqnarrayrulerow{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarrayrulerow}{\@IEEEeqnarrayrulerow[\arrayrulewidth]}}
+\def\@IEEEeqnarrayrulerow[#1]{\leaders\hrule height#1\hfil\relax% put in our rule 
+% turn off any struts
+\IEEEeqnarraystrutsize{0pt}{0pt}[\relax]\relax}
+
+
+% draws a double rule by using a single rule row, a separator row, and then
+% another single rule row 
+% first optional argument determines the rule thicknesses, \arrayrulewidth is the default
+% second optional argument determines the rule spacing, \doublerulesep is the default
+% usage: \IEEEeqnarraydblrulerow[rule line thickness][rule spacing]
+\def\IEEEeqnarraydblrulerow{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarraydblrulerow}{\@IEEEeqnarraydblrulerow[\arrayrulewidth]}}
+\def\@IEEEeqnarraydblrulerow[#1]{\relax\@ifnextchar[{\@@IEEEeqnarraydblrulerow[#1]}%
+{\@@IEEEeqnarraydblrulerow[#1][\doublerulesep]}}
+\def\@@IEEEeqnarraydblrulerow[#1][#2]{\def\@IEEEeqnarraydblrulerowARG{#1}%
+% we allow the user to say \IEEEeqnarraydblrulerow[][]
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]\relax%
+\fi%
+\def\@IEEEeqnarraydblrulerowARG{#2}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\\\IEEEeqnarrayseprow[\doublerulesep][\relax]%
+\else%
+\\\IEEEeqnarrayseprow[#2][\relax]%
+\fi%
+\\\multispan{\@IEEEeqnnumcols}%
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\def\@IEEEeqnarraydblrulerowARG{#1}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]%
+\fi%
+}
+
+% draws a double rule by using a single rule row, a separator (cutting) row, and then
+% another single rule row 
+% first optional argument determines the rule thicknesses, \arrayrulewidth is the default
+% second optional argument determines the rule spacing, \doublerulesep is the default
+% usage: \IEEEeqnarraydblrulerow[rule line thickness][rule spacing]
+\def\IEEEeqnarraydblrulerowcut{\multispan{\@IEEEeqnnumcols}\relax% span all the cols
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\@ifnextchar[{\@IEEEeqnarraydblrulerowcut}{\@IEEEeqnarraydblrulerowcut[\arrayrulewidth]}}
+\def\@IEEEeqnarraydblrulerowcut[#1]{\relax\@ifnextchar[{\@@IEEEeqnarraydblrulerowcut[#1]}%
+{\@@IEEEeqnarraydblrulerowcut[#1][\doublerulesep]}}
+\def\@@IEEEeqnarraydblrulerowcut[#1][#2]{\def\@IEEEeqnarraydblrulerowARG{#1}%
+% we allow the user to say \IEEEeqnarraydblrulerow[][]
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]%
+\fi%
+\def\@IEEEeqnarraydblrulerowARG{#2}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\\\IEEEeqnarrayseprowcut[\doublerulesep][\relax]%
+\else%
+\\\IEEEeqnarrayseprowcut[#2][\relax]%
+\fi%
+\\\multispan{\@IEEEeqnnumcols}%
+% advance column counter only if the IEEEeqnarray environment wants it
+\if@advanceIEEEeqncolcnt\global\advance\@IEEEeqncolcnt by \@IEEEeqnnumcols\relax\fi%
+\def\@IEEEeqnarraydblrulerowARG{#1}%
+\ifx\@IEEEeqnarraydblrulerowARG\@empty%
+\@IEEEeqnarrayrulerow[\arrayrulewidth]%
+\else%
+\@IEEEeqnarrayrulerow[#1]%
+\fi%
+}
+
+
+
+% inserts a full row's worth of &'s
+% relies on \@IEEEeqnnumcols to provide the correct number of columns
+% uses \@IEEEtrantmptoksA, \count0 as scratch registers
+\def\@IEEEeqnarrayhoptolastcolumn{\@IEEEtrantmptoksA={}\count0=1\relax%
+\loop% add cols if the user did not use them all
+\ifnum\count0<\@IEEEeqnnumcols\relax%
+\@IEEEappendtoksA{&}%
+\advance\count0 by 1\relax% update the col count
+\repeat%
+\the\@IEEEtrantmptoksA%execute the &'s
+}
+
+
+
+\newif\if@IEEEeqnarrayISinner % flag to indicate if we are within the lines
+\@IEEEeqnarrayISinnerfalse    % of an IEEEeqnarray - after the IEEEeqnarraydecl
+
+\edef\@IEEEeqnarrayTHEstrutheight{0pt} % height and depth of IEEEeqnarray struts
+\edef\@IEEEeqnarrayTHEstrutdepth{0pt}
+
+\edef\@IEEEeqnarrayTHEmasterstrutheight{0pt} % default height and depth of
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{0pt}  % struts within an IEEEeqnarray
+
+\edef\@IEEEeqnarrayTHEmasterstrutHSAVE{0pt} % saved master strut height
+\edef\@IEEEeqnarrayTHEmasterstrutDSAVE{0pt} % and depth
+
+\newif\if@IEEEeqnarrayusemasterstrut % flag to indicate that the master strut value
+\@IEEEeqnarrayusemasterstruttrue     % is to be used
+
+
+
+% saves the strut height and depth of the master strut
+\def\@IEEEeqnarraymasterstrutsave{\relax%
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+% remove stretchability
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% save values
+\edef\@IEEEeqnarrayTHEmasterstrutHSAVE{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutDSAVE{\the\dimen2}}
+
+% restores the strut height and depth of the master strut
+\def\@IEEEeqnarraymasterstrutrestore{\relax%
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutHSAVE\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutDSAVE\relax%
+% remove stretchability
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% restore values
+\edef\@IEEEeqnarrayTHEmasterstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{\the\dimen2}}
+
+
+% globally restores the strut height and depth to the 
+% master values and sets the master strut flag to true
+\def\@IEEEeqnarraystrutreset{\relax%
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+% remove stretchability
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% restore values
+\xdef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\xdef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\global\@IEEEeqnarrayusemasterstruttrue}
+
+
+% if the master strut is not to be used, make the current
+% values of \@IEEEeqnarrayTHEstrutheight, \@IEEEeqnarrayTHEstrutdepth
+% and the use master strut flag, global
+% this allows user strut commands issued in the last column to be carried
+% into the isolation/strut column
+\def\@IEEEeqnarrayglobalizestrutstatus{\relax%
+\if@IEEEeqnarrayusemasterstrut\else%
+\xdef\@IEEEeqnarrayTHEstrutheight{\@IEEEeqnarrayTHEstrutheight}%
+\xdef\@IEEEeqnarrayTHEstrutdepth{\@IEEEeqnarrayTHEstrutdepth}%
+\global\@IEEEeqnarrayusemasterstrutfalse%
+\fi}
+
+
+
+% usage: \IEEEeqnarraystrutsize{height}{depth}[font size commands]
+% If called outside the lines of an IEEEeqnarray, sets the height
+% and depth of both the master and local struts. If called inside
+% an IEEEeqnarray line, sets the height and depth of the local strut
+% only and sets the flag to indicate the use of the local strut
+% values. If the height or depth is left blank, 0.7\normalbaselineskip
+% and 0.3\normalbaselineskip will be used, respectively.
+% The optional argument can be used to evaluate the lengths under
+% a different font size and styles. If none is specified, the current
+% font is used.
+% uses scratch registers \skip0, \skip2, \skip3, \dimen0, \dimen2
+\def\IEEEeqnarraystrutsize#1#2{\relax\@ifnextchar[{\@IEEEeqnarraystrutsize{#1}{#2}}{\@IEEEeqnarraystrutsize{#1}{#2}[\relax]}}
+\def\@IEEEeqnarraystrutsize#1#2[#3]{\def\@IEEEeqnarraystrutsizeARG{#1}%
+\ifx\@IEEEeqnarraystrutsizeARG\@empty%
+{\setbox0=\hbox{#3\relax\global\skip3=0.7\normalbaselineskip}}%
+\skip0=\skip3\relax%
+\else% arg one present
+{\setbox0=\hbox{#3\relax\global\skip3=#1\relax}}%
+\skip0=\skip3\relax%
+\fi% if null arg
+\def\@IEEEeqnarraystrutsizeARG{#2}%
+\ifx\@IEEEeqnarraystrutsizeARG\@empty%
+{\setbox0=\hbox{#3\relax\global\skip3=0.3\normalbaselineskip}}%
+\skip2=\skip3\relax%
+\else% arg two present
+{\setbox0=\hbox{#3\relax\global\skip3=#2\relax}}%
+\skip2=\skip3\relax%
+\fi% if null arg
+% remove stretchability, just to be safe
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% dimen0 = height, dimen2 = depth
+\if@IEEEeqnarrayISinner% inner does not touch master strut size
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstrutfalse% do not use master
+\else% outer, have to set master strut too
+\edef\@IEEEeqnarrayTHEmasterstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{\the\dimen2}%
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstruttrue% use master strut
+\fi}
+
+
+% usage: \IEEEeqnarraystrutsizeadd{added height}{added depth}[font size commands]
+% If called outside the lines of an IEEEeqnarray, adds the given height
+% and depth to both the master and local struts.
+% If called inside an IEEEeqnarray line, adds the given height and depth
+% to the local strut only and sets the flag to indicate the use 
+% of the local strut values.
+% In both cases, if a height or depth is left blank, 0pt is used instead.
+% The optional argument can be used to evaluate the lengths under
+% a different font size and styles. If none is specified, the current
+% font is used.
+% uses scratch registers \skip0, \skip2, \skip3, \dimen0, \dimen2
+\def\IEEEeqnarraystrutsizeadd#1#2{\relax\@ifnextchar[{\@IEEEeqnarraystrutsizeadd{#1}{#2}}{\@IEEEeqnarraystrutsizeadd{#1}{#2}[\relax]}}
+\def\@IEEEeqnarraystrutsizeadd#1#2[#3]{\def\@IEEEeqnarraystrutsizearg{#1}%
+\ifx\@IEEEeqnarraystrutsizearg\@empty%
+\skip0=0pt\relax%
+\else% arg one present
+{\setbox0=\hbox{#3\relax\global\skip3=#1}}%
+\skip0=\skip3\relax%
+\fi% if null arg
+\def\@IEEEeqnarraystrutsizearg{#2}%
+\ifx\@IEEEeqnarraystrutsizearg\@empty%
+\skip2=0pt\relax%
+\else% arg two present
+{\setbox0=\hbox{#3\relax\global\skip3=#2}}%
+\skip2=\skip3\relax%
+\fi% if null arg
+% remove stretchability, just to be safe
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% dimen0 = height, dimen2 = depth
+\if@IEEEeqnarrayISinner% inner does not touch master strut size
+% get local strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEstrutdepth\relax%
+% add it to the user supplied values
+\advance\dimen0 by \skip0\relax%
+\advance\dimen2 by \skip2\relax%
+% update the local strut size
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstrutfalse% do not use master
+\else% outer, have to set master strut too
+% get master strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+% add it to the user supplied values
+\advance\dimen0 by \skip0\relax%
+\advance\dimen2 by \skip2\relax%
+% update the local and master strut sizes
+\edef\@IEEEeqnarrayTHEmasterstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEmasterstrutdepth{\the\dimen2}%
+\edef\@IEEEeqnarrayTHEstrutheight{\the\dimen0}%
+\edef\@IEEEeqnarrayTHEstrutdepth{\the\dimen2}%
+\@IEEEeqnarrayusemasterstruttrue% use master strut
+\fi}
+
+
+% allow user a way to see the struts
+\newif\ifIEEEvisiblestruts
+\IEEEvisiblestrutsfalse
+
+% inserts an invisible strut using the master or local strut values
+% uses scratch registers \skip0, \skip2, \dimen0, \dimen2
+\def\@IEEEeqnarrayinsertstrut{\relax%
+\if@IEEEeqnarrayusemasterstrut
+% get master strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEmasterstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEmasterstrutdepth\relax%
+\else%
+% get local strut size
+\expandafter\skip0=\@IEEEeqnarrayTHEstrutheight\relax%
+\expandafter\skip2=\@IEEEeqnarrayTHEstrutdepth\relax%
+\fi%
+% remove stretchability, probably not needed
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+% dimen0 = height, dimen2 = depth
+% allow user to see struts if desired
+\ifIEEEvisiblestruts%
+\vrule width0.2pt height\dimen0 depth\dimen2\relax%
+\else%
+\vrule width0pt height\dimen0 depth\dimen2\relax\fi}
+
+
+% creates an invisible strut, useable even outside \IEEEeqnarray
+% if \IEEEvisiblestrutstrue, the strut will be visible and 0.2pt wide. 
+% usage: \IEEEstrut[height][depth][font size commands]
+% default is \IEEEstrut[0.7\normalbaselineskip][0.3\normalbaselineskip][\relax]
+% blank arguments inherit the default values
+% uses \dimen0, \dimen2, \skip0, \skip2
+\def\IEEEstrut{\relax\@ifnextchar[{\@IEEEstrut}{\@IEEEstrut[0.7\normalbaselineskip]}}
+\def\@IEEEstrut[#1]{\relax\@ifnextchar[{\@@IEEEstrut[#1]}{\@@IEEEstrut[#1][0.3\normalbaselineskip]}}
+\def\@@IEEEstrut[#1][#2]{\relax\@ifnextchar[{\@@@IEEEstrut[#1][#2]}{\@@@IEEEstrut[#1][#2][\relax]}}
+\def\@@@IEEEstrut[#1][#2][#3]{\mbox{#3\relax%
+\def\@IEEEstrutARG{#1}%
+\ifx\@IEEEstrutARG\@empty%
+\skip0=0.7\normalbaselineskip\relax%
+\else%
+\skip0=#1\relax%
+\fi%
+\def\@IEEEstrutARG{#2}%
+\ifx\@IEEEstrutARG\@empty%
+\skip2=0.3\normalbaselineskip\relax%
+\else%
+\skip2=#2\relax%
+\fi%
+% remove stretchability, probably not needed
+\dimen0\skip0\relax%
+\dimen2\skip2\relax%
+\ifIEEEvisiblestruts%
+\vrule width0.2pt height\dimen0 depth\dimen2\relax%
+\else%
+\vrule width0.0pt height\dimen0 depth\dimen2\relax\fi}}
+
+
+% enables strut mode by setting a default strut size and then zeroing the
+% \baselineskip, \lineskip, \lineskiplimit and \jot
+\def\IEEEeqnarraystrutmode{\IEEEeqnarraystrutsize{0.7\normalbaselineskip}{0.3\normalbaselineskip}[\relax]%
+\baselineskip=0pt\lineskip=0pt\lineskiplimit=0pt\jot=0pt}
+
+
+% equation and subequation forms to use to setup hyperref's \@currentHref
+\def\@IEEEtheHrefequation{equation.\theHequation}
+\def\@IEEEtheHrefsubequation{equation.\theHequation\alph{IEEEsubequation}}
+
+
+\def\IEEEeqnarray{\@IEEEeqnumpersisttrue\@IEEEsubeqnumpersistfalse\@IEEEeqnarray}
+\def\endIEEEeqnarray{\end@IEEEeqnarray}
+
+\@namedef{IEEEeqnarray*}{\@IEEEeqnumpersistfalse\@IEEEsubeqnumpersistfalse\@IEEEeqnarray}
+\@namedef{endIEEEeqnarray*}{\end@IEEEeqnarray}
+
+
+% \IEEEeqnarray is an enhanced \eqnarray. 
+% The star form defaults to not putting equation numbers at the end of each row.
+% usage: \IEEEeqnarray[decl]{cols}
+\def\@IEEEeqnarray{\relax\@ifnextchar[{\@@IEEEeqnarray}{\@@IEEEeqnarray[\relax]}}
+\def\@@IEEEeqnarray[#1]#2{%
+   % default to showing the equation number or not based on whether or not
+   % the star form was involked
+   \if@IEEEeqnumpersist\global\@eqnswtrue
+   \else% not the star form
+   \global\@eqnswfalse
+   \fi% if star form
+   % provide a basic hyperref \theHequation if this has not already been setup (hyperref not loaded, or no section counter)
+   \@ifundefined{theHequation}{\def\theHequation{\arabic{equation}}}{}\relax
+   % provide dummy hyperref commands in case hyperref is not loaded
+   \providecommand{\Hy@raisedlink}[1]{}\relax
+   \providecommand{\hyper@anchorstart}[1]{}\relax
+   \providecommand{\hyper@anchorend}{}\relax
+   \providecommand{\@currentHref}{}\relax
+   \@IEEEeqnumpreadvfalse% reset eqnpreadv flag
+   \@IEEEsubeqnumpreadvfalse% reset subeqnpreadv flag
+   \@IEEEeqnarrayISinnerfalse% not yet within the lines of the halign
+   \@IEEEeqnarraystrutsize{0pt}{0pt}[\relax]% turn off struts by default
+   \@IEEEeqnarrayusemasterstruttrue% use master strut till user asks otherwise
+   \IEEEvisiblestrutsfalse% diagnostic mode defaults to off
+   % no extra space unless the user specifically requests it
+   \lineskip=0pt\relax
+   \lineskiplimit=0pt\relax
+   \baselineskip=\normalbaselineskip\relax%
+   \jot=\IEEEnormaljot\relax%
+   \mathsurround\z@\relax% no extra spacing around math
+   \@advanceIEEEeqncolcnttrue% advance the col counter for each col the user uses, 
+                             % used in \IEEEeqnarraymulticol and in the preamble build
+   %V1.8 Here we preadvance to the next equation number.
+   % If the user later wants a continued subequation, we can roll back.
+   \global\@IEEEsubeqnnumrollback=\c@IEEEsubequation%
+   \stepcounter{equation}\@IEEEeqnumpreadvtrue% advance equation counter before first line
+   \setcounter{IEEEsubequation}{0}% no subequation yet
+   \let\@IEEEcurrentlabelsave\@currentlabel% save current label as we later change it globally
+   \let\@IEEEcurrentHrefsave\@currentHref% save current href label as we later change it globally
+   \def\@currentlabel{\p@equation\theequation}% redefine the ref label
+   \def\@currentHref{\@IEEEtheHrefequation}% setup hyperref label
+   \IEEEeqnarraydecl\relax% allow a way for the user to make global overrides
+   #1\relax% allow user to override defaults
+   \let\\\@IEEEeqnarraycr% replace newline with one that can put in eqn. numbers
+   \global\@IEEEeqncolcnt\z@% col. count = 0 for first line
+   \@IEEEbuildpreamble #2\end\relax% build the preamble and put it into \@IEEEtrantmptoksA 
+   % put in the column for the equation number
+   \ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi% col separator for those after the first
+   \toks0={##}%
+   % advance the \@IEEEeqncolcnt for the isolation col, this helps with error checking
+   \@IEEEappendtoksA{\global\advance\@IEEEeqncolcnt by 1\relax}%
+   % add the isolation column
+   \@IEEEappendtoksA{\tabskip\z@skip\bgroup\the\toks0\egroup}%
+   % advance the \@IEEEeqncolcnt for the equation number col, this helps with error checking
+   \@IEEEappendtoksA{&\global\advance\@IEEEeqncolcnt by 1\relax}%
+   % add the equation number col to the preamble
+   \@IEEEappendtoksA{\tabskip\z@skip\hb@xt@\z@\bgroup\hss\the\toks0\egroup}%
+   % note \@IEEEeqnnumcols does not count the equation col or isolation col
+   % set the starting tabskip glue as determined by the preamble build
+   \tabskip=\@IEEEBPstartglue\relax
+   % begin the display alignment
+   \@IEEEeqnarrayISinnertrue% commands are now within the lines
+   $$\everycr{}\halign to\displaywidth\bgroup
+   % "exspand" the preamble
+   \span\the\@IEEEtrantmptoksA\cr}
+
+% enter isolation/strut column (or the next column if the user did not use
+% every column), record the strut status, complete the columns, do the strut if needed,
+% restore counters (to backout any equation setup for a next line that was never used)
+% to their correct values and exit
+\def\end@IEEEeqnarray{\@IEEEeqnarrayglobalizestrutstatus&\@@IEEEeqnarraycr\egroup
+\if@IEEEsubeqnumpreadv\global\advance\c@IEEEsubequation\m@ne\fi
+\if@IEEEeqnumpreadv\global\advance\c@equation\m@ne\global\c@IEEEsubequation=\@IEEEsubeqnnumrollback\fi
+\global\let\@currentlabel\@IEEEcurrentlabelsave% restore current label
+\global\let\@currentHref\@IEEEcurrentHrefsave% restore current href label
+$$\@ignoretrue}
+
+
+% IEEEeqnarray uses a modifed \\ instead of the plain \cr to
+% end rows. This allows for things like \\*[vskip amount]
+% These "cr" macros are modified versions of those for LaTeX2e's eqnarray
+% the {\ifnum0=`} braces must be kept away from the last column to avoid
+% altering spacing of its math, so we use & to advance to the next column
+% as there is an isolation/strut column after the user's columns
+\def\@IEEEeqnarraycr{\@IEEEeqnarrayglobalizestrutstatus&% save strut status and advance to next column
+   {\ifnum0=`}\fi
+   \@ifstar{%
+      \global\@eqpen\@M\@IEEEeqnarrayYCR
+   }{%
+      \global\@eqpen\interdisplaylinepenalty \@IEEEeqnarrayYCR
+   }%
+}
+
+\def\@IEEEeqnarrayYCR{\@testopt\@IEEEeqnarrayXCR\z@skip}
+
+\def\@IEEEeqnarrayXCR[#1]{%
+   \ifnum0=`{\fi}%
+   \@@IEEEeqnarraycr
+   \noalign{\penalty\@eqpen\vskip\jot\vskip #1\relax}}%
+
+\def\@@IEEEeqnarraycr{\@IEEEtrantmptoksA={}% clear token register
+    \advance\@IEEEeqncolcnt by -1\relax% adjust col count because of the isolation column
+    \ifnum\@IEEEeqncolcnt>\@IEEEeqnnumcols\relax
+    \@IEEEclspkgerror{Too many columns within the IEEEeqnarray\MessageBreak
+                          environment}%
+    {Use fewer \string &'s or put more columns in the IEEEeqnarray column\MessageBreak 
+     specifications.}\relax%
+    \else
+    \loop% add cols if the user did not use them all
+    \ifnum\@IEEEeqncolcnt<\@IEEEeqnnumcols\relax
+    \@IEEEappendtoksA{&}%
+    \advance\@IEEEeqncolcnt by 1\relax% update the col count
+    \repeat
+    % this number of &'s will take us the the isolation column
+    \fi
+    % execute the &'s
+    \the\@IEEEtrantmptoksA%
+    % handle the strut/isolation column
+    \@IEEEeqnarrayinsertstrut% do the strut if needed
+    \@IEEEeqnarraystrutreset% reset the strut system for next line or IEEEeqnarray
+    &% and enter the equation number column
+    \if@eqnsw% only if we display something
+      \Hy@raisedlink{\hyper@anchorstart{\@currentHref}}% start a hyperref anchor
+      \global\@IEEEeqnumpreadvfalse\relax% displaying an equation number means
+      \global\@IEEEsubeqnumpreadvfalse\relax% the equation counters point to valid equations
+      % V1.8 Here we setup the counters, currentlabel and status for what would be the *next*
+      % equation line as would be the case under the current settings. However, there are two problems.
+      % One problem is that there might not ever be a next line. The second problem is that the user
+      % may later alter the meaning of a line with commands such as \IEEEyessubnumber. So, to handle
+      % these cases we have to record the current values of the (sub)equation counters and revert back
+      % to them if the next line is changed or never comes. The \if@IEEEeqnumpreadv, \if@IEEEsubeqnumpreadv
+      % and \@IEEEsubeqnnumrollback stuff tracks this.
+      % The logic to handle all this is surprisingly complex, but a nice feature of the approach here is
+      % that the equation counters and labels remain valid for what the line would be unless a
+      % \IEEEyessubnumber et al. later changes it. So, any hyperref links are always correct.
+      \ifnum\c@IEEEsubequation>0\relax% handle subequation
+         \theIEEEsubequationdis\relax
+         \if@IEEEsubeqnumpersist% setup for default type of next line
+            \stepcounter{IEEEsubequation}\global\@IEEEsubeqnumpreadvtrue\relax
+            \gdef\@currentlabel{\p@IEEEsubequation\theIEEEsubequation}\relax
+            \gdef\@currentHref{\@IEEEtheHrefsubequation}% setup hyperref label
+         \else
+             % if no subeqnum persist, go ahead and setup for a new equation number
+             \global\@IEEEsubeqnnumrollback=\c@IEEEsubequation
+             \stepcounter{equation}\global\@IEEEeqnumpreadvtrue\relax
+             \setcounter{IEEEsubequation}{0}\gdef\@currentlabel{\p@equation\theequation}\relax
+             \gdef\@currentHref{\@IEEEtheHrefequation}% setup hyperref label
+         \fi
+      \else% display a standard equation number
+        \theequationdis\relax
+        \setcounter{IEEEsubequation}{0}\relax% not really needed
+        \if@IEEEsubeqnumpersist% setup for default type of next line
+           % subequations that follow plain equations carry the same equation number e.g, 5, 5a rather than 5, 6a
+           \stepcounter{IEEEsubequation}\global\@IEEEsubeqnumpreadvtrue\relax
+           \gdef\@currentlabel{\p@IEEEsubequation\theIEEEsubequation}\relax
+           \gdef\@currentHref{\@IEEEtheHrefsubequation}% setup hyperref label
+         \else
+             % if no subeqnum persist, go ahead and setup for a new equation number
+             \global\@IEEEsubeqnnumrollback=\c@IEEEsubequation
+             \stepcounter{equation}\global\@IEEEeqnumpreadvtrue\relax
+             \setcounter{IEEEsubequation}{0}\gdef\@currentlabel{\p@equation\theequation}\relax
+             \gdef\@currentHref{\@IEEEtheHrefequation}% setup hyperref label
+         \fi
+      \fi%
+      \Hy@raisedlink{\hyper@anchorend}% end hyperref anchor
+    \fi% fi only if we display something
+    % reset the flags to indicate the default preferences of the display of equation numbers
+    \if@IEEEeqnumpersist\global\@eqnswtrue\else\global\@eqnswfalse\fi
+    \if@IEEEsubeqnumpersist\global\@eqnswtrue\fi% ditto for the subequation flag
+    % reset the number of columns the user actually used
+    \global\@IEEEeqncolcnt\z@\relax
+    % the real end of the line
+    \cr}
+
+
+
+
+
+% \IEEEeqnarraybox is like \IEEEeqnarray except the box form puts everything
+% inside a vtop, vbox, or vcenter box depending on the letter in the second
+% optional argument (t,b,c). Vbox is the default. Unlike \IEEEeqnarray,
+% equation numbers are not displayed and \IEEEeqnarraybox can be nested.
+% \IEEEeqnarrayboxm is for math mode (like \array) and does not put the vbox
+% within an hbox.
+% \IEEEeqnarrayboxt is for text mode (like \tabular) and puts the vbox within
+% a \hbox{$ $} construct.
+% \IEEEeqnarraybox will auto detect whether to use \IEEEeqnarrayboxm or 
+% \IEEEeqnarrayboxt depending on the math mode.
+% The third optional argument specifies the width this box is to be set to -
+% natural width is the default.
+% The * forms do not add \jot line spacing
+% usage: \IEEEeqnarraybox[decl][pos][width]{cols}
+\def\IEEEeqnarrayboxm{\@IEEEeqnarrayboxnojotfalse\@IEEEeqnarrayboxHBOXSWfalse\@IEEEeqnarraybox}
+\def\endIEEEeqnarrayboxm{\end@IEEEeqnarraybox}
+\@namedef{IEEEeqnarrayboxm*}{\@IEEEeqnarrayboxnojottrue\@IEEEeqnarrayboxHBOXSWfalse\@IEEEeqnarraybox}
+\@namedef{endIEEEeqnarrayboxm*}{\end@IEEEeqnarraybox}
+
+\def\IEEEeqnarrayboxt{\@IEEEeqnarrayboxnojotfalse\@IEEEeqnarrayboxHBOXSWtrue\@IEEEeqnarraybox}
+\def\endIEEEeqnarrayboxt{\end@IEEEeqnarraybox}
+\@namedef{IEEEeqnarrayboxt*}{\@IEEEeqnarrayboxnojottrue\@IEEEeqnarrayboxHBOXSWtrue\@IEEEeqnarraybox}
+\@namedef{endIEEEeqnarrayboxt*}{\end@IEEEeqnarraybox}
+
+\def\IEEEeqnarraybox{\@IEEEeqnarrayboxnojotfalse\ifmmode\@IEEEeqnarrayboxHBOXSWfalse\else\@IEEEeqnarrayboxHBOXSWtrue\fi%
+\@IEEEeqnarraybox}
+\def\endIEEEeqnarraybox{\end@IEEEeqnarraybox}
+
+\@namedef{IEEEeqnarraybox*}{\@IEEEeqnarrayboxnojottrue\ifmmode\@IEEEeqnarrayboxHBOXSWfalse\else\@IEEEeqnarrayboxHBOXSWtrue\fi%
+\@IEEEeqnarraybox}
+\@namedef{endIEEEeqnarraybox*}{\end@IEEEeqnarraybox}
+
+% flag to indicate if the \IEEEeqnarraybox needs to put things into an hbox{$ $} 
+% for \vcenter in non-math mode
+\newif\if@IEEEeqnarrayboxHBOXSW%
+\@IEEEeqnarrayboxHBOXSWfalse
+
+\def\@IEEEeqnarraybox{\relax\@ifnextchar[{\@@IEEEeqnarraybox}{\@@IEEEeqnarraybox[\relax]}}
+\def\@@IEEEeqnarraybox[#1]{\relax\@ifnextchar[{\@@@IEEEeqnarraybox[#1]}{\@@@IEEEeqnarraybox[#1][b]}}
+\def\@@@IEEEeqnarraybox[#1][#2]{\relax\@ifnextchar[{\@@@@IEEEeqnarraybox[#1][#2]}{\@@@@IEEEeqnarraybox[#1][#2][\relax]}}
+
+% #1 = decl; #2 = t,b,c; #3 = width, #4 = col specs
+\def\@@@@IEEEeqnarraybox[#1][#2][#3]#4{\@IEEEeqnarrayISinnerfalse % not yet within the lines of the halign
+   \@IEEEeqnarraymasterstrutsave% save current master strut values
+   \@IEEEeqnarraystrutsize{0pt}{0pt}[\relax]% turn off struts by default
+   \@IEEEeqnarrayusemasterstruttrue% use master strut till user asks otherwise
+   \IEEEvisiblestrutsfalse% diagnostic mode defaults to off
+   % no extra space unless the user specifically requests it
+   \lineskip=0pt\relax%
+   \lineskiplimit=0pt\relax%
+   \baselineskip=\normalbaselineskip\relax%
+   \jot=\IEEEnormaljot\relax%
+   \mathsurround\z@\relax% no extra spacing around math
+   % the default end glues are zero for an \IEEEeqnarraybox
+   \edef\@IEEEeqnarraycolSEPdefaultstart{\@IEEEeqnarraycolSEPzero}% default start glue
+   \edef\@IEEEeqnarraycolSEPdefaultend{\@IEEEeqnarraycolSEPzero}% default end glue
+   \edef\@IEEEeqnarraycolSEPdefaultmid{\@IEEEeqnarraycolSEPzero}% default inter-column glue
+   \@advanceIEEEeqncolcntfalse% do not advance the col counter for each col the user uses, 
+                              % used in \IEEEeqnarraymulticol and in the preamble build
+   \IEEEeqnarrayboxdecl\relax% allow a way for the user to make global overrides
+   #1\relax% allow user to override defaults
+   \let\\\@IEEEeqnarrayboxcr% replace newline with one that allows optional spacing
+   \@IEEEbuildpreamble #4\end\relax% build the preamble and put it into \@IEEEtrantmptoksA
+   % add an isolation column to the preamble to stop \\'s {} from getting into the last col
+   \ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi% col separator for those after the first
+   \toks0={##}%
+   % add the isolation column to the preamble
+   \@IEEEappendtoksA{\tabskip\z@skip\bgroup\the\toks0\egroup}% 
+   % set the starting tabskip glue as determined by the preamble build
+   \tabskip=\@IEEEBPstartglue\relax
+   % begin the alignment
+   \everycr{}%
+   % use only the very first token to determine the positioning
+   % this stops some problems when the user uses more than one letter,
+   % but is probably not worth the effort
+   % \noindent is used as a delimiter
+   \def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+   \@IEEEgrabfirstoken#2\relax\relax\noindent
+   % \@IEEEgrabbedfirstoken has the first token, the rest are discarded
+   % if we need to put things into and hbox and go into math mode, do so now
+   \if@IEEEeqnarrayboxHBOXSW \leavevmode \hbox \bgroup $\fi%
+   % use the appropriate vbox type
+   \if\@IEEEgrabbedfirstoken t\relax\vtop\else\if\@IEEEgrabbedfirstoken c\relax%
+   \vcenter\else\vbox\fi\fi\bgroup%
+   \@IEEEeqnarrayISinnertrue% commands are now within the lines
+   \ifx#3\relax\halign\else\halign to #3\relax\fi%
+   \bgroup
+   % "exspand" the preamble
+   \span\the\@IEEEtrantmptoksA\cr}
+
+% carry strut status and enter the isolation/strut column, 
+% exit from math mode if needed, and exit
+\def\end@IEEEeqnarraybox{\@IEEEeqnarrayglobalizestrutstatus% carry strut status
+&% enter isolation/strut column
+\@IEEEeqnarrayinsertstrut% do strut if needed
+\@IEEEeqnarraymasterstrutrestore% restore the previous master strut values
+% reset the strut system for next IEEEeqnarray
+% (sets local strut values back to previous master strut values)
+\@IEEEeqnarraystrutreset%
+% ensure last line, exit from halign, close vbox
+\crcr\egroup\egroup%
+% exit from math mode and close hbox if needed
+\if@IEEEeqnarrayboxHBOXSW $\egroup\fi}
+
+
+
+% IEEEeqnarraybox uses a modifed \\ instead of the plain \cr to
+% end rows. This allows for things like \\[vskip amount]
+% This "cr" macros are modified versions those for LaTeX2e's eqnarray
+% For IEEEeqnarraybox, \\* is the same as \\
+% the {\ifnum0=`} braces must be kept away from the last column to avoid
+% altering spacing of its math, so we use & to advance to the isolation/strut column
+% carry strut status into isolation/strut column
+\def\@IEEEeqnarrayboxcr{\@IEEEeqnarrayglobalizestrutstatus% carry strut status
+&% enter isolation/strut column
+\@IEEEeqnarrayinsertstrut% do strut if needed
+% reset the strut system for next line or IEEEeqnarray
+\@IEEEeqnarraystrutreset%
+{\ifnum0=`}\fi%
+\@ifstar{\@IEEEeqnarrayboxYCR}{\@IEEEeqnarrayboxYCR}}
+
+% test and setup the optional argument to \\[]
+\def\@IEEEeqnarrayboxYCR{\@testopt\@IEEEeqnarrayboxXCR\z@skip}
+
+% IEEEeqnarraybox does not automatically increase line spacing by \jot
+\def\@IEEEeqnarrayboxXCR[#1]{\ifnum0=`{\fi}%
+\cr\noalign{\if@IEEEeqnarrayboxnojot\else\vskip\jot\fi\vskip#1\relax}}
+
+
+
+% starts the halign preamble build
+\def\@IEEEbuildpreamble{\@IEEEtrantmptoksA={}% clear token register
+\let\@IEEEBPcurtype=u%current column type is not yet known
+\let\@IEEEBPprevtype=s%the previous column type was the start
+\let\@IEEEBPnexttype=u%next column type is not yet known
+% ensure these are valid
+\def\@IEEEBPcurglue={0pt plus 0pt minus 0pt}%
+\def\@IEEEBPcurcolname{@IEEEdefault}% name of current column definition
+% currently acquired numerically referenced glue
+% use a name that is easier to remember
+\let\@IEEEBPcurnum=\@IEEEtrantmpcountA%
+\@IEEEBPcurnum=0%
+% tracks number of columns in the preamble
+\@IEEEeqnnumcols=0%
+% record the default end glues
+\edef\@IEEEBPstartglue{\@IEEEeqnarraycolSEPdefaultstart}%
+\edef\@IEEEBPendglue{\@IEEEeqnarraycolSEPdefaultend}%
+% now parse the user's column specifications
+\@@IEEEbuildpreamble}
+
+
+% parses and builds the halign preamble
+\def\@@IEEEbuildpreamble#1#2{\let\@@nextIEEEbuildpreamble=\@@IEEEbuildpreamble%
+% use only the very first token to check the end
+% \noindent is used as a delimiter as \end can be present here
+\def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+\@IEEEgrabfirstoken#1\relax\relax\noindent
+\ifx\@IEEEgrabbedfirstoken\end\let\@@nextIEEEbuildpreamble=\@@IEEEfinishpreamble\else%
+% identify current and next token type
+\@IEEEgetcoltype{#1}{\@IEEEBPcurtype}{1}% current, error on invalid
+\@IEEEgetcoltype{#2}{\@IEEEBPnexttype}{0}% next, no error on invalid next
+% if curtype is a glue, get the glue def
+\if\@IEEEBPcurtype g\@IEEEgetcurglue{#1}{\@IEEEBPcurglue}\fi%
+% if curtype is a column, get the column def and set the current column name
+\if\@IEEEBPcurtype c\@IEEEgetcurcol{#1}\fi%
+% if curtype is a numeral, acquire the user defined glue
+\if\@IEEEBPcurtype n\@IEEEprocessNcol{#1}\fi%
+% process the acquired glue 
+\if\@IEEEBPcurtype g\@IEEEprocessGcol\fi%
+% process the acquired col 
+\if\@IEEEBPcurtype c\@IEEEprocessCcol\fi%
+% ready prevtype for next col spec.
+\let\@IEEEBPprevtype=\@IEEEBPcurtype%
+% be sure and put back the future token(s) as a group
+\fi\@@nextIEEEbuildpreamble{#2}}
+
+
+% executed just after preamble build is completed
+% warn about zero cols, and if prevtype type = u, put in end tabskip glue
+\def\@@IEEEfinishpreamble#1{\ifnum\@IEEEeqnnumcols<1\relax
+\@IEEEclspkgerror{No column specifiers declared for IEEEeqnarray}%
+{At least one column type must be declared for each IEEEeqnarray.}%
+\fi%num cols less than 1
+%if last type undefined, set default end tabskip glue
+\if\@IEEEBPprevtype u\@IEEEappendtoksA{\tabskip=\@IEEEBPendglue}\fi}
+
+
+% Identify and return the column specifier's type code
+\def\@IEEEgetcoltype#1#2#3{%
+% use only the very first token to determine the type
+% \noindent is used as a delimiter as \end can be present here
+\def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+\@IEEEgrabfirstoken#1\relax\relax\noindent
+% \@IEEEgrabfirstoken has the first token, the rest are discarded
+% n = number
+% g = glue (any other char in catagory 12)
+% c = letter
+% e = \end
+% u = undefined
+% third argument: 0 = no error message, 1 = error on invalid char
+\let#2=u\relax% assume invalid until know otherwise
+\ifx\@IEEEgrabbedfirstoken\end\let#2=e\else
+\ifcat\@IEEEgrabbedfirstoken\relax\else% screen out control sequences
+\if0\@IEEEgrabbedfirstoken\let#2=n\else
+\if1\@IEEEgrabbedfirstoken\let#2=n\else
+\if2\@IEEEgrabbedfirstoken\let#2=n\else
+\if3\@IEEEgrabbedfirstoken\let#2=n\else
+\if4\@IEEEgrabbedfirstoken\let#2=n\else
+\if5\@IEEEgrabbedfirstoken\let#2=n\else
+\if6\@IEEEgrabbedfirstoken\let#2=n\else
+\if7\@IEEEgrabbedfirstoken\let#2=n\else
+\if8\@IEEEgrabbedfirstoken\let#2=n\else
+\if9\@IEEEgrabbedfirstoken\let#2=n\else
+\ifcat,\@IEEEgrabbedfirstoken\let#2=g\relax
+\else\ifcat a\@IEEEgrabbedfirstoken\let#2=c\relax\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi
+\if#2u\relax
+\if0\noexpand#3\relax\else\@IEEEclspkgerror{Invalid character in column specifications}%
+{Only letters, numerals and certain other symbols are allowed \MessageBreak
+as IEEEeqnarray column specifiers.}\fi\fi}
+
+
+% identify the current letter referenced column
+% if invalid, use a default column
+\def\@IEEEgetcurcol#1{\expandafter\ifx\csname @IEEEeqnarraycolDEF#1\endcsname\@IEEEeqnarraycolisdefined%
+\def\@IEEEBPcurcolname{#1}\else% invalid column name
+\@IEEEclspkgerror{Invalid column type "#1" in column specifications.\MessageBreak
+Using a default centering column instead}%
+{You must define IEEEeqnarray column types before use.}%
+\def\@IEEEBPcurcolname{@IEEEdefault}\fi}
+
+
+% identify and return the predefined (punctuation) glue value
+\def\@IEEEgetcurglue#1#2{%
+% ! = \! (neg small)  -0.16667em (-3/18 em)
+% , = \, (small)       0.16667em ( 3/18 em)
+% : = \: (med)         0.22222em ( 4/18 em)
+% ; = \; (large)       0.27778em ( 5/18 em)
+% ' = \quad            1em
+% " = \qquad           2em
+% . = 0.5\arraycolsep
+% / = \arraycolsep
+% ? = 2\arraycolsep
+% * = 1fil
+% + = \@IEEEeqnarraycolSEPcenter
+% - = \@IEEEeqnarraycolSEPzero
+% Note that all em values are referenced to the math font (textfont2) fontdimen6
+% value for 1em.
+% 
+% use only the very first token to determine the type
+% this prevents errant tokens from getting in the main text
+% \noindent is used as a delimiter here
+\def\@IEEEgrabfirstoken##1##2\noindent{\let\@IEEEgrabbedfirstoken=##1}%
+\@IEEEgrabfirstoken#1\relax\relax\noindent
+% get the math font 1em value
+% LaTeX2e's NFSS2 does not preload the fonts, but \IEEEeqnarray needs
+% to gain access to the math (\textfont2) font's spacing parameters.
+% So we create a bogus box here that uses the math font to ensure
+% that \textfont2 is loaded and ready. If this is not done,
+% the \textfont2 stuff here may not work.
+% Thanks to Bernd Raichle for his 1997 post on this topic.
+{\setbox0=\hbox{$\displaystyle\relax$}}%
+% fontdimen6 has the width of 1em (a quad).
+\@IEEEtrantmpdimenA=\fontdimen6\textfont2\relax%
+% identify the glue value based on the first token
+% we discard anything after the first
+\if!\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=-0.16667\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if,\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.16667\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if:\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.22222\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if;\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.27778\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if'\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=1\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if"\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=2\@IEEEtrantmpdimenA\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if.\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=0.5\arraycolsep\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if/\@IEEEgrabbedfirstoken\edef#2{\the\arraycolsep}\else
+\if?\@IEEEgrabbedfirstoken\@IEEEtrantmpdimenA=2\arraycolsep\edef#2{\the\@IEEEtrantmpdimenA}\else
+\if *\@IEEEgrabbedfirstoken\edef#2{0pt plus 1fil minus 0pt}\else
+\if+\@IEEEgrabbedfirstoken\edef#2{\@IEEEeqnarraycolSEPcenter}\else
+\if-\@IEEEgrabbedfirstoken\edef#2{\@IEEEeqnarraycolSEPzero}\else
+\edef#2{\@IEEEeqnarraycolSEPzero}%
+\@IEEEclspkgerror{Invalid predefined inter-column glue type "#1" in\MessageBreak
+column specifications. Using a default value of\MessageBreak
+0pt instead}%
+{Only !,:;'"./?*+ and - are valid predefined glue types in the\MessageBreak 
+IEEEeqnarray column specifications.}\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi\fi}
+
+
+
+% process a numerical digit from the column specification
+% and look up the corresponding user defined glue value
+% can transform current type from n to g or a as the user defined glue is acquired
+\def\@IEEEprocessNcol#1{\if\@IEEEBPprevtype g%
+\@IEEEclspkgerror{Back-to-back inter-column glue specifiers in column\MessageBreak
+specifications. Ignoring consecutive glue specifiers\MessageBreak
+after the first}%
+{You cannot have two or more glue types next to each other\MessageBreak 
+in the IEEEeqnarray column specifications.}%
+\let\@IEEEBPcurtype=a% abort this glue, future digits will be discarded
+\@IEEEBPcurnum=0\relax%
+\else% if we previously aborted a glue
+\if\@IEEEBPprevtype a\@IEEEBPcurnum=0\let\@IEEEBPcurtype=a%maintain digit abortion
+\else%acquire this number
+% save the previous type before the numerical digits started
+\if\@IEEEBPprevtype n\else\let\@IEEEBPprevsavedtype=\@IEEEBPprevtype\fi%
+\multiply\@IEEEBPcurnum by 10\relax%
+\advance\@IEEEBPcurnum by #1\relax% add in number, \relax is needed to stop TeX's number scan
+\if\@IEEEBPnexttype n\else%close acquisition
+\expandafter\ifx\csname @IEEEeqnarraycolSEPDEF\expandafter\romannumeral\number\@IEEEBPcurnum\endcsname\@IEEEeqnarraycolisdefined%
+\edef\@IEEEBPcurglue{\csname @IEEEeqnarraycolSEP\expandafter\romannumeral\number\@IEEEBPcurnum\endcsname}%
+\else%user glue not defined
+\@IEEEclspkgerror{Invalid user defined inter-column glue type "\number\@IEEEBPcurnum" in\MessageBreak
+column specifications. Using a default value of\MessageBreak
+0pt instead}%
+{You must define all IEEEeqnarray numerical inter-column glue types via\MessageBreak
+\string\IEEEeqnarraydefcolsep \space before they are used in column specifications.}%
+\edef\@IEEEBPcurglue{\@IEEEeqnarraycolSEPzero}%
+\fi% glue defined or not
+\let\@IEEEBPcurtype=g% change the type to reflect the acquired glue
+\let\@IEEEBPprevtype=\@IEEEBPprevsavedtype% restore the prev type before this number glue
+\@IEEEBPcurnum=0\relax%ready for next acquisition
+\fi%close acquisition, get glue
+\fi%discard or acquire number
+\fi%prevtype glue or not
+}
+
+
+% process an acquired glue
+% add any acquired column/glue pair to the preamble
+\def\@IEEEprocessGcol{\if\@IEEEBPprevtype a\let\@IEEEBPcurtype=a%maintain previous glue abortions
+\else
+% if this is the start glue, save it, but do nothing else 
+% as this is not used in the preamble, but before
+\if\@IEEEBPprevtype s\edef\@IEEEBPstartglue{\@IEEEBPcurglue}%
+\else%not the start glue
+\if\@IEEEBPprevtype g%ignore if back to back glues
+\@IEEEclspkgerror{Back-to-back inter-column glue specifiers in column\MessageBreak
+specifications. Ignoring consecutive glue specifiers\MessageBreak
+after the first}%
+{You cannot have two or more glue types next to each other\MessageBreak 
+in the IEEEeqnarray column specifications.}%
+\let\@IEEEBPcurtype=a% abort this glue
+\else% not a back to back glue
+\if\@IEEEBPprevtype c\relax% if the previoustype was a col, add column/glue pair to preamble
+\ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi
+\toks0={##}%
+% make preamble advance col counter if this environment needs this
+\if@advanceIEEEeqncolcnt\@IEEEappendtoksA{\global\advance\@IEEEeqncolcnt by 1\relax}\fi
+% insert the column defintion into the preamble, being careful not to expand
+% the column definition
+\@IEEEappendtoksA{\tabskip=\@IEEEBPcurglue}%
+\@IEEEappendNOEXPANDtoksA{\begingroup\csname @IEEEeqnarraycolPRE}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname}%
+\@IEEEappendtoksA{\the\toks0}%
+\@IEEEappendNOEXPANDtoksA{\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\csname @IEEEeqnarraycolPOST}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\endgroup}%
+\advance\@IEEEeqnnumcols by 1\relax%one more column in the preamble
+\else% error: non-start glue with no pending column
+\@IEEEclspkgerror{Inter-column glue specifier without a prior column\MessageBreak
+type in the column specifications. Ignoring this glue\MessageBreak 
+specifier}%
+{Except for the first and last positions, glue can be placed only\MessageBreak
+between column types.}%
+\let\@IEEEBPcurtype=a% abort this glue
+\fi% previous was a column
+\fi% back-to-back glues
+\fi% is start column glue
+\fi% prev type not a
+}
+
+
+% process an acquired letter referenced column and, if necessary, add it to the preamble
+\def\@IEEEprocessCcol{\if\@IEEEBPnexttype g\else
+\if\@IEEEBPnexttype n\else
+% we have a column followed by something other than a glue (or numeral glue)
+% so we must add this column to the preamble now
+\ifnum\@IEEEeqnnumcols>0\relax\@IEEEappendtoksA{&}\fi%col separator for those after the first
+\if\@IEEEBPnexttype e\@IEEEappendtoksA{\tabskip=\@IEEEBPendglue\relax}\else%put in end glue
+\@IEEEappendtoksA{\tabskip=\@IEEEeqnarraycolSEPdefaultmid\relax}\fi% or default mid glue
+\toks0={##}%
+% make preamble advance col counter if this environment needs this
+\if@advanceIEEEeqncolcnt\@IEEEappendtoksA{\global\advance\@IEEEeqncolcnt by 1\relax}\fi
+% insert the column definition into the preamble, being careful not to expand
+% the column definition
+\@IEEEappendNOEXPANDtoksA{\begingroup\csname @IEEEeqnarraycolPRE}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname}%
+\@IEEEappendtoksA{\the\toks0}%
+\@IEEEappendNOEXPANDtoksA{\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\csname @IEEEeqnarraycolPOST}%
+\@IEEEappendtoksA{\@IEEEBPcurcolname}%
+\@IEEEappendNOEXPANDtoksA{\endcsname\relax\relax\relax\relax\relax%
+\relax\relax\relax\relax\relax\endgroup}%
+\advance\@IEEEeqnnumcols by 1\relax%one more column in the preamble
+\fi%next type not numeral
+\fi%next type not glue
+}
+
+
+%%
+%% END OF IEEEeqnarray DEFINITIONS
+%%
+
+
+
+
+% \IEEEPARstart
+% Definition for the big two line drop cap letter at the beginning of the
+% first paragraph of journal papers. The first argument is the first letter
+% of the first word, the second argument is the remaining letters of the
+% first word which will be rendered in upper case.
+% In V1.6 this has been completely rewritten to:
+% 
+% 1. no longer have problems when the user begins an environment
+%    within the paragraph that uses \IEEEPARstart.
+% 2. auto-detect and use the current font family
+% 3. revise handling of the space at the end of the first word so that
+%    interword glue will now work as normal.
+% 4. produce correctly aligned edges for the (two) indented lines.
+% 
+% We generalize things via control macros - playing with these is fun too.
+% 
+% For IEEEtrantools, we do not use a "@" in the names as these are user
+% alterable controls.
+% 
+% V1.7 added more control macros to make it easy for IEEEtrantools.sty users
+% to change the font style.
+% 
+% the number of lines that are indented to clear it
+% may need to increase if using decenders
+\providecommand{\IEEEPARstartDROPLINES}{2}
+% minimum number of lines left on a page to allow a \@IEEEPARstart
+% Does not take into consideration rubber shrink, so it tends to
+% be overly cautious
+\providecommand{\IEEEPARstartMINPAGELINES}{2}
+% V1.7 the height of the drop cap is adjusted to match the height of this text
+% in the current font (when \IEEEPARstart is called).
+\providecommand{\IEEEPARstartHEIGHTTEXT}{T}
+% the depth the letter is lowered below the baseline
+% the height (and size) of the letter is determined by the sum
+% of this value and the height of the \IEEEPARstartHEIGHTTEXT in the current
+% font. It is a good idea to set this value in terms of the baselineskip
+% so that it can respond to changes therein.
+\providecommand{\IEEEPARstartDROPDEPTH}{1.1\baselineskip}
+% V1.7 the font the drop cap will be rendered in,
+% can take zero or one argument.
+\providecommand{\IEEEPARstartFONTSTYLE}{\bfseries}
+% V1.7 any additional, non-font related commands needed to modify
+% the drop cap letter, can take zero or one argument.
+\providecommand{\IEEEPARstartCAPSTYLE}{\MakeUppercase}
+% V1.7 the font that will be used to render the rest of the word,
+% can take zero or one argument.
+\providecommand{\IEEEPARstartWORDFONTSTYLE}{\relax}
+% V1.7 any additional, non-font related commands needed to modify
+% the rest of the word, can take zero or one argument.
+\providecommand{\IEEEPARstartWORDCAPSTYLE}{\MakeUppercase}
+% This is the horizontal separation distance from the drop letter to the main text.
+% Lengths that depend on the font (e.g., ex, em, etc.) will be referenced
+% to the font that is active when \IEEEPARstart is called. 
+\providecommand{\IEEEPARstartSEP}{0.15em}
+% V1.7 horizontal offset applied to the left of the drop cap.
+\providecommand{\IEEEPARstartHOFFSET}{0em}
+% V1.7 Italic correction command applied at the end of the drop cap.
+\providecommand{\IEEEPARstartITLCORRECT}{\/}
+
+% width of the letter output, set globally. Can be used in \IEEEPARstartSEP
+% or \IEEEPARstartHOFFSET, but not the height lengths.
+\newdimen\IEEEPARstartletwidth
+\IEEEPARstartletwidth 0pt\relax
+
+% definition of \IEEEPARstart
+% THIS IS A CONTROLLED SPACING AREA, DO NOT ALLOW SPACES WITHIN THESE LINES
+% 
+% The token \@IEEEPARstartfont will be globally defined after the first use
+% of \IEEEPARstart and will be a font command which creates the big letter
+% The first argument is the first letter of the first word and the second
+% argument is the rest of the first word(s).
+\def\IEEEPARstart#1#2{\par{%
+% if this page does not have enough space, break it and lets start
+% on a new one
+\@IEEEtranneedspace{\IEEEPARstartMINPAGELINES\baselineskip}{\relax}%
+% V1.7 move this up here in case user uses \textbf for \IEEEPARstartFONTSTYLE
+% which uses command \leavevmode which causes an unwanted \indent to be issued
+\noindent
+% calculate the desired height of the big letter
+% it extends from the top of \IEEEPARstartHEIGHTTEXT in the current font
+% down to \IEEEPARstartDROPDEPTH below the current baseline
+\settoheight{\@IEEEtrantmpdimenA}{\IEEEPARstartHEIGHTTEXT}%
+\addtolength{\@IEEEtrantmpdimenA}{\IEEEPARstartDROPDEPTH}%
+% extract the name of the current font in bold
+% and place it in \@IEEEPARstartFONTNAME
+\def\@IEEEPARstartGETFIRSTWORD##1 ##2\relax{##1}%
+{\IEEEPARstartFONTSTYLE{\selectfont\edef\@IEEEPARstartFONTNAMESPACE{\fontname\font\space}%
+\xdef\@IEEEPARstartFONTNAME{\expandafter\@IEEEPARstartGETFIRSTWORD\@IEEEPARstartFONTNAMESPACE\relax}}}%
+% define a font based on this name with a point size equal to the desired
+% height of the drop letter
+\font\@IEEEPARstartsubfont\@IEEEPARstartFONTNAME\space at \@IEEEtrantmpdimenA\relax%
+% save this value as a counter (integer) value (sp points)
+\@IEEEtrantmpcountA=\@IEEEtrantmpdimenA%
+% now get the height of the actual letter produced by this font size
+\settoheight{\@IEEEtrantmpdimenB}{\@IEEEPARstartsubfont\IEEEPARstartCAPSTYLE{#1}}%
+% If something bogus happens like the first argument is empty or the
+% current font is strange, do not allow a zero height.
+\ifdim\@IEEEtrantmpdimenB=0pt\relax%
+\typeout{** WARNING: IEEEPARstart drop letter has zero height! (line \the\inputlineno)}%
+\typeout{ Forcing the drop letter font size to 10pt.}%
+\@IEEEtrantmpdimenB=10pt%
+\fi%
+% and store it as a counter
+\@IEEEtrantmpcountB=\@IEEEtrantmpdimenB%
+% Since a font size doesn't exactly correspond to the height of the capital
+% letters in that font, the actual height of the letter, \@IEEEtrantmpcountB,
+% will be less than that desired, \@IEEEtrantmpcountA
+% we need to raise the font size, \@IEEEtrantmpdimenA 
+% by \@IEEEtrantmpcountA / \@IEEEtrantmpcountB
+% But, TeX doesn't have floating point division, so we have to use integer
+% division. Hence the use of the counters.
+% We need to reduce the denominator so that the loss of the remainder will
+% have minimal affect on the accuracy of the result
+\divide\@IEEEtrantmpcountB by 200%
+\divide\@IEEEtrantmpcountA by \@IEEEtrantmpcountB%
+% Then reequalize things when we use TeX's ability to multiply by
+% floating point values
+\@IEEEtrantmpdimenB=0.005\@IEEEtrantmpdimenA%
+\multiply\@IEEEtrantmpdimenB by \@IEEEtrantmpcountA%
+% \@IEEEPARstartfont is globaly set to the calculated font of the big letter
+% We need to carry this out of the local calculation area to to create the
+% big letter.
+\global\font\@IEEEPARstartfont\@IEEEPARstartFONTNAME\space at \@IEEEtrantmpdimenB%
+% Now set \@IEEEtrantmpdimenA to the width of the big letter
+% We need to carry this out of the local calculation area to set the
+% hanging indent
+\settowidth{\global\@IEEEtrantmpdimenA}{\@IEEEPARstartfont
+\IEEEPARstartCAPSTYLE{#1\IEEEPARstartITLCORRECT}}}%
+% end of the isolated calculation environment
+\global\IEEEPARstartletwidth\@IEEEtrantmpdimenA\relax%
+% add in the extra clearance we want
+\advance\@IEEEtrantmpdimenA by \IEEEPARstartSEP\relax%
+% add in the optional offset
+\advance\@IEEEtrantmpdimenA by \IEEEPARstartHOFFSET\relax%
+% V1.7 don't allow negative offsets to produce negative hanging indents
+\@IEEEtrantmpdimenB\@IEEEtrantmpdimenA
+\ifnum\@IEEEtrantmpdimenB < 0 \@IEEEtrantmpdimenB 0pt\fi
+% \@IEEEtrantmpdimenA has the width of the big letter plus the
+% separation space and \@IEEEPARstartfont is the font we need to use
+% Now, we make the letter and issue the hanging indent command
+% The letter is placed in a box of zero width and height so that other
+% text won't be displaced by it.
+\hangindent\@IEEEtrantmpdimenB\hangafter=-\IEEEPARstartDROPLINES%
+\makebox[0pt][l]{\hspace{-\@IEEEtrantmpdimenA}%
+\raisebox{-\IEEEPARstartDROPDEPTH}[0pt][0pt]{\hspace{\IEEEPARstartHOFFSET}%
+\@IEEEPARstartfont\IEEEPARstartCAPSTYLE{#1\IEEEPARstartITLCORRECT}%
+\hspace{\IEEEPARstartSEP}}}%
+{\IEEEPARstartWORDFONTSTYLE{\IEEEPARstartWORDCAPSTYLE{\selectfont#2}}}}
+
+
+
+
+
+
+% determines if the space remaining on a given page is equal to or greater
+% than the specified space of argument one
+% if not, execute argument two (only if the remaining space is greater than zero)
+% and issue a \newpage
+% 
+% example: \@IEEEtranneedspace{2in}{\vfill}
+% 
+% Does not take into consideration rubber shrinkage, so it tends to
+% be overly cautious
+% Based on an example posted by Donald Arseneau
+% Note this macro uses \@IEEEtrantmpdimenB internally for calculations,
+% so DO NOT PASS \@IEEEtrantmpdimenB to this routine
+% if you need a dimen register, import with \@IEEEtrantmpdimenA instead
+\def\@IEEEtranneedspace#1#2{\penalty-100\begingroup%shield temp variable
+\@IEEEtrantmpdimenB\pagegoal\advance\@IEEEtrantmpdimenB-\pagetotal% space left
+\ifdim #1>\@IEEEtrantmpdimenB\relax% not enough space left
+\ifdim\@IEEEtrantmpdimenB>\z@\relax #2\fi%
+\newpage%
+\fi\endgroup}
+
+
+% \IEEEauthorrefmark
+\DeclareRobustCommand*{\IEEEauthorrefmark}[1]{\raisebox{0pt}[0pt][0pt]{\textsuperscript{\footnotesize\ensuremath{\ifcase#1\or *\or \dagger\or \ddagger\or%
+    \mathsection\or \mathparagraph\or \|\or **\or \dagger\dagger%
+    \or \ddagger\ddagger \else\textsuperscript{\expandafter\romannumeral#1}\fi}}}}
+
+
+% V1.3 IEEEQED and IEEEproof
+\def\IEEEproofname{Proof}
+
+\def\IEEEQEDclosed{\mbox{\rule[0pt]{1.3ex}{1.3ex}}} % for a filled box
+\def\IEEEQEDopen{{\setlength{\fboxsep}{0pt}\setlength{\fboxrule}{0.2pt}\fbox{\rule[0pt]{0pt}{1.3ex}\rule[0pt]{1.3ex}{0pt}}}}
+\def\IEEEQED{\IEEEQEDclosed} % default to closed
+
+%V1.8 flag to indicate if QED symbol is to be shown
+\newif\if@IEEEQEDshow  \@IEEEQEDshowtrue
+\def\IEEEproofindentspace{2\parindent}% V1.8 allow user to change indentation amount if desired
+% v1.7 name change to avoid namespace collision with amsthm. Also add support
+% for an optional argument.
+\def\IEEEproof{\@ifnextchar[{\@IEEEproof}{\@IEEEproof[\IEEEproofname]}}
+\def\@IEEEproof[#1]{\@IEEEQEDshowtrue\par\noindent\hspace{\IEEEproofindentspace}{\itshape #1: }}
+\def\endIEEEproof{\if@IEEEQEDshow\hspace*{\fill}\nobreakspace\IEEEQED\fi\par}
+% qedhere for equation environments, similar to AMS \qedhere
+\def\IEEEQEDhereeqn{\global\@IEEEQEDshowfalse\eqno\let\eqno\relax\let\leqno\relax
+                    \let\veqno\relax\hbox{\IEEEQED}}
+% IEEE style qedhere for IEEEeqnarray and other environments
+\def\IEEEQEDhere{\global\@IEEEQEDshowfalse\IEEEQED}
+% command to disable QED at end of IEEEproof
+\def\IEEEQEDoff{\global\@IEEEQEDshowfalse}
+
+
+% Provide support for the control entries of IEEEtran.bst V1.00 and later.
+% V1.7 optional argument allows for a different aux file to be specified in
+% order to handle multiple bibliographies. For example, with multibib.sty:
+% \newcites{sec}{Secondary Literature}
+% \bstctlcite[@auxoutsec]{BSTcontrolhak}
+% V1.7 I see no need for \providecommand here.
+\def\bstctlcite{\@ifnextchar[{\@bstctlcite}{\@bstctlcite[@auxout]}}
+\def\@bstctlcite[#1]#2{\@bsphack
+  \@for\@citeb:=#2\do{%
+    \edef\@citeb{\expandafter\@firstofone\@citeb}%
+    \if@filesw\immediate\write\csname #1\endcsname{\string\citation{\@citeb}}\fi}%
+  \@esphack}
+
+
+
+% need a backslash character for typeout output
+{\catcode`\|=0 \catcode`\\=12
+|xdef|@IEEEbackslash{\}}
+
+
+% hook to allow easy disabling of all legacy warnings
+\def\@IEEElegacywarn#1#2{\typeout{** ATTENTION: \@IEEEbackslash #1 is deprecated (line \the\inputlineno).
+Use \@IEEEbackslash #2 instead.}}
+
+% provide for legacy commands
+\def\PARstart{\@IEEElegacywarn{PARstart}{IEEEPARstart}\IEEEPARstart}
+
+% V1.3 no longer support legacy IED list commands
+% \let\labelindent\IEEElabelindent
+% \def\calcleftmargin{\@IEEElegacywarn{calcleftmargin}{IEEEcalcleftmargin}\IEEEcalcleftmargin}
+% \def\setlabelwidth{\@IEEElegacywarn{setlabelwidth}{IEEEsetlabelwidth}\IEEEsetlabelwidth}
+% \def\usemathlabelsep{\@IEEElegacywarn{usemathlabelsep}{IEEEusemathlabelsep}\IEEEusemathlabelsep}
+% \def\iedlabeljustifyc{\@IEEElegacywarn{iedlabeljustifyc}{IEEEiedlabeljustifyc}\IEEEiedlabeljustifyc}
+% \def\iedlabeljustifyl{\@IEEElegacywarn{iedlabeljustifyl}{IEEEiedlabeljustifyl}\IEEEiedlabeljustifyl}
+% \def\iedlabeljustifyr{\@IEEElegacywarn{iedlabeljustifyr}{IEEEiedlabeljustifyr}\IEEEiedlabeljustifyr}
+
+
+\endinput
+%%%%%%%%%%%%%%%%%%%%%%%%%% End of IEEEtrantools.sty  %%%%%%%%%%%%%%%%%%%%%%
+% That's all folks!
+
+

--- a/ieee/README
+++ b/ieee/README
@@ -1,0 +1,135 @@
+
+November 21, 2012
+
+IEEEtran.cls version 1.8 revises format specifications so that the final
+layout more closely matches the layout of the Microsoft Word templates.
+
+Additionally, the IEEEtran_HOWTO.pdf now includes the notice to not use
+symbols, special characters, or math in the paper title and abstract.
+
+
+*******
+
+
+March 5, 2007
+
+
+IEEEtran is the official LaTeX class for authors of the Institute of
+Electrical and Electronics Engineers (IEEE) transactions journals and
+conferences. The latest version of the IEEEtran package can be found
+at CTAN:
+
+http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+
+as well as within IEEE's site:
+
+http://www.ieee.org/
+
+For latest news, helpful tips, answers to frequently asked questions,
+beta releases and other support, visit the IEEEtran home page at my
+website:  http://www.michaelshell.org/tex/ieeetran/
+
+
+Version 1.7a is a bug fix release that corrects the two column peer
+review title page problem. This problem was not present in the 1.6 series.
+
+
+V1.7 is a significant update over the 1.6 series with many important
+changes. For a full list, please read the file changelog.txt. The most
+notable changes include:
+
+ 1. New class option compsoc to support the IEEE Computer Society format.
+
+ 2. Several commands and environments have been deprecated in favor of
+    replacements with IEEE prefixes to better avoid potential future name
+    clashes with other packages. Legacy code retained to allow the use of
+    the obsolete forms (for now), but with a warning message to the console
+    during compilation:
+    \IEEEauthorblockA, \IEEEauthorblockN, \IEEEauthorrefmark,
+    \IEEEbiography, \IEEEbiographynophoto, \IEEEkeywords, \IEEEPARstart,
+    \IEEEproof, \IEEEpubid, \IEEEpubidadjcol, \IEEEQED, \IEEEQEDclosed,
+    \IEEEQEDopen, \IEEEspecialpapernotice. IEEEtran.cls now redefines
+    \proof in way to avoid problems with the amsthm.sty package.
+    For IED lists:
+    \IEEEiedlabeljustifyc, \IEEEiedlabeljustifyl, \IEEEiedlabeljustifyr,
+    \IEEEnocalcleftmargin, \IEEElabelindent, \IEEEsetlabelwidth,
+    \IEEEusemathlabelsep
+    These commands/lengths now require the IEEE prefix and do not have
+    legacy support: \IEEEnormaljot.
+    For IED lists: \ifIEEEnocalcleftmargin, \ifIEEEnolabelindentfactor,
+    \IEEEiedlistdecl, \IEEElabelindentfactor
+
+ 3. New \CLASSINPUT, \CLASSOPTION and \CLASSINFO interface allows for more
+    user control and conditional compilation.
+
+ 4. Several bug fixes and improved compatibility with other packages.
+
+
+A note to those who create classes derived from IEEEtran.cls: Consider the
+use of patch code, either in an example .tex file or as a .sty file,
+rather than creating a new class. The IEEEtran.cls CLASSINPUT interface
+allows IEEEtran.cls to be fully programmable with respect to document
+margins, so there is no need for new class files just for altered margins.
+In this way, authors can benefit from updates to IEEEtran.cls and the need
+to maintain derivative classes and backport later IEEEtran.cls revisions
+thereto is avoided. As always, developers who create classes derived from
+IEEEtran.cls should use a different name for the derived class, so that it
+cannot be confused with the official/base version here, as well as provide
+authors with technical support for the derived class. It is generally a bad
+idea to produce a new class that is not going to be maintained.
+
+
+Best wishes for all your publication endeavors,
+
+Michael Shell
+http://www.michaelshell.org/
+
+
+********************************** Files **********************************
+
+README                 - This file.
+
+IEEEtran.cls           - The IEEEtran LaTeX class file.
+
+changelog.txt          - The revision history.
+
+IEEEtran_HOWTO.pdf     - The IEEEtran LaTeX class user manual.
+
+bare_conf.tex          - A bare bones starter file for conference papers.
+
+bare_jrnl.tex          - A bare bones starter file for journal papers.
+
+bare_jrnl_compsoc.tex  - A bare bones starter file for Computer Society
+                         journal papers.
+
+bare_adv.tex           - A bare bones starter file showing advanced
+                         techniques such as conditional compilation,
+                         hyperlinks, PDF thumbnails, etc. The illustrated
+                         format is for a Computer Society journal paper.
+
+***************************************************************************
+Legal Notice:
+This code is offered as-is without any warranty either expressed or
+implied; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE! 
+User assumes all risk.
+In no event shall IEEE or any contributor to this code be liable for
+any damages or losses, including, but not limited to, incidental,
+consequential, or any other damages, resulting from the use or misuse
+of any information contained here.
+
+All comments are the opinions of their respective authors and are not
+necessarily endorsed by the IEEE.
+
+This work is distributed under the LaTeX Project Public License (LPPL)
+( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+distributed and modified. A copy of the LPPL, version 1.3, is included
+in the base LaTeX documentation of all distributions of LaTeX released
+2003/12/01 or later.
+Retain all contribution notices and credits.
+** Modified files should be clearly indicated as such, including  **
+** renaming them and changing author support contact information. **
+
+File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+                   bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+***************************************************************************

--- a/ieee/bare_adv.tex
+++ b/ieee/bare_adv.tex
@@ -1,0 +1,1100 @@
+
+%% bare_adv.tex
+%% V1.3
+%% 2007/01/11
+%% by Michael Shell
+%% See: 
+%% http://www.michaelshell.org/
+%% for current contact information.
+%%
+%% This is a skeleton file demonstrating the advanced use of IEEEtran.cls
+%% (requires IEEEtran.cls version 1.7 or later) with an IEEE Computer
+%% Society journal paper.
+%%
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and
+%% http://www.ieee.org/
+
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+%%                    bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+%%*************************************************************************
+
+% *** Authors should verify (and, if needed, correct) their LaTeX system  ***
+% *** with the testflow diagnostic prior to trusting their LaTeX platform ***
+% *** with production work. IEEE's font choices can trigger bugs that do  ***
+% *** not appear when using other class files.                            ***
+% The testflow support page is at:
+% http://www.michaelshell.org/tex/testflow/
+
+
+
+% IEEEtran V1.7 and later provides for these CLASSINPUT macros to allow the
+% user to reprogram some IEEEtran.cls defaults if needed. These settings
+% override the internal defaults of IEEEtran.cls regardless of which class
+% options are used. Do not use these unless you have good reason to do so as
+% they can result in nonIEEE compliant documents. User beware. ;)
+%
+%\newcommand{\CLASSINPUTbaselinestretch}{1.0} % baselinestretch
+%\newcommand{\CLASSINPUTinnersidemargin}{1in} % inner side margin
+%\newcommand{\CLASSINPUToutersidemargin}{1in} % outer side margin
+%\newcommand{\CLASSINPUTtoptextmargin}{1in}   % top text margin
+%\newcommand{\CLASSINPUTbottomtextmargin}{1in}% bottom text margin
+
+
+
+% Note that the a4paper option is mainly intended so that authors in
+% countries using A4 can easily print to A4 and see how their papers will
+% look in print - the typesetting of the document will not typically be
+% affected with changes in paper size (but the bottom and side margins will).
+% Use the testflow package mentioned above to verify correct handling of
+% both paper sizes by the user's LaTeX system.
+%
+% Also note that the "draftcls" or "draftclsnofoot", not "draft", option
+% should be used if it is desired that the figures are to be displayed in
+% draft mode.
+%
+\documentclass[12pt,journal,compsoc]{IEEEtran}
+% The Computer Society requires 12pt.
+% If IEEEtran.cls has not been installed into the LaTeX system files,
+% manually specify the path to it like:
+% \documentclass[10pt,journal,compsoc]{../sty/IEEEtran}
+
+
+% For Computer Society journals, IEEEtran defaults to the use of 
+% Palatino/Palladio as is done in IEEE Computer Society journals.
+% To go back to Times Roman, you can use this code:
+%\renewcommand{\rmdefault}{ptm}\selectfont
+
+
+
+
+
+% Some very useful LaTeX packages include:
+% (uncomment the ones you want to load)
+
+
+
+% *** MISC UTILITY PACKAGES ***
+%
+%\usepackage{ifpdf}
+% Heiko Oberdiek's ifpdf.sty is very useful if you need conditional
+% compilation based on whether the output is pdf or dvi.
+% usage:
+% \ifpdf
+%   % pdf code
+% \else
+%   % dvi code
+% \fi
+% The latest version of ifpdf.sty can be obtained from:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/oberdiek/
+% Also, note that IEEEtran.cls V1.7 and later provides a builtin
+% \ifCLASSINFOpdf conditional that works the same way.
+% When switching from latex to pdflatex and vice-versa, the compiler may
+% have to be run twice to clear warning/error messages.
+
+
+
+
+
+
+% *** CITATION PACKAGES ***
+%
+\ifCLASSOPTIONcompsoc
+  % IEEE Computer Society needs nocompress option
+  % requires cite.sty v4.0 or later (November 2003)
+  % \usepackage[nocompress]{cite}
+\else
+  % normal IEEE
+  % \usepackage{cite}
+\fi
+% cite.sty was written by Donald Arseneau
+% V1.6 and later of IEEEtran pre-defines the format of the cite.sty package
+% \cite{} output to follow that of IEEE. Loading the cite package will
+% result in citation numbers being automatically sorted and properly
+% "compressed/ranged". e.g., [1], [9], [2], [7], [5], [6] without using
+% cite.sty will become [1], [2], [5]--[7], [9] using cite.sty. cite.sty's
+% \cite will automatically add leading space, if needed. Use cite.sty's
+% noadjust option (cite.sty V3.8 and later) if you want to turn this off.
+% cite.sty is already installed on most LaTeX systems. Be sure and use
+% version 4.0 (2003-05-27) and later if using hyperref.sty. cite.sty does
+% not currently provide for hyperlinked citations.
+% The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/cite/
+% The documentation is contained in the cite.sty file itself.
+%
+% Note that some packages require special options to format as the Computer
+% Society requires. In particular, Computer Society  papers do not use
+% compressed citation ranges as is done in typical IEEE papers
+% (e.g., [1]-[4]). Instead, they list every citation separately in order
+% (e.g., [1], [2], [3], [4]). To get the latter we need to load the cite
+% package with the nocompress option which is supported by cite.sty v4.0
+% and later. Note also the use of a CLASSOPTION conditional provided by
+% IEEEtran.cls V1.7 and later.
+
+
+
+
+
+% *** GRAPHICS RELATED PACKAGES ***
+%
+\ifCLASSINFOpdf
+  % \usepackage[pdftex]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../pdf/}{../jpeg/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.pdf,.jpeg,.png}
+\else
+  % or other class option (dvipsone, dvipdf, if not using dvips). graphicx
+  % will default to the driver specified in the system graphics.cfg if no
+  % driver is specified.
+  % \usepackage[dvips]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../eps/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.eps}
+\fi
+% graphicx was written by David Carlisle and Sebastian Rahtz. It is
+% required if you want graphics, photos, etc. graphicx.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at: 
+% http://www.ctan.org/tex-archive/macros/latex/required/graphics/
+% Another good source of documentation is "Using Imported Graphics in
+% LaTeX2e" by Keith Reckdahl which can be found as epslatex.ps or
+% epslatex.pdf at: http://www.ctan.org/tex-archive/info/
+%
+% latex, and pdflatex in dvi mode, support graphics in encapsulated
+% postscript (.eps) format. pdflatex in pdf mode supports graphics
+% in .pdf, .jpeg, .png and .mps (metapost) formats. Users should ensure
+% that all non-photo figures use a vector format (.eps, .pdf, .mps) and
+% not a bitmapped formats (.jpeg, .png). IEEE frowns on bitmapped formats
+% which can result in "jaggedy"/blurry rendering of lines and letters as
+% well as large increases in file sizes.
+%
+% You can find documentation about the pdfTeX application at:
+% http://www.tug.org/applications/pdftex
+
+
+
+%\usepackage{ps4pdf}
+% dvi->ps workflow is required to use such packages as psfrag.sty and
+% pstricks.sty. However, Rolf Niepraschk's ps4pdf.sty provides a way to
+% apply psfrag/pstricks effects to .eps figures and then get the resultant
+% figures in .pdf form. Thus, providing an easier way for migrating from
+% .eps to .pdf figures. After ps4pdf.sty loads, if:
+% 1. producing .dvi output: the output file will consist ONLY of the
+%    figures (or other constructs encased within \PSforPDF commands)
+% 2. producing .pdf output: pdflatex will look in the filename-pics.pdf
+%    file, where filename is the basename of the tex document, for the
+%    graphics (or other constructs encased within \PSforPDF commands).
+%    NOTE: If you ever change your figures, you must remember to remake
+%    the filename-pics.pdf file.
+%
+% This way you can do a:
+% 
+% latex filename
+% dvips -Ppdf -o filename-pics.ps filename.dvi
+% ps2pdf filename-pics.ps filename-pics.pdf
+% 
+% to produce a filename-pics.pdf graphics container that contains
+% .pdf versions of the graphics with psfrag, pstricks, etc. features.
+% Note that you will not typically be able to view the figures in 
+% filename-pics.ps because of an offset. However, you will be able to
+% view them in filename-pics.pdf. Also, note that when ps4pdf is in effect
+% with .dvi output, you may get harmless over/under full box warnings - 
+% ignore them. 
+% Then, run pdflatex:
+% 
+% pdflatex filename
+% 
+% to use pdflatex to make PDF output, automatically using the figures in
+% filename-pics.pdf. Alternatively, you could use dvips -i option to
+% obtain separate .pdf files for each figure:
+%
+% dvips -Ppdf -i -E -o fig filename
+%
+% then convert each figure to pdf via a command such as epstopdf and then
+% use pdflatex with these pdf figures and then to dispense with ps4pdf.
+%
+% Remember to rerun through latex/dvips/ps2pdf if you ever change your
+% figures so that filename-pics.pdf gets updated.
+% ps4pdf requires David Kastrup's preview-latex and a recent LaTeX system
+% (circa 2001 or later). The ps4pdf package and documentation can be
+% obtained at: http://www.ctan.org/tex-archive/macros/latex/contrib/ps4pdf/
+% The preview-latex package and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/preview/
+%
+% provide a bogus \PSforPDF, even when not loading pd4pdf. This way we can
+% stop loading ps4pdf.sty if we choose to make separate .pdf versions of
+% each of our figures.
+\providecommand{\PSforPDF}[1]{#1}
+% Note that in order for ps4pdf to work, all commands related to psfrag,
+% pstricks, etc. must be called within the PSforPDF command. This applies
+% even when *loading* via \usepackage psfrag.sty, etc.
+
+
+%\PSforPDF{\usepackage{psfrag}}
+% psfrag.sty was written by Craig Barratt, Michael C. Grant, and
+% David Carlisle. It allows you to substitute LaTeX commands for text in
+% imported EPS graphic files. In this way, LaTeX symbols can be placed into
+% graphics that have been generated by other applications. You must use
+% latex->dvips->ps2pdf workflow (not direct pdf output from pdflatex) if
+% you wish to use this capability because it works via some PostScript
+% tricks. Alternatively, the graphics could be processed as separate files
+% via psfrag and dvips, then converted to PDF for inclusion in the main file
+% which uses pdflatex. ps4pdf.sty (above) provides a way of doing this all
+% at once within the main file.
+% Docs are in "The PSfrag System" by Michael C. Grant and David Carlisle.
+% There is also some information about using psfrag in "Using Imported
+% Graphics in LaTeX2e" by Keith Reckdahl which documents the graphicx
+% package (see above). The psfrag package and documentation can be obtained
+% at: http://www.ctan.org/tex-archive/macros/latex/contrib/psfrag/
+% 
+% Note that the current version of psfrag does not "turn itself off" when
+% running under pdf output. This will result in a harmless warning
+% about a non-PDF \special. However, to silence this, a bogus psfrag
+% command can be provided instead of loading psfrag.sty when PDF output
+% is being used. Thus, a more complex alternative conditional loading scheme
+% can be employed instead of the straightforword way above:
+%
+%\ifCLASSINFOpdf
+% if outputting PDF, do not use or load psfrag.sty as current versions
+% output a non-PDF special that generates a harmless, but annoying warning.
+% Instead, we provide a bogus \psfrag command that does nothing with
+% its arguments. This is a tad tricky because \psfrag can have up to six
+% arguments four of which are optional: \psfrag{}[][][][]{}
+% Code based on that in psfrag.sty
+%\makeatletter
+%\def\psfrag{\@ifstar{\@BOGUSpsfraga}{\@BOGUSpsfraga}}
+%\def\@BOGUSpsfraga{\begingroup
+%   \@makeother\"\@makeother\*\@makeother\!\@makeother\~%
+%   \@makeother\:\@makeother\\\@makeother\%\@makeother\#%
+%   \@makeother\ \@BOGUSpsfragb}
+%\def\@BOGUSpsfragb#1{\endgroup
+%                \@ifnextchar [{\@BOGUSpsfragc}%
+%                              {\@BOGUSpsfrag}}
+%\def\@BOGUSpsfragc[#1]{\@ifnextchar [{\@BOGUSpsfragd}%
+%                                     {\@BOGUSpsfrag}}
+%\def\@BOGUSpsfragd[#1]{\@ifnextchar [{\@BOGUSpsfrage}%
+%                                     {\@BOGUSpsfrag}}
+%\def\@BOGUSpsfrage[#1]{\@ifnextchar [{\@BOGUSpsfragf}%
+%                                     {\@BOGUSpsfrag}}
+%\def\@BOGUSpsfragf[#1]{\@BOGUSpsfrag}
+%\def\@BOGUSpsfrag#1{\ignorespaces}
+%\makeatother
+%\else
+% using dvi output, load psfrag, but funnel it through PSforPDF
+% as required by ps4pdf.sty
+%\PSforPDF{\usepackage{psfrag}}
+%\fi
+
+
+
+
+
+% *** MATH PACKAGES ***
+%
+%\usepackage[cmex10]{amsmath}
+% A popular package from the American Mathematical Society that provides
+% many useful and powerful commands for dealing with mathematics. If using
+% it, be sure to load this package with the cmex10 option to ensure that
+% only type 1 fonts will utilized at all point sizes. Without this option,
+% it is possible that some math symbols, particularly those within
+% footnotes, will be rendered in bitmap form which will result in a
+% document that can not be IEEE Xplore compliant!
+%
+% Also, note that the amsmath package sets \interdisplaylinepenalty to 10000
+% thus preventing page breaks from occurring within multiline equations. Use:
+%\interdisplaylinepenalty=2500
+% after loading amsmath to restore such page breaks as IEEEtran.cls normally
+% does. amsmath.sty is already installed on most LaTeX systems. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/amslatex/math/
+
+
+
+
+
+% *** SPECIALIZED LIST PACKAGES ***
+%\usepackage{acronym}
+% acronym.sty was written by Tobias Oetiker. This package provides tools for
+% managing documents with large numbers of acronyms. (You don't *have* to
+% use this package - unless you have a lot of acronyms, you may feel that
+% such package management of them is bit of an overkill.)
+% Do note that the acronym environment (which lists acronyms) will have a
+% problem when used under IEEEtran.cls because acronym.sty relies on the
+% description list environment - which IEEEtran.cls has customized for
+% producing IEEE style lists. A workaround is to declared the longest
+% label width via the IEEEtran.cls \IEEEiedlistdecl global control:
+%
+% \renewcommand{\IEEEiedlistdecl}{\IEEEsetlabelwidth{SONET}}
+% \begin{acronym}
+%
+% \end{acronym}
+% \renewcommand{\IEEEiedlistdecl}{\relax}% remember to reset \IEEEiedlistdecl
+%
+% instead of using the acronym environment's optional argument.
+% The latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/acronym/
+
+
+%\usepackage{algorithmic}
+% algorithmic.sty was written by Peter Williams and Rogerio Brito.
+% This package provides an algorithmic environment fo describing algorithms.
+% You can use the algorithmic environment in-text or within a figure
+% environment to provide for a floating algorithm. Do NOT use the algorithm
+% floating environment provided by algorithm.sty (by the same authors) or
+% algorithm2e.sty (by Christophe Fiorio) as IEEE does not use dedicated
+% algorithm float types and packages that provide these will not provide
+% correct IEEE style captions. The latest version and documentation of
+% algorithmic.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithms/
+% There is also a support site at:
+% http://algorithms.berlios.de/index.html
+% Also of interest may be the (relatively newer and more customizable)
+% algorithmicx.sty package by Szasz Janos:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithmicx/
+
+
+
+
+% *** ALIGNMENT PACKAGES ***
+%
+%\usepackage{array}
+% Frank Mittelbach's and David Carlisle's array.sty patches and improves
+% the standard LaTeX2e array and tabular environments to provide better
+% appearance and additional user controls. As the default LaTeX2e table
+% generation code is lacking to the point of almost being broken with
+% respect to the quality of the end results, all users are strongly
+% advised to use an enhanced (at the very least that provided by array.sty)
+% set of table tools. array.sty is already installed on most systems. The
+% latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/tools/
+
+
+%\usepackage{mdwmath}
+%\usepackage{mdwtab}
+% Also highly recommended is Mark Wooding's extremely powerful MDW tools,
+% especially mdwmath.sty and mdwtab.sty which are used to format equations
+% and tables, respectively. The MDWtools set is already installed on most
+% LaTeX systems. The lastest version and documentation is available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/mdwtools/
+
+
+% IEEEtran contains the IEEEeqnarray family of commands that can be used to
+% generate multiline equations as well as matrices, tables, etc., of high
+% quality.
+
+
+%\usepackage{eqparbox}
+% Also of notable interest is Scott Pakin's eqparbox package for creating
+% (automatically sized) equal width boxes - aka "natural width parboxes".
+% Available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/eqparbox/
+
+
+
+
+
+% *** SUBFIGURE PACKAGES ***
+%\ifCLASSOPTIONcompsoc
+%\usepackage[tight,normalsize,sf,SF]{subfigure}
+%\else
+%\usepackage[tight,footnotesize]{subfigure}
+%\fi
+% subfigure.sty was written by Steven Douglas Cochran. This package makes it
+% easy to put subfigures in your figures. e.g., "Figure 1a and 1b". For IEEE
+% work, it is a good idea to load it with the tight package option to reduce
+% the amount of white space around the subfigures. Computer Society papers
+% use a larger font and \sffamily font for their captions, hence the
+% additional options needed under compsoc mode. subfigure.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/obsolete/macros/latex/contrib/subfigure/
+% subfigure.sty has been superceeded by subfig.sty.
+
+
+%\ifCLASSOPTIONcompsoc
+%  \usepackage[caption=false]{caption}
+%  \usepackage[font=normalsize,labelfont=sf,textfont=sf]{subfig}
+%\else
+%  \usepackage[caption=false]{caption}
+%  \usepackage[font=footnotesize]{subfig}
+%\fi
+% subfig.sty, also written by Steven Douglas Cochran, is the modern
+% replacement for subfigure.sty. However, subfig.sty requires and
+% automatically loads Axel Sommerfeldt's caption.sty which will override
+% IEEEtran.cls handling of captions and this will result in nonIEEE style
+% figure/table captions. To prevent this problem, be sure and preload
+% caption.sty with its "caption=false" package option. This is will preserve
+% IEEEtran.cls handing of captions. Version 1.3 (2005/06/28) and later 
+% (recommended due to many improvements over 1.2) of subfig.sty supports
+% the caption=false option directly:
+%\ifCLASSOPTIONcompsoc
+%  \usepackage[caption=false,font=normalsize,labelfont=sf,textfont=sf]{subfig}
+%\else
+%  \usepackage[caption=false,font=footnotesize]{subfig}
+%\fi
+%
+% The latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/subfig/
+% The latest version and documentation of caption.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/caption/
+
+
+
+
+% *** FLOAT PACKAGES ***
+%
+%\usepackage{fixltx2e}
+% fixltx2e, the successor to the earlier fix2col.sty, was written by
+% Frank Mittelbach and David Carlisle. This package corrects a few problems
+% in the LaTeX2e kernel, the most notable of which is that in current
+% LaTeX2e releases, the ordering of single and double column floats is not
+% guaranteed to be preserved. Thus, an unpatched LaTeX2e can allow a
+% single column figure to be placed prior to an earlier double column
+% figure. The latest version and documentation can be found at:
+% http://www.ctan.org/tex-archive/macros/latex/base/
+
+
+%\usepackage{stfloats}
+% stfloats.sty was written by Sigitas Tolusis. This package gives LaTeX2e
+% the ability to do double column floats at the bottom of the page as well
+% as the top. (e.g., "\begin{figure*}[!b]" is not normally possible in
+% LaTeX2e). It also provides a command:
+%\fnbelowfloat
+% to enable the placement of footnotes below bottom floats (the standard
+% LaTeX2e kernel puts them above bottom floats). This is an invasive package
+% which rewrites many portions of the LaTeX2e float routines. It may not work
+% with other packages that modify the LaTeX2e float routines. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/sttools/
+% Documentation is contained in the stfloats.sty comments as well as in the
+% presfull.pdf file. Do not use the stfloats baselinefloat ability as IEEE
+% does not allow \baselineskip to stretch. Authors submitting work to the
+% IEEE should note that IEEE rarely uses double column equations and
+% that authors should try to avoid such use. Do not be tempted to use the
+% cuted.sty or midfloat.sty packages (also by Sigitas Tolusis) as IEEE does
+% not format its papers in such ways.
+
+
+%\ifCLASSOPTIONcaptionsoff
+%  \usepackage[nomarkers]{endfloat}
+% \let\MYoriglatexcaption\caption
+% \renewcommand{\caption}[2][\relax]{\MYoriglatexcaption[#2]{#2}}
+%\fi
+% endfloat.sty was written by James Darrell McCauley and Jeff Goldberg.
+% This package may be useful when used in conjunction with IEEEtran.cls'
+% captionsoff option. Some IEEE journals/societies require that submissions
+% have lists of figures/tables at the end of the paper and that
+% figures/tables without any captions are placed on a page by themselves at
+% the end of the document. If needed, the draftcls IEEEtran class option or
+% \CLASSINPUTbaselinestretch interface can be used to increase the line
+% spacing as well. Be sure and use the nomarkers option of endfloat to
+% prevent endfloat from "marking" where the figures would have been placed
+% in the text. The two hack lines of code above are a slight modification of
+% that suggested by in the endfloat docs (section 8.3.1) to ensure that
+% the full captions always appear in the list of figures/tables - even if
+% the user used the short optional argument of \caption[]{}.
+% IEEE papers do not typically make use of \caption[]'s optional argument,
+% so this should not be an issue. A similar trick can be used to disable
+% captions of packages such as subfig.sty that lack options to turn off
+% the subcaptions:
+% For subfig.sty:
+% \let\MYorigsubfloat\subfloat
+% \renewcommand{\subfloat}[2][\relax]{\MYorigsubfloat[]{#2}}
+% For subfigure.sty:
+% \let\MYorigsubfigure\subfigure
+% \renewcommand{\subfigure}[2][\relax]{\MYorigsubfigure[]{#2}}
+% However, the above trick will not work if both optional arguments of
+% the \subfloat/subfig command are used. Furthermore, there needs to be a
+% description of each subfigure *somewhere* and endfloat does not add
+% subfigure captions to its list of figures. Thus, the best approach is to
+% avoid the use of subfigure captions (many IEEE journals avoid them anyway)
+% and instead reference/explain all the subfigures within the main caption.
+% The latest version of endfloat.sty and its documentation can obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/endfloat/
+%
+% The IEEEtran \ifCLASSOPTIONcaptionsoff conditional can also be used
+% later in the document, say, to conditionally put the References on a 
+% page by themselves.
+
+
+
+
+
+% *** PDF, URL AND HYPERLINK PACKAGES ***
+%
+%\usepackage{url}
+% url.sty was written by Donald Arseneau. It provides better support for
+% handling and breaking URLs. url.sty is already installed on most LaTeX
+% systems. The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/misc/
+% Read the url.sty source comments for usage information. Basically,
+% \url{my_url_here}.
+
+
+% NOTE: PDF thumbnail features are not required in IEEE papers
+%       and their use requires extra complexity and work.
+%\ifCLASSINFOpdf
+%  \usepackage[pdftex]{thumbpdf}
+%\else
+%  \usepackage[dvips]{thumbpdf}
+%\fi
+% thumbpdf.sty and its companion Perl utility were written by Heiko Oberdiek.
+% It allows the user a way to produce PDF documents that contain fancy
+% thumbnail images of each of the pages (which tools like acrobat reader can
+% utilize). This is possible even when using dvi->ps->pdf workflow if the
+% correct thumbpdf driver options are used. thumbpdf.sty incorporates the
+% file containing the PDF thumbnail information (filename.tpm is used with
+% dvips, filename.tpt is used with pdftex, where filename is the base name of
+% your tex document) into the final ps or pdf output document. An external
+% utility, the thumbpdf *Perl script* is needed to make these .tpm or .tpt
+% thumbnail files from a .ps or .pdf version of the document (which obviously
+% does not yet contain pdf thumbnails). Thus, one does a:
+% 
+% thumbpdf filename.pdf 
+%
+% to make a filename.tpt, and:
+%
+% thumbpdf --mode dvips filename.ps
+%
+% to make a filename.tpm which will then be loaded into the document by
+% thumbpdf.sty the NEXT time the document is compiled (by pdflatex or
+% latex->dvips->ps2pdf). Users must be careful to regenerate the .tpt and/or
+% .tpm files if the main document changes and then to recompile the
+% document to incorporate the revised thumbnails to ensure that thumbnails
+% match the actual pages. It is easy to forget to do this!
+% 
+% Unix systems come with a Perl interpreter. However, MS Windows users
+% will usually have to install a Perl interpreter so that the thumbpdf
+% script can be run. The Ghostscript PS/PDF interpreter is also required.
+% See the thumbpdf docs for details. The latest version and documentation
+% can be obtained at.
+% http://www.ctan.org/tex-archive/support/thumbpdf/
+% Be sure and use only version 3.8 (2005/07/06) or later of thumbpdf as
+% earlier versions will not work properly with recent versions of pdfTeX
+% (1.20a and later).
+
+
+% NOTE: PDF hyperlink and bookmark features are not required in IEEE
+%       papers and their use requires extra complexity and work.
+% *** IF USING HYPERREF BE SURE AND CHANGE THE EXAMPLE PDF ***
+% *** TITLE/SUBJECT/AUTHOR/KEYWORDS INFO BELOW!!           ***
+\newcommand\MYhyperrefoptions{bookmarks=true,bookmarksnumbered=true,
+pdfpagemode={UseOutlines},plainpages=false,pdfpagelabels=true,
+colorlinks=true,linkcolor={black},citecolor={black},pagecolor={black},
+urlcolor={black},
+pdftitle={Bare Demo of IEEEtran.cls for Computer Society Journals},%<!CHANGE!
+pdfsubject={Typesetting},%<!CHANGE!
+pdfauthor={Michael D. Shell},%<!CHANGE!
+pdfkeywords={Computer Society, IEEEtran, journal, LaTeX, paper,
+             template}}%<^!CHANGE!
+%\ifCLASSINFOpdf
+%\usepackage[\MYhyperrefoptions,pdftex]{hyperref}
+%\else
+%\usepackage[\MYhyperrefoptions,breaklinks=true,dvips]{hyperref}
+%\usepackage{breakurl}
+%\fi
+% One significant drawback of using hyperref under DVI output is that the
+% LaTeX compiler cannot break URLs across lines or pages as can be done
+% under pdfLaTeX's PDF output via the hyperref pdftex driver. This is
+% probably the single most important capability distinction between the
+% DVI and PDF output. Perhaps surprisingly, all the other PDF features
+% (PDF bookmarks, thumbnails, etc.) can be preserved in
+% .tex->.dvi->.ps->.pdf workflow if the respective packages/scripts are
+% loaded/invoked with the correct driver options (dvips, etc.). 
+% As most IEEE papers use URLs sparingly (mainly in the references), this
+% may not be as big an issue as with other publications.
+%
+% That said, recently Vilar Camara Neto introduced his breakurl.sty
+% package which permits hyperref to easily break URLs even in dvi
+% mode. Note that breakurl, unlike most other packages, must be loaded
+% AFTER hyperref. The latest version of breakurl and its documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/breakurl/
+% breakurl.sty is not for use under pdflatex pdf mode. Versions 1.10 
+% (September 23, 2005) and later are recommened to avoid bugs in earlier
+% releases.
+%
+% The advanced features offer by hyperref.sty are not required for IEEE
+% submission, so users should weigh these features against the added
+% complexity of use. Users who wish to use hyperref *must* ensure that
+% their hyperref version is 6.72u or later *and* IEEEtran.cls is version
+% 1.6b or later.
+% The package options above demonstrate how to enable PDF bookmarks
+% (a type of table of contents viewable in Acrobat Reader) as well as
+% PDF document information (title, subject, author and keywords) that is
+% viewable in Acrobat reader's Document_Properties menu. PDF document
+% information is also used extensively to automate the cataloging of PDF
+% documents. The above set of options ensures that hyperlinks will not be
+% colored in the text and thus will not be visible in the printed page,
+% but will be active on "mouse over". USING COLORS OR OTHER HIGHLIGHTING
+% OF HYPERLINKS CAN RESULT IN DOCUMENT REJECTION BY THE IEEE, especially if
+% these appear on the "printed" page. IF IN DOUBT, ASK THE RELEVANT
+% SUBMISSION EDITOR. You may need to add the option hypertexnames=false if
+% you used duplicate equation numbers, etc., but this should not be needed
+% in normal IEEE work.
+% The latest version of hyperref and its documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/hyperref/
+
+
+
+
+
+% *** Do not adjust lengths that control margins, column widths, etc. ***
+% *** Do not use packages that alter fonts (such as pslatex).         ***
+% There should be no need to do such things with IEEEtran.cls V1.6 and later.
+% (Unless specifically asked to do so by the journal or conference you plan
+% to submit to, of course. )
+
+
+% correct bad hyphenation here
+\hyphenation{op-tical net-works semi-conduc-tor}
+
+
+\begin{document}
+%
+% paper title
+% can use linebreaks \\ within to get better formatting as desired
+\title{Bare Advanced Demo of IEEEtran.cls\\ for Computer Society Journals}
+%
+%
+% author names and IEEE memberships
+% note positions of commas and nonbreaking spaces ( ~ ) LaTeX will not break
+% a structure at a ~ so this keeps an author's name from being broken across
+% two lines.
+% use \thanks{} to gain access to the first footnote area
+% a separate \thanks must be used for each paragraph as LaTeX2e's \thanks
+% was not built to handle multiple paragraphs
+%
+%
+%\IEEEcompsocitemizethanks is a special \thanks that produces the bulleted
+% lists the Computer Society journals use for "first footnote" author
+% affiliations. Use \IEEEcompsocthanksitem which works much like \item
+% for each affiliation group. When not in compsoc mode,
+% \IEEEcompsocitemizethanks becomes like \thanks and
+% \IEEEcompsocthanksitem becomes a line break with idention. This
+% facilitates dual compilation, although admittedly the differences in the
+% desired content of \author between the different types of papers makes a
+% one-size-fits-all approach a daunting prospect. For instance, compsoc 
+% journal papers have the author affiliations above the "Manuscript
+% received ..."  text while in non-compsoc journals this is reversed. Sigh.
+
+\author{Michael~Shell,~\IEEEmembership{Member,~IEEE,}
+        John~Doe,~\IEEEmembership{Fellow,~OSA,}
+        and~Jane~Doe,~\IEEEmembership{Life~Fellow,~IEEE}% <-this % stops a space
+\IEEEcompsocitemizethanks{\IEEEcompsocthanksitem M. Shell is with the Department
+of Electrical and Computer Engineering, Georgia Institute of Technology, Atlanta,
+GA, 30332.\protect\\
+% note need leading \protect in front of \\ to get a newline within \thanks as
+% \\ is fragile and will error, could use \hfil\break instead.
+E-mail: see http://www.michaelshell.org/contact.html
+\IEEEcompsocthanksitem J. Doe and J. Doe are with Anonymous University.}% <-this % stops a space
+\thanks{Manuscript received April 19, 2005; revised January 11, 2007.}}
+
+% note the % following the last \IEEEmembership and also \thanks - 
+% these prevent an unwanted space from occurring between the last author name
+% and the end of the author line. i.e., if you had this:
+% 
+% \author{....lastname \thanks{...} \thanks{...} }
+%                     ^------------^------------^----Do not want these spaces!
+%
+% a space would be appended to the last name and could cause every name on that
+% line to be shifted left slightly. This is one of those "LaTeX things". For
+% instance, "\textbf{A} \textbf{B}" will typeset as "A B" not "AB". To get
+% "AB" then you have to do: "\textbf{A}\textbf{B}"
+% \thanks is no different in this regard, so shield the last } of each \thanks
+% that ends a line with a % and do not let a space in before the next \thanks.
+% Spaces after \IEEEmembership other than the last one are OK (and needed) as
+% you are supposed to have spaces between the names. For what it is worth,
+% this is a minor point as most people would not even notice if the said evil
+% space somehow managed to creep in.
+
+
+
+% The paper headers
+\markboth{Journal of \LaTeX\ Class Files,~Vol.~6, No.~1, January~2007}%
+{Shell \MakeLowercase{\textit{et al.}}: Bare Advanced Demo of IEEEtran.cls for Journals}
+% The only time the second header will appear is for the odd numbered pages
+% after the title page when using the twoside option.
+% 
+% *** Note that you probably will NOT want to include the author's ***
+% *** name in the headers of peer review papers.                   ***
+% You can use \ifCLASSOPTIONpeerreview for conditional compilation here if
+% you desire.
+
+
+
+% The publisher's ID mark at the bottom of the page is less important with
+% Computer Society journal papers as those publications place the marks
+% outside of the main text columns and, therefore, unlike regular IEEE
+% journals, the available text space is not reduced by their presence.
+% If you want to put a publisher's ID mark on the page you can do it like
+% this:
+%\IEEEpubid{0000--0000/00\$00.00~\copyright~2007 IEEE}
+% or like this to get the Computer Society new two part style.
+%\IEEEpubid{\makebox[\columnwidth]{\hfill 0000--0000/00/\$00.00~\copyright~2007 IEEE}%
+%\hspace{\columnsep}\makebox[\columnwidth]{Published by the IEEE Computer Society\hfill}}
+% Remember, if you use this you must call \IEEEpubidadjcol in the second
+% column for its text to clear the IEEEpubid mark (Computer Society jorunal
+% papers don't need this extra clearance.)
+
+
+
+% use for special paper notices
+%\IEEEspecialpapernotice{(Invited Paper)}
+
+
+
+% for Computer Society papers, we must declare the abstract and index terms
+% PRIOR to the title within the \IEEEcompsoctitleabstractindextext IEEEtran
+% command as these need to go into the title area created by \maketitle.
+\IEEEcompsoctitleabstractindextext{%
+\begin{abstract}
+%\boldmath
+The abstract goes here.
+\end{abstract}
+% IEEEtran.cls defaults to using nonbold math in the Abstract.
+% This preserves the distinction between vectors and scalars. However,
+% if the journal you are submitting to favors bold math in the abstract,
+% then you can use LaTeX's standard command \boldmath at the very start
+% of the abstract to achieve this. Many IEEE journals frown on math
+% in the abstract anyway. In particular, the Computer Society does
+% not want either math or citations to appear in the abstract.
+
+% Note that keywords are not normally used for peerreview papers.
+\begin{IEEEkeywords}
+Computer Society, IEEEtran, journal, \LaTeX, paper, template.
+\end{IEEEkeywords}}
+
+
+% make the title area
+\maketitle
+
+
+% To allow for easy dual compilation without having to reenter the
+% abstract/keywords data, the \IEEEcompsoctitleabstractindextext text will
+% not be used in maketitle, but will appear (i.e., to be "transported")
+% here as \IEEEdisplaynotcompsoctitleabstractindextext when compsoc mode
+% is not selected <OR> if conference mode is selected - because compsoc
+% conference papers position the abstract like regular (non-compsoc)
+% papers do!
+\IEEEdisplaynotcompsoctitleabstractindextext
+% \IEEEdisplaynotcompsoctitleabstractindextext has no effect when using
+% compsoc under a non-conference mode.
+
+
+% For peer review papers, you can put extra information on the cover
+% page as needed:
+% \ifCLASSOPTIONpeerreview
+% \begin{center} \bfseries EDICS Category: 3-BBND \end{center}
+% \fi
+%
+% For peerreview papers, this IEEEtran command inserts a page break and
+% creates the second title. It will be ignored for other modes.
+\IEEEpeerreviewmaketitle
+
+
+
+\section{Introduction}
+% Computer Society journal papers do something a tad strange with the very
+% first section heading (almost always called "Introduction"). They place it
+% ABOVE the main text! IEEEtran.cls currently does not do this for you.
+% However, You can achieve this effect by making LaTeX jump through some
+% hoops via something like:
+%
+%\ifCLASSOPTIONcompsoc
+%  \noindent\raisebox{2\baselineskip}[0pt][0pt]%
+%  {\parbox{\columnwidth}{\section{Introduction}\label{sec:introduction}%
+%  \global\everypar=\everypar}}%
+%  \vspace{-1\baselineskip}\vspace{-\parskip}\par
+%\else
+%  \section{Introduction}\label{sec:introduction}\par
+%\fi
+%
+% Admittedly, this is a hack and may well be fragile, but seems to do the
+% trick for me. Note the need to keep any \label that may be used right
+% after \section in the above as the hack puts \section within a raised box.
+
+
+
+% The very first letter is a 2 line initial drop letter followed
+% by the rest of the first word in caps (small caps for compsoc).
+% 
+% form to use if the first word consists of a single letter:
+% \IEEEPARstart{A}{demo} file is ....
+% 
+% form to use if you need the single drop letter followed by
+% normal text (unknown if ever used by IEEE):
+% \IEEEPARstart{A}{}demo file is ....
+% 
+% Some journals put the first two words in caps:
+% \IEEEPARstart{T}{his demo} file is ....
+% 
+% Here we have the typical use of a "T" for an initial drop letter
+% and "HIS" in caps to complete the first word.
+\IEEEPARstart{T}{his} demo file is intended to serve as a ``starter file''
+for IEEE Computer Society journal papers produced under \LaTeX\ using
+IEEEtran.cls version 1.7 and later.
+% You must have at least 2 lines in the paragraph with the drop letter
+% (should never be an issue)
+I wish you the best of success.
+
+\hfill mds
+ 
+\hfill January 11, 2007
+
+\subsection{Subsection Heading Here}
+Subsection text here.
+
+% needed in second column of first page if using \IEEEpubid
+%\IEEEpubidadjcol
+
+\subsubsection{Subsubsection Heading Here}
+Subsubsection text here.
+
+
+% An example of a floating figure using the graphicx package.
+% Note that \label must occur AFTER (or within) \caption.
+% For figures, \caption should occur after the \includegraphics.
+% Note that IEEEtran v1.7 and later has special internal code that
+% is designed to preserve the operation of \label within \caption
+% even when the captionsoff option is in effect. However, because
+% of issues like this, it may be the safest practice to put all your
+% \label just after \caption rather than within \caption{}.
+%
+% Reminder: the "draftcls" or "draftclsnofoot", not "draft", class
+% option should be used if it is desired that the figures are to be
+% displayed while in draft mode.
+%
+%\begin{figure}[!t]
+%\centering
+%\includegraphics[width=2.5in]{myfigure}
+% where an .eps filename suffix will be assumed under latex, 
+% and a .pdf suffix will be assumed for pdflatex; or what has been declared
+% via \DeclareGraphicsExtensions.
+%\caption{Simulation Results}
+%\label{fig_sim}
+%\end{figure}
+
+% Note that IEEE typically puts floats only at the top, even when this
+% results in a large percentage of a column being occupied by floats.
+% However, the Computer Society has been known to put floats at the bottom.
+
+
+% An example of a double column floating figure using two subfigures.
+% (The subfig.sty package must be loaded for this to work.)
+% The subfigure \label commands are set within each subfloat command, the
+% \label for the overall figure must come after \caption.
+% \hfil must be used as a separator to get equal spacing.
+% The subfigure.sty package works much the same way, except \subfigure is
+% used instead of \subfloat.
+%
+%\begin{figure*}[!t]
+%\centerline{\subfloat[Case I]\includegraphics[width=2.5in]{subfigcase1}%
+%\label{fig_first_case}}
+%\hfil
+%\subfloat[Case II]{\includegraphics[width=2.5in]{subfigcase2}%
+%\label{fig_second_case}}}
+%\caption{Simulation results}
+%\label{fig_sim}
+%\end{figure*}
+%
+% Note that often IEEE papers with subfigures do not employ subfigure
+% captions (using the optional argument to \subfloat), but instead will
+% reference/describe all of them (a), (b), etc., within the main caption.
+
+
+% An example of a floating table. Note that, for IEEE style tables, the 
+% \caption command should come BEFORE the table. Table text will default to
+% \footnotesize as IEEE normally uses this smaller font for tables.
+% The \label must come after \caption as always.
+%
+%\begin{table}[!t]
+%% increase table row spacing, adjust to taste
+%\renewcommand{\arraystretch}{1.3}
+% if using array.sty, it might be a good idea to tweak the value of
+% \extrarowheight as needed to properly center the text within the cells
+%\caption{An Example of a Table}
+%\label{table_example}
+%\centering
+%% Some packages, such as MDW tools, offer better commands for making tables
+%% than the plain LaTeX2e tabular which is used here.
+%\begin{tabular}{|c||c|}
+%\hline
+%One & Two\\
+%\hline
+%Three & Four\\
+%\hline
+%\end{tabular}
+%\end{table}
+
+
+% Note that IEEE does not put floats in the very first column - or typically
+% anywhere on the first page for that matter. Also, in-text middle ("here")
+% positioning is not used. Most IEEE journals use top floats exclusively.
+% However, Computer Society journals sometimes do use bottom floats - bear
+% this in mind when choosing appropriate optional arguments for the
+% figure/table environments.
+% Note that, LaTeX2e, unlike IEEE journals, places footnotes above bottom
+% floats. This can be corrected via the \fnbelowfloat command of the
+% stfloats package.
+
+
+
+\section{Conclusion}
+The conclusion goes here.
+
+
+
+
+
+% if have a single appendix:
+%\appendix[Proof of the Zonklar Equations]
+% or
+%\appendix  % for no appendix heading
+% do not use \section anymore after \appendix, only \section*
+% is possibly needed
+
+% use appendices with more than one appendix
+% then use \section to start each appendix
+% you must declare a \section before using any
+% \subsection or using \label (\appendices by itself
+% starts a section numbered zero.)
+%
+
+
+\appendices
+\section{Proof of the First Zonklar Equation}
+Appendix one text goes here.
+
+% you can choose not to have a title for an appendix
+% if you want by leaving the argument blank
+\section{}
+Appendix two text goes here.
+
+
+% use section* for acknowledgement
+\ifCLASSOPTIONcompsoc
+  % The Computer Society usually uses the plural form
+  \section*{Acknowledgments}
+\else
+  % regular IEEE prefers the singular form
+  \section*{Acknowledgment}
+\fi
+
+
+The authors would like to thank...
+
+
+% Can use something like this to put references on a page
+% by themselves when using endfloat and the captionsoff option.
+\ifCLASSOPTIONcaptionsoff
+  \newpage
+\fi
+
+
+
+% trigger a \newpage just before the given reference
+% number - used to balance the columns on the last page
+% adjust value as needed - may need to be readjusted if
+% the document is modified later
+%\IEEEtriggeratref{8}
+% The "triggered" command can be changed if desired:
+%\IEEEtriggercmd{\enlargethispage{-5in}}
+
+% references section
+
+% can use a bibliography generated by BibTeX as a .bbl file
+% BibTeX documentation can be easily obtained at:
+% http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/
+% The IEEEtran BibTeX style support page is at:
+% http://www.michaelshell.org/tex/ieeetran/bibtex/
+%\bibliographystyle{IEEEtran}
+% argument is your BibTeX string definitions and bibliography database(s)
+%\bibliography{IEEEabrv,../bib/paper}
+%
+% <OR> manually copy in the resultant .bbl file
+% set second argument of \begin to the number of references
+% (used to reserve space for the reference number labels box)
+\begin{thebibliography}{1}
+
+\bibitem{IEEEhowto:kopka}
+H.~Kopka and P.~W. Daly, \emph{A Guide to {\LaTeX}}, 3rd~ed.\hskip 1em plus
+  0.5em minus 0.4em\relax Harlow, England: Addison-Wesley, 1999.
+
+\end{thebibliography}
+
+% biography section
+% 
+% If you have an EPS/PDF photo (graphicx package needed) extra braces are
+% needed around the contents of the optional argument to biography to prevent
+% the LaTeX parser from getting confused when it sees the complicated
+% \includegraphics command within an optional argument. (You could create
+% your own custom macro containing the \includegraphics command to make things
+% simpler here.)
+%\begin{biography}[{\includegraphics[width=1in,height=1.25in,clip,keepaspectratio]{mshell}}]{Michael Shell}
+% or if you just want to reserve a space for a photo:
+
+\begin{IEEEbiography}{Michael Shell}
+Biography text here.
+\end{IEEEbiography}
+
+% if you will not have a photo at all:
+\begin{IEEEbiographynophoto}{John Doe}
+Biography text here.
+\end{IEEEbiographynophoto}
+
+% insert where needed to balance the two columns on the last page with
+% biographies
+%\newpage
+
+\begin{IEEEbiographynophoto}{Jane Doe}
+Biography text here.
+\end{IEEEbiographynophoto}
+
+% You can push biographies down or up by placing
+% a \vfill before or after them. The appropriate
+% use of \vfill depends on what kind of text is
+% on the last page and whether or not the columns
+% are being equalized.
+
+%\vfill
+
+% Can be used to pull up biographies so that the bottom of the last one
+% is flush with the other column.
+%\enlargethispage{-5in}
+
+
+
+% that's all folks
+\end{document}
+
+

--- a/ieee/bare_jrnl.tex
+++ b/ieee/bare_jrnl.tex
@@ -1,0 +1,745 @@
+
+%% bare_jrnl.tex
+%% V1.3
+%% 2007/01/11
+%% by Michael Shell
+%% see http://www.michaelshell.org/
+%% for current contact information.
+%%
+%% This is a skeleton file demonstrating the use of IEEEtran.cls
+%% (requires IEEEtran.cls version 1.7 or later) with an IEEE journal paper.
+%%
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and
+%% http://www.ieee.org/
+
+
+
+% *** Authors should verify (and, if needed, correct) their LaTeX system  ***
+% *** with the testflow diagnostic prior to trusting their LaTeX platform ***
+% *** with production work. IEEE's font choices can trigger bugs that do  ***
+% *** not appear when using other class files.                            ***
+% The testflow support page is at:
+% http://www.michaelshell.org/tex/testflow/
+
+
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+%%                    bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+%%*************************************************************************
+
+% Note that the a4paper option is mainly intended so that authors in
+% countries using A4 can easily print to A4 and see how their papers will
+% look in print - the typesetting of the document will not typically be
+% affected with changes in paper size (but the bottom and side margins will).
+% Use the testflow package mentioned above to verify correct handling of
+% both paper sizes by the user's LaTeX system.
+%
+% Also note that the "draftcls" or "draftclsnofoot", not "draft", option
+% should be used if it is desired that the figures are to be displayed in
+% draft mode.
+%
+\documentclass[journal]{IEEEtran}
+%
+% If IEEEtran.cls has not been installed into the LaTeX system files,
+% manually specify the path to it like:
+% \documentclass[journal]{../sty/IEEEtran}
+
+
+
+
+
+% Some very useful LaTeX packages include:
+% (uncomment the ones you want to load)
+
+
+% *** MISC UTILITY PACKAGES ***
+%
+%\usepackage{ifpdf}
+% Heiko Oberdiek's ifpdf.sty is very useful if you need conditional
+% compilation based on whether the output is pdf or dvi.
+% usage:
+% \ifpdf
+%   % pdf code
+% \else
+%   % dvi code
+% \fi
+% The latest version of ifpdf.sty can be obtained from:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/oberdiek/
+% Also, note that IEEEtran.cls V1.7 and later provides a builtin
+% \ifCLASSINFOpdf conditional that works the same way.
+% When switching from latex to pdflatex and vice-versa, the compiler may
+% have to be run twice to clear warning/error messages.
+
+
+
+
+
+
+% *** CITATION PACKAGES ***
+%
+%\usepackage{cite}
+% cite.sty was written by Donald Arseneau
+% V1.6 and later of IEEEtran pre-defines the format of the cite.sty package
+% \cite{} output to follow that of IEEE. Loading the cite package will
+% result in citation numbers being automatically sorted and properly
+% "compressed/ranged". e.g., [1], [9], [2], [7], [5], [6] without using
+% cite.sty will become [1], [2], [5]--[7], [9] using cite.sty. cite.sty's
+% \cite will automatically add leading space, if needed. Use cite.sty's
+% noadjust option (cite.sty V3.8 and later) if you want to turn this off.
+% cite.sty is already installed on most LaTeX systems. Be sure and use
+% version 4.0 (2003-05-27) and later if using hyperref.sty. cite.sty does
+% not currently provide for hyperlinked citations.
+% The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/cite/
+% The documentation is contained in the cite.sty file itself.
+
+
+
+
+
+
+% *** GRAPHICS RELATED PACKAGES ***
+%
+\ifCLASSINFOpdf
+  % \usepackage[pdftex]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../pdf/}{../jpeg/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.pdf,.jpeg,.png}
+\else
+  % or other class option (dvipsone, dvipdf, if not using dvips). graphicx
+  % will default to the driver specified in the system graphics.cfg if no
+  % driver is specified.
+  % \usepackage[dvips]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../eps/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.eps}
+\fi
+% graphicx was written by David Carlisle and Sebastian Rahtz. It is
+% required if you want graphics, photos, etc. graphicx.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at: 
+% http://www.ctan.org/tex-archive/macros/latex/required/graphics/
+% Another good source of documentation is "Using Imported Graphics in
+% LaTeX2e" by Keith Reckdahl which can be found as epslatex.ps or
+% epslatex.pdf at: http://www.ctan.org/tex-archive/info/
+%
+% latex, and pdflatex in dvi mode, support graphics in encapsulated
+% postscript (.eps) format. pdflatex in pdf mode supports graphics
+% in .pdf, .jpeg, .png and .mps (metapost) formats. Users should ensure
+% that all non-photo figures use a vector format (.eps, .pdf, .mps) and
+% not a bitmapped formats (.jpeg, .png). IEEE frowns on bitmapped formats
+% which can result in "jaggedy"/blurry rendering of lines and letters as
+% well as large increases in file sizes.
+%
+% You can find documentation about the pdfTeX application at:
+% http://www.tug.org/applications/pdftex
+
+
+
+
+
+% *** MATH PACKAGES ***
+%
+%\usepackage[cmex10]{amsmath}
+% A popular package from the American Mathematical Society that provides
+% many useful and powerful commands for dealing with mathematics. If using
+% it, be sure to load this package with the cmex10 option to ensure that
+% only type 1 fonts will utilized at all point sizes. Without this option,
+% it is possible that some math symbols, particularly those within
+% footnotes, will be rendered in bitmap form which will result in a
+% document that can not be IEEE Xplore compliant!
+%
+% Also, note that the amsmath package sets \interdisplaylinepenalty to 10000
+% thus preventing page breaks from occurring within multiline equations. Use:
+%\interdisplaylinepenalty=2500
+% after loading amsmath to restore such page breaks as IEEEtran.cls normally
+% does. amsmath.sty is already installed on most LaTeX systems. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/amslatex/math/
+
+
+
+
+
+% *** SPECIALIZED LIST PACKAGES ***
+%
+%\usepackage{algorithmic}
+% algorithmic.sty was written by Peter Williams and Rogerio Brito.
+% This package provides an algorithmic environment fo describing algorithms.
+% You can use the algorithmic environment in-text or within a figure
+% environment to provide for a floating algorithm. Do NOT use the algorithm
+% floating environment provided by algorithm.sty (by the same authors) or
+% algorithm2e.sty (by Christophe Fiorio) as IEEE does not use dedicated
+% algorithm float types and packages that provide these will not provide
+% correct IEEE style captions. The latest version and documentation of
+% algorithmic.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithms/
+% There is also a support site at:
+% http://algorithms.berlios.de/index.html
+% Also of interest may be the (relatively newer and more customizable)
+% algorithmicx.sty package by Szasz Janos:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithmicx/
+
+
+
+
+% *** ALIGNMENT PACKAGES ***
+%
+%\usepackage{array}
+% Frank Mittelbach's and David Carlisle's array.sty patches and improves
+% the standard LaTeX2e array and tabular environments to provide better
+% appearance and additional user controls. As the default LaTeX2e table
+% generation code is lacking to the point of almost being broken with
+% respect to the quality of the end results, all users are strongly
+% advised to use an enhanced (at the very least that provided by array.sty)
+% set of table tools. array.sty is already installed on most systems. The
+% latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/tools/
+
+
+%\usepackage{mdwmath}
+%\usepackage{mdwtab}
+% Also highly recommended is Mark Wooding's extremely powerful MDW tools,
+% especially mdwmath.sty and mdwtab.sty which are used to format equations
+% and tables, respectively. The MDWtools set is already installed on most
+% LaTeX systems. The lastest version and documentation is available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/mdwtools/
+
+
+% IEEEtran contains the IEEEeqnarray family of commands that can be used to
+% generate multiline equations as well as matrices, tables, etc., of high
+% quality.
+
+
+%\usepackage{eqparbox}
+% Also of notable interest is Scott Pakin's eqparbox package for creating
+% (automatically sized) equal width boxes - aka "natural width parboxes".
+% Available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/eqparbox/
+
+
+
+
+
+% *** SUBFIGURE PACKAGES ***
+%\usepackage[tight,footnotesize]{subfigure}
+% subfigure.sty was written by Steven Douglas Cochran. This package makes it
+% easy to put subfigures in your figures. e.g., "Figure 1a and 1b". For IEEE
+% work, it is a good idea to load it with the tight package option to reduce
+% the amount of white space around the subfigures. subfigure.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/obsolete/macros/latex/contrib/subfigure/
+% subfigure.sty has been superceeded by subfig.sty.
+
+
+
+%\usepackage[caption=false]{caption}
+%\usepackage[font=footnotesize]{subfig}
+% subfig.sty, also written by Steven Douglas Cochran, is the modern
+% replacement for subfigure.sty. However, subfig.sty requires and
+% automatically loads Axel Sommerfeldt's caption.sty which will override
+% IEEEtran.cls handling of captions and this will result in nonIEEE style
+% figure/table captions. To prevent this problem, be sure and preload
+% caption.sty with its "caption=false" package option. This is will preserve
+% IEEEtran.cls handing of captions. Version 1.3 (2005/06/28) and later 
+% (recommended due to many improvements over 1.2) of subfig.sty supports
+% the caption=false option directly:
+%\usepackage[caption=false,font=footnotesize]{subfig}
+%
+% The latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/subfig/
+% The latest version and documentation of caption.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/caption/
+
+
+
+
+% *** FLOAT PACKAGES ***
+%
+%\usepackage{fixltx2e}
+% fixltx2e, the successor to the earlier fix2col.sty, was written by
+% Frank Mittelbach and David Carlisle. This package corrects a few problems
+% in the LaTeX2e kernel, the most notable of which is that in current
+% LaTeX2e releases, the ordering of single and double column floats is not
+% guaranteed to be preserved. Thus, an unpatched LaTeX2e can allow a
+% single column figure to be placed prior to an earlier double column
+% figure. The latest version and documentation can be found at:
+% http://www.ctan.org/tex-archive/macros/latex/base/
+
+
+
+%\usepackage{stfloats}
+% stfloats.sty was written by Sigitas Tolusis. This package gives LaTeX2e
+% the ability to do double column floats at the bottom of the page as well
+% as the top. (e.g., "\begin{figure*}[!b]" is not normally possible in
+% LaTeX2e). It also provides a command:
+%\fnbelowfloat
+% to enable the placement of footnotes below bottom floats (the standard
+% LaTeX2e kernel puts them above bottom floats). This is an invasive package
+% which rewrites many portions of the LaTeX2e float routines. It may not work
+% with other packages that modify the LaTeX2e float routines. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/sttools/
+% Documentation is contained in the stfloats.sty comments as well as in the
+% presfull.pdf file. Do not use the stfloats baselinefloat ability as IEEE
+% does not allow \baselineskip to stretch. Authors submitting work to the
+% IEEE should note that IEEE rarely uses double column equations and
+% that authors should try to avoid such use. Do not be tempted to use the
+% cuted.sty or midfloat.sty packages (also by Sigitas Tolusis) as IEEE does
+% not format its papers in such ways.
+
+
+%\ifCLASSOPTIONcaptionsoff
+%  \usepackage[nomarkers]{endfloat}
+% \let\MYoriglatexcaption\caption
+% \renewcommand{\caption}[2][\relax]{\MYoriglatexcaption[#2]{#2}}
+%\fi
+% endfloat.sty was written by James Darrell McCauley and Jeff Goldberg.
+% This package may be useful when used in conjunction with IEEEtran.cls'
+% captionsoff option. Some IEEE journals/societies require that submissions
+% have lists of figures/tables at the end of the paper and that
+% figures/tables without any captions are placed on a page by themselves at
+% the end of the document. If needed, the draftcls IEEEtran class option or
+% \CLASSINPUTbaselinestretch interface can be used to increase the line
+% spacing as well. Be sure and use the nomarkers option of endfloat to
+% prevent endfloat from "marking" where the figures would have been placed
+% in the text. The two hack lines of code above are a slight modification of
+% that suggested by in the endfloat docs (section 8.3.1) to ensure that
+% the full captions always appear in the list of figures/tables - even if
+% the user used the short optional argument of \caption[]{}.
+% IEEE papers do not typically make use of \caption[]'s optional argument,
+% so this should not be an issue. A similar trick can be used to disable
+% captions of packages such as subfig.sty that lack options to turn off
+% the subcaptions:
+% For subfig.sty:
+% \let\MYorigsubfloat\subfloat
+% \renewcommand{\subfloat}[2][\relax]{\MYorigsubfloat[]{#2}}
+% For subfigure.sty:
+% \let\MYorigsubfigure\subfigure
+% \renewcommand{\subfigure}[2][\relax]{\MYorigsubfigure[]{#2}}
+% However, the above trick will not work if both optional arguments of
+% the \subfloat/subfig command are used. Furthermore, there needs to be a
+% description of each subfigure *somewhere* and endfloat does not add
+% subfigure captions to its list of figures. Thus, the best approach is to
+% avoid the use of subfigure captions (many IEEE journals avoid them anyway)
+% and instead reference/explain all the subfigures within the main caption.
+% The latest version of endfloat.sty and its documentation can obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/endfloat/
+%
+% The IEEEtran \ifCLASSOPTIONcaptionsoff conditional can also be used
+% later in the document, say, to conditionally put the References on a 
+% page by themselves.
+
+
+
+
+
+% *** PDF, URL AND HYPERLINK PACKAGES ***
+%
+%\usepackage{url}
+% url.sty was written by Donald Arseneau. It provides better support for
+% handling and breaking URLs. url.sty is already installed on most LaTeX
+% systems. The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/misc/
+% Read the url.sty source comments for usage information. Basically,
+% \url{my_url_here}.
+
+
+
+
+
+% *** Do not adjust lengths that control margins, column widths, etc. ***
+% *** Do not use packages that alter fonts (such as pslatex).         ***
+% There should be no need to do such things with IEEEtran.cls V1.6 and later.
+% (Unless specifically asked to do so by the journal or conference you plan
+% to submit to, of course. )
+
+
+% correct bad hyphenation here
+\hyphenation{op-tical net-works semi-conduc-tor}
+
+
+\begin{document}
+%
+% paper title
+% can use linebreaks \\ within to get better formatting as desired
+\title{Bare Demo of IEEEtran.cls for Journals}
+%
+%
+% author names and IEEE memberships
+% note positions of commas and nonbreaking spaces ( ~ ) LaTeX will not break
+% a structure at a ~ so this keeps an author's name from being broken across
+% two lines.
+% use \thanks{} to gain access to the first footnote area
+% a separate \thanks must be used for each paragraph as LaTeX2e's \thanks
+% was not built to handle multiple paragraphs
+%
+
+\author{Michael~Shell,~\IEEEmembership{Member,~IEEE,}
+        John~Doe,~\IEEEmembership{Fellow,~OSA,}
+        and~Jane~Doe,~\IEEEmembership{Life~Fellow,~IEEE}% <-this % stops a space
+\thanks{M. Shell is with the Department
+of Electrical and Computer Engineering, Georgia Institute of Technology, Atlanta,
+GA, 30332 USA e-mail: (see http://www.michaelshell.org/contact.html).}% <-this % stops a space
+\thanks{J. Doe and J. Doe are with Anonymous University.}% <-this % stops a space
+\thanks{Manuscript received April 19, 2005; revised January 11, 2007.}}
+
+% note the % following the last \IEEEmembership and also \thanks - 
+% these prevent an unwanted space from occurring between the last author name
+% and the end of the author line. i.e., if you had this:
+% 
+% \author{....lastname \thanks{...} \thanks{...} }
+%                     ^------------^------------^----Do not want these spaces!
+%
+% a space would be appended to the last name and could cause every name on that
+% line to be shifted left slightly. This is one of those "LaTeX things". For
+% instance, "\textbf{A} \textbf{B}" will typeset as "A B" not "AB". To get
+% "AB" then you have to do: "\textbf{A}\textbf{B}"
+% \thanks is no different in this regard, so shield the last } of each \thanks
+% that ends a line with a % and do not let a space in before the next \thanks.
+% Spaces after \IEEEmembership other than the last one are OK (and needed) as
+% you are supposed to have spaces between the names. For what it is worth,
+% this is a minor point as most people would not even notice if the said evil
+% space somehow managed to creep in.
+
+
+
+% The paper headers
+\markboth{Journal of \LaTeX\ Class Files,~Vol.~6, No.~1, January~2007}%
+{Shell \MakeLowercase{\textit{et al.}}: Bare Demo of IEEEtran.cls for Journals}
+% The only time the second header will appear is for the odd numbered pages
+% after the title page when using the twoside option.
+% 
+% *** Note that you probably will NOT want to include the author's ***
+% *** name in the headers of peer review papers.                   ***
+% You can use \ifCLASSOPTIONpeerreview for conditional compilation here if
+% you desire.
+
+
+
+
+% If you want to put a publisher's ID mark on the page you can do it like
+% this:
+%\IEEEpubid{0000--0000/00\$00.00~\copyright~2007 IEEE}
+% Remember, if you use this you must call \IEEEpubidadjcol in the second
+% column for its text to clear the IEEEpubid mark.
+
+
+
+% use for special paper notices
+%\IEEEspecialpapernotice{(Invited Paper)}
+
+
+
+
+% make the title area
+\maketitle
+
+
+\begin{abstract}
+%\boldmath
+The abstract goes here.
+\end{abstract}
+% IEEEtran.cls defaults to using nonbold math in the Abstract.
+% This preserves the distinction between vectors and scalars. However,
+% if the journal you are submitting to favors bold math in the abstract,
+% then you can use LaTeX's standard command \boldmath at the very start
+% of the abstract to achieve this. Many IEEE journals frown on math
+% in the abstract anyway.
+
+% Note that keywords are not normally used for peerreview papers.
+\begin{IEEEkeywords}
+IEEEtran, journal, \LaTeX, paper, template.
+\end{IEEEkeywords}
+
+
+
+
+
+
+% For peer review papers, you can put extra information on the cover
+% page as needed:
+% \ifCLASSOPTIONpeerreview
+% \begin{center} \bfseries EDICS Category: 3-BBND \end{center}
+% \fi
+%
+% For peerreview papers, this IEEEtran command inserts a page break and
+% creates the second title. It will be ignored for other modes.
+\IEEEpeerreviewmaketitle
+
+
+
+\section{Introduction}
+% The very first letter is a 2 line initial drop letter followed
+% by the rest of the first word in caps.
+% 
+% form to use if the first word consists of a single letter:
+% \IEEEPARstart{A}{demo} file is ....
+% 
+% form to use if you need the single drop letter followed by
+% normal text (unknown if ever used by IEEE):
+% \IEEEPARstart{A}{}demo file is ....
+% 
+% Some journals put the first two words in caps:
+% \IEEEPARstart{T}{his demo} file is ....
+% 
+% Here we have the typical use of a "T" for an initial drop letter
+% and "HIS" in caps to complete the first word.
+\IEEEPARstart{T}{his} demo file is intended to serve as a ``starter file''
+for IEEE journal papers produced under \LaTeX\ using
+IEEEtran.cls version 1.7 and later.
+% You must have at least 2 lines in the paragraph with the drop letter
+% (should never be an issue)
+I wish you the best of success.
+
+\hfill mds
+ 
+\hfill January 11, 2007
+
+\subsection{Subsection Heading Here}
+Subsection text here.
+
+% needed in second column of first page if using \IEEEpubid
+%\IEEEpubidadjcol
+
+\subsubsection{Subsubsection Heading Here}
+Subsubsection text here.
+
+
+% An example of a floating figure using the graphicx package.
+% Note that \label must occur AFTER (or within) \caption.
+% For figures, \caption should occur after the \includegraphics.
+% Note that IEEEtran v1.7 and later has special internal code that
+% is designed to preserve the operation of \label within \caption
+% even when the captionsoff option is in effect. However, because
+% of issues like this, it may be the safest practice to put all your
+% \label just after \caption rather than within \caption{}.
+%
+% Reminder: the "draftcls" or "draftclsnofoot", not "draft", class
+% option should be used if it is desired that the figures are to be
+% displayed while in draft mode.
+%
+%\begin{figure}[!t]
+%\centering
+%\includegraphics[width=2.5in]{myfigure}
+% where an .eps filename suffix will be assumed under latex, 
+% and a .pdf suffix will be assumed for pdflatex; or what has been declared
+% via \DeclareGraphicsExtensions.
+%\caption{Simulation Results}
+%\label{fig_sim}
+%\end{figure}
+
+% Note that IEEE typically puts floats only at the top, even when this
+% results in a large percentage of a column being occupied by floats.
+
+
+% An example of a double column floating figure using two subfigures.
+% (The subfig.sty package must be loaded for this to work.)
+% The subfigure \label commands are set within each subfloat command, the
+% \label for the overall figure must come after \caption.
+% \hfil must be used as a separator to get equal spacing.
+% The subfigure.sty package works much the same way, except \subfigure is
+% used instead of \subfloat.
+%
+%\begin{figure*}[!t]
+%\centerline{\subfloat[Case I]\includegraphics[width=2.5in]{subfigcase1}%
+%\label{fig_first_case}}
+%\hfil
+%\subfloat[Case II]{\includegraphics[width=2.5in]{subfigcase2}%
+%\label{fig_second_case}}}
+%\caption{Simulation results}
+%\label{fig_sim}
+%\end{figure*}
+%
+% Note that often IEEE papers with subfigures do not employ subfigure
+% captions (using the optional argument to \subfloat), but instead will
+% reference/describe all of them (a), (b), etc., within the main caption.
+
+
+% An example of a floating table. Note that, for IEEE style tables, the 
+% \caption command should come BEFORE the table. Table text will default to
+% \footnotesize as IEEE normally uses this smaller font for tables.
+% The \label must come after \caption as always.
+%
+%\begin{table}[!t]
+%% increase table row spacing, adjust to taste
+%\renewcommand{\arraystretch}{1.3}
+% if using array.sty, it might be a good idea to tweak the value of
+% \extrarowheight as needed to properly center the text within the cells
+%\caption{An Example of a Table}
+%\label{table_example}
+%\centering
+%% Some packages, such as MDW tools, offer better commands for making tables
+%% than the plain LaTeX2e tabular which is used here.
+%\begin{tabular}{|c||c|}
+%\hline
+%One & Two\\
+%\hline
+%Three & Four\\
+%\hline
+%\end{tabular}
+%\end{table}
+
+
+% Note that IEEE does not put floats in the very first column - or typically
+% anywhere on the first page for that matter. Also, in-text middle ("here")
+% positioning is not used. Most IEEE journals use top floats exclusively.
+% Note that, LaTeX2e, unlike IEEE journals, places footnotes above bottom
+% floats. This can be corrected via the \fnbelowfloat command of the
+% stfloats package.
+
+
+
+\section{Conclusion}
+The conclusion goes here.
+
+
+
+
+
+% if have a single appendix:
+%\appendix[Proof of the Zonklar Equations]
+% or
+%\appendix  % for no appendix heading
+% do not use \section anymore after \appendix, only \section*
+% is possibly needed
+
+% use appendices with more than one appendix
+% then use \section to start each appendix
+% you must declare a \section before using any
+% \subsection or using \label (\appendices by itself
+% starts a section numbered zero.)
+%
+
+
+\appendices
+\section{Proof of the First Zonklar Equation}
+Appendix one text goes here.
+
+% you can choose not to have a title for an appendix
+% if you want by leaving the argument blank
+\section{}
+Appendix two text goes here.
+
+
+% use section* for acknowledgement
+\section*{Acknowledgment}
+
+
+The authors would like to thank...
+
+
+% Can use something like this to put references on a page
+% by themselves when using endfloat and the captionsoff option.
+\ifCLASSOPTIONcaptionsoff
+  \newpage
+\fi
+
+
+
+% trigger a \newpage just before the given reference
+% number - used to balance the columns on the last page
+% adjust value as needed - may need to be readjusted if
+% the document is modified later
+%\IEEEtriggeratref{8}
+% The "triggered" command can be changed if desired:
+%\IEEEtriggercmd{\enlargethispage{-5in}}
+
+% references section
+
+% can use a bibliography generated by BibTeX as a .bbl file
+% BibTeX documentation can be easily obtained at:
+% http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/
+% The IEEEtran BibTeX style support page is at:
+% http://www.michaelshell.org/tex/ieeetran/bibtex/
+%\bibliographystyle{IEEEtran}
+% argument is your BibTeX string definitions and bibliography database(s)
+%\bibliography{IEEEabrv,../bib/paper}
+%
+% <OR> manually copy in the resultant .bbl file
+% set second argument of \begin to the number of references
+% (used to reserve space for the reference number labels box)
+\begin{thebibliography}{1}
+
+\bibitem{IEEEhowto:kopka}
+H.~Kopka and P.~W. Daly, \emph{A Guide to \LaTeX}, 3rd~ed.\hskip 1em plus
+  0.5em minus 0.4em\relax Harlow, England: Addison-Wesley, 1999.
+
+\end{thebibliography}
+
+% biography section
+% 
+% If you have an EPS/PDF photo (graphicx package needed) extra braces are
+% needed around the contents of the optional argument to biography to prevent
+% the LaTeX parser from getting confused when it sees the complicated
+% \includegraphics command within an optional argument. (You could create
+% your own custom macro containing the \includegraphics command to make things
+% simpler here.)
+%\begin{biography}[{\includegraphics[width=1in,height=1.25in,clip,keepaspectratio]{mshell}}]{Michael Shell}
+% or if you just want to reserve a space for a photo:
+
+\begin{IEEEbiography}{Michael Shell}
+Biography text here.
+\end{IEEEbiography}
+
+% if you will not have a photo at all:
+\begin{IEEEbiographynophoto}{John Doe}
+Biography text here.
+\end{IEEEbiographynophoto}
+
+% insert where needed to balance the two columns on the last page with
+% biographies
+%\newpage
+
+\begin{IEEEbiographynophoto}{Jane Doe}
+Biography text here.
+\end{IEEEbiographynophoto}
+
+% You can push biographies down or up by placing
+% a \vfill before or after them. The appropriate
+% use of \vfill depends on what kind of text is
+% on the last page and whether or not the columns
+% are being equalized.
+
+%\vfill
+
+% Can be used to pull up biographies so that the bottom of the last one
+% is flush with the other column.
+%\enlargethispage{-5in}
+
+
+
+% that's all folks
+\end{document}
+
+

--- a/ieee/bare_jrnl_compsoc.tex
+++ b/ieee/bare_jrnl_compsoc.tex
@@ -1,0 +1,844 @@
+
+%% bare_jrnl_compsoc.tex
+%% V1.3
+%% 2007/01/11
+%% by Michael Shell
+%% See:
+%% http://www.michaelshell.org/
+%% for current contact information.
+%%
+%% This is a skeleton file demonstrating the use of IEEEtran.cls
+%% (requires IEEEtran.cls version 1.7 or later) with an IEEE Computer
+%% Society journal paper.
+%%
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and
+%% http://www.ieee.org/
+
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE! 
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+%%                    bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+%%*************************************************************************
+
+% *** Authors should verify (and, if needed, correct) their LaTeX system  ***
+% *** with the testflow diagnostic prior to trusting their LaTeX platform ***
+% *** with production work. IEEE's font choices can trigger bugs that do  ***
+% *** not appear when using other class files.                            ***
+% The testflow support page is at:
+% http://www.michaelshell.org/tex/testflow/
+
+
+
+
+% Note that the a4paper option is mainly intended so that authors in
+% countries using A4 can easily print to A4 and see how their papers will
+% look in print - the typesetting of the document will not typically be
+% affected with changes in paper size (but the bottom and side margins will).
+% Use the testflow package mentioned above to verify correct handling of
+% both paper sizes by the user's LaTeX system.
+%
+% Also note that the "draftcls" or "draftclsnofoot", not "draft", option
+% should be used if it is desired that the figures are to be displayed in
+% draft mode.
+%
+% The Computer Society usually requires 12pt for submissions.
+%
+\documentclass[12pt,journal,compsoc]{IEEEtran}
+%
+% If IEEEtran.cls has not been installed into the LaTeX system files,
+% manually specify the path to it like:
+% \documentclass[12pt,journal,compsoc]{../sty/IEEEtran}
+
+
+
+
+
+% Some very useful LaTeX packages include:
+% (uncomment the ones you want to load)
+
+
+% *** MISC UTILITY PACKAGES ***
+%
+%\usepackage{ifpdf}
+% Heiko Oberdiek's ifpdf.sty is very useful if you need conditional
+% compilation based on whether the output is pdf or dvi.
+% usage:
+% \ifpdf
+%   % pdf code
+% \else
+%   % dvi code
+% \fi
+% The latest version of ifpdf.sty can be obtained from:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/oberdiek/
+% Also, note that IEEEtran.cls V1.7 and later provides a builtin
+% \ifCLASSINFOpdf conditional that works the same way.
+% When switching from latex to pdflatex and vice-versa, the compiler may
+% have to be run twice to clear warning/error messages.
+
+
+
+
+
+
+% *** CITATION PACKAGES ***
+%
+\ifCLASSOPTIONcompsoc
+  % IEEE Computer Society needs nocompress option
+  % requires cite.sty v4.0 or later (November 2003)
+  % \usepackage[nocompress]{cite}
+\else
+  % normal IEEE
+  % \usepackage{cite}
+\fi
+% cite.sty was written by Donald Arseneau
+% V1.6 and later of IEEEtran pre-defines the format of the cite.sty package
+% \cite{} output to follow that of IEEE. Loading the cite package will
+% result in citation numbers being automatically sorted and properly
+% "compressed/ranged". e.g., [1], [9], [2], [7], [5], [6] without using
+% cite.sty will become [1], [2], [5]--[7], [9] using cite.sty. cite.sty's
+% \cite will automatically add leading space, if needed. Use cite.sty's
+% noadjust option (cite.sty V3.8 and later) if you want to turn this off.
+% cite.sty is already installed on most LaTeX systems. Be sure and use
+% version 4.0 (2003-05-27) and later if using hyperref.sty. cite.sty does
+% not currently provide for hyperlinked citations.
+% The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/cite/
+% The documentation is contained in the cite.sty file itself.
+%
+% Note that some packages require special options to format as the Computer
+% Society requires. In particular, Computer Society  papers do not use
+% compressed citation ranges as is done in typical IEEE papers
+% (e.g., [1]-[4]). Instead, they list every citation separately in order
+% (e.g., [1], [2], [3], [4]). To get the latter we need to load the cite
+% package with the nocompress option which is supported by cite.sty v4.0
+% and later. Note also the use of a CLASSOPTION conditional provided by
+% IEEEtran.cls V1.7 and later.
+
+
+
+
+
+% *** GRAPHICS RELATED PACKAGES ***
+%
+\ifCLASSINFOpdf
+  % \usepackage[pdftex]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../pdf/}{../jpeg/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.pdf,.jpeg,.png}
+\else
+  % or other class option (dvipsone, dvipdf, if not using dvips). graphicx
+  % will default to the driver specified in the system graphics.cfg if no
+  % driver is specified.
+  % \usepackage[dvips]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../eps/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.eps}
+\fi
+% graphicx was written by David Carlisle and Sebastian Rahtz. It is
+% required if you want graphics, photos, etc. graphicx.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at: 
+% http://www.ctan.org/tex-archive/macros/latex/required/graphics/
+% Another good source of documentation is "Using Imported Graphics in
+% LaTeX2e" by Keith Reckdahl which can be found as epslatex.ps or
+% epslatex.pdf at: http://www.ctan.org/tex-archive/info/
+%
+% latex, and pdflatex in dvi mode, support graphics in encapsulated
+% postscript (.eps) format. pdflatex in pdf mode supports graphics
+% in .pdf, .jpeg, .png and .mps (metapost) formats. Users should ensure
+% that all non-photo figures use a vector format (.eps, .pdf, .mps) and
+% not a bitmapped formats (.jpeg, .png). IEEE frowns on bitmapped formats
+% which can result in "jaggedy"/blurry rendering of lines and letters as
+% well as large increases in file sizes.
+%
+% You can find documentation about the pdfTeX application at:
+% http://www.tug.org/applications/pdftex
+
+
+
+
+
+% *** MATH PACKAGES ***
+%
+%\usepackage[cmex10]{amsmath}
+% A popular package from the American Mathematical Society that provides
+% many useful and powerful commands for dealing with mathematics. If using
+% it, be sure to load this package with the cmex10 option to ensure that
+% only type 1 fonts will utilized at all point sizes. Without this option,
+% it is possible that some math symbols, particularly those within
+% footnotes, will be rendered in bitmap form which will result in a
+% document that can not be IEEE Xplore compliant!
+%
+% Also, note that the amsmath package sets \interdisplaylinepenalty to 10000
+% thus preventing page breaks from occurring within multiline equations. Use:
+%\interdisplaylinepenalty=2500
+% after loading amsmath to restore such page breaks as IEEEtran.cls normally
+% does. amsmath.sty is already installed on most LaTeX systems. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/amslatex/math/
+
+
+
+
+
+% *** SPECIALIZED LIST PACKAGES ***
+%
+%\usepackage{algorithmic}
+% algorithmic.sty was written by Peter Williams and Rogerio Brito.
+% This package provides an algorithmic environment fo describing algorithms.
+% You can use the algorithmic environment in-text or within a figure
+% environment to provide for a floating algorithm. Do NOT use the algorithm
+% floating environment provided by algorithm.sty (by the same authors) or
+% algorithm2e.sty (by Christophe Fiorio) as IEEE does not use dedicated
+% algorithm float types and packages that provide these will not provide
+% correct IEEE style captions. The latest version and documentation of
+% algorithmic.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithms/
+% There is also a support site at:
+% http://algorithms.berlios.de/index.html
+% Also of interest may be the (relatively newer and more customizable)
+% algorithmicx.sty package by Szasz Janos:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithmicx/
+
+
+
+
+% *** ALIGNMENT PACKAGES ***
+%
+%\usepackage{array}
+% Frank Mittelbach's and David Carlisle's array.sty patches and improves
+% the standard LaTeX2e array and tabular environments to provide better
+% appearance and additional user controls. As the default LaTeX2e table
+% generation code is lacking to the point of almost being broken with
+% respect to the quality of the end results, all users are strongly
+% advised to use an enhanced (at the very least that provided by array.sty)
+% set of table tools. array.sty is already installed on most systems. The
+% latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/tools/
+
+
+%\usepackage{mdwmath}
+%\usepackage{mdwtab}
+% Also highly recommended is Mark Wooding's extremely powerful MDW tools,
+% especially mdwmath.sty and mdwtab.sty which are used to format equations
+% and tables, respectively. The MDWtools set is already installed on most
+% LaTeX systems. The lastest version and documentation is available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/mdwtools/
+
+
+% IEEEtran contains the IEEEeqnarray family of commands that can be used to
+% generate multiline equations as well as matrices, tables, etc., of high
+% quality.
+
+
+%\usepackage{eqparbox}
+% Also of notable interest is Scott Pakin's eqparbox package for creating
+% (automatically sized) equal width boxes - aka "natural width parboxes".
+% Available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/eqparbox/
+
+
+
+
+
+% *** SUBFIGURE PACKAGES ***
+%\ifCLASSOPTIONcompsoc
+%\usepackage[tight,normalsize,sf,SF]{subfigure}
+%\else
+%\usepackage[tight,footnotesize]{subfigure}
+%\fi
+% subfigure.sty was written by Steven Douglas Cochran. This package makes it
+% easy to put subfigures in your figures. e.g., "Figure 1a and 1b". For IEEE
+% work, it is a good idea to load it with the tight package option to reduce
+% the amount of white space around the subfigures. Computer Society papers
+% use a larger font and \sffamily font for their captions, hence the
+% additional options needed under compsoc mode. subfigure.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/obsolete/macros/latex/contrib/subfigure/
+% subfigure.sty has been superceeded by subfig.sty.
+
+
+%\ifCLASSOPTIONcompsoc
+%  \usepackage[caption=false]{caption}
+%  \usepackage[font=normalsize,labelfont=sf,textfont=sf]{subfig}
+%\else
+%  \usepackage[caption=false]{caption}
+%  \usepackage[font=footnotesize]{subfig}
+%\fi
+% subfig.sty, also written by Steven Douglas Cochran, is the modern
+% replacement for subfigure.sty. However, subfig.sty requires and
+% automatically loads Axel Sommerfeldt's caption.sty which will override
+% IEEEtran.cls handling of captions and this will result in nonIEEE style
+% figure/table captions. To prevent this problem, be sure and preload
+% caption.sty with its "caption=false" package option. This is will preserve
+% IEEEtran.cls handing of captions. Version 1.3 (2005/06/28) and later 
+% (recommended due to many improvements over 1.2) of subfig.sty supports
+% the caption=false option directly:
+%\ifCLASSOPTIONcompsoc
+%  \usepackage[caption=false,font=normalsize,labelfont=sf,textfont=sf]{subfig}
+%\else
+%  \usepackage[caption=false,font=footnotesize]{subfig}
+%\fi
+%
+% The latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/subfig/
+% The latest version and documentation of caption.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/caption/
+
+
+
+
+% *** FLOAT PACKAGES ***
+%
+%\usepackage{fixltx2e}
+% fixltx2e, the successor to the earlier fix2col.sty, was written by
+% Frank Mittelbach and David Carlisle. This package corrects a few problems
+% in the LaTeX2e kernel, the most notable of which is that in current
+% LaTeX2e releases, the ordering of single and double column floats is not
+% guaranteed to be preserved. Thus, an unpatched LaTeX2e can allow a
+% single column figure to be placed prior to an earlier double column
+% figure. The latest version and documentation can be found at:
+% http://www.ctan.org/tex-archive/macros/latex/base/
+
+
+
+%\usepackage{stfloats}
+% stfloats.sty was written by Sigitas Tolusis. This package gives LaTeX2e
+% the ability to do double column floats at the bottom of the page as well
+% as the top. (e.g., "\begin{figure*}[!b]" is not normally possible in
+% LaTeX2e). It also provides a command:
+%\fnbelowfloat
+% to enable the placement of footnotes below bottom floats (the standard
+% LaTeX2e kernel puts them above bottom floats). This is an invasive package
+% which rewrites many portions of the LaTeX2e float routines. It may not work
+% with other packages that modify the LaTeX2e float routines. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/sttools/
+% Documentation is contained in the stfloats.sty comments as well as in the
+% presfull.pdf file. Do not use the stfloats baselinefloat ability as IEEE
+% does not allow \baselineskip to stretch. Authors submitting work to the
+% IEEE should note that IEEE rarely uses double column equations and
+% that authors should try to avoid such use. Do not be tempted to use the
+% cuted.sty or midfloat.sty packages (also by Sigitas Tolusis) as IEEE does
+% not format its papers in such ways.
+
+
+
+
+%\ifCLASSOPTIONcaptionsoff
+%  \usepackage[nomarkers]{endfloat}
+% \let\MYoriglatexcaption\caption
+% \renewcommand{\caption}[2][\relax]{\MYoriglatexcaption[#2]{#2}}
+%\fi
+% endfloat.sty was written by James Darrell McCauley and Jeff Goldberg.
+% This package may be useful when used in conjunction with IEEEtran.cls'
+% captionsoff option. Some IEEE journals/societies require that submissions
+% have lists of figures/tables at the end of the paper and that
+% figures/tables without any captions are placed on a page by themselves at
+% the end of the document. If needed, the draftcls IEEEtran class option or
+% \CLASSINPUTbaselinestretch interface can be used to increase the line
+% spacing as well. Be sure and use the nomarkers option of endfloat to
+% prevent endfloat from "marking" where the figures would have been placed
+% in the text. The two hack lines of code above are a slight modification of
+% that suggested by in the endfloat docs (section 8.3.1) to ensure that
+% the full captions always appear in the list of figures/tables - even if
+% the user used the short optional argument of \caption[]{}.
+% IEEE papers do not typically make use of \caption[]'s optional argument,
+% so this should not be an issue. A similar trick can be used to disable
+% captions of packages such as subfig.sty that lack options to turn off
+% the subcaptions:
+% For subfig.sty:
+% \let\MYorigsubfloat\subfloat
+% \renewcommand{\subfloat}[2][\relax]{\MYorigsubfloat[]{#2}}
+% For subfigure.sty:
+% \let\MYorigsubfigure\subfigure
+% \renewcommand{\subfigure}[2][\relax]{\MYorigsubfigure[]{#2}}
+% However, the above trick will not work if both optional arguments of
+% the \subfloat/subfig command are used. Furthermore, there needs to be a
+% description of each subfigure *somewhere* and endfloat does not add
+% subfigure captions to its list of figures. Thus, the best approach is to
+% avoid the use of subfigure captions (many IEEE journals avoid them anyway)
+% and instead reference/explain all the subfigures within the main caption.
+% The latest version of endfloat.sty and its documentation can obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/endfloat/
+%
+% The IEEEtran \ifCLASSOPTIONcaptionsoff conditional can also be used
+% later in the document, say, to conditionally put the References on a 
+% page by themselves.
+
+
+
+
+% *** PDF, URL AND HYPERLINK PACKAGES ***
+%
+%\usepackage{url}
+% url.sty was written by Donald Arseneau. It provides better support for
+% handling and breaking URLs. url.sty is already installed on most LaTeX
+% systems. The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/misc/
+% Read the url.sty source comments for usage information. Basically,
+% \url{my_url_here}.
+
+
+
+
+
+% *** Do not adjust lengths that control margins, column widths, etc. ***
+% *** Do not use packages that alter fonts (such as pslatex).         ***
+% There should be no need to do such things with IEEEtran.cls V1.6 and later.
+% (Unless specifically asked to do so by the journal or conference you plan
+% to submit to, of course. )
+
+
+% correct bad hyphenation here
+\hyphenation{op-tical net-works semi-conduc-tor}
+
+
+\begin{document}
+%
+% paper title
+% can use linebreaks \\ within to get better formatting as desired
+\title{Bare Demo of IEEEtran.cls\\ for Computer Society Journals}
+%
+%
+% author names and IEEE memberships
+% note positions of commas and nonbreaking spaces ( ~ ) LaTeX will not break
+% a structure at a ~ so this keeps an author's name from being broken across
+% two lines.
+% use \thanks{} to gain access to the first footnote area
+% a separate \thanks must be used for each paragraph as LaTeX2e's \thanks
+% was not built to handle multiple paragraphs
+%
+%
+%\IEEEcompsocitemizethanks is a special \thanks that produces the bulleted
+% lists the Computer Society journals use for "first footnote" author
+% affiliations. Use \IEEEcompsocthanksitem which works much like \item
+% for each affiliation group. When not in compsoc mode,
+% \IEEEcompsocitemizethanks becomes like \thanks and
+% \IEEEcompsocthanksitem becomes a line break with idention. This
+% facilitates dual compilation, although admittedly the differences in the
+% desired content of \author between the different types of papers makes a
+% one-size-fits-all approach a daunting prospect. For instance, compsoc 
+% journal papers have the author affiliations above the "Manuscript
+% received ..."  text while in non-compsoc journals this is reversed. Sigh.
+
+\author{Michael~Shell,~\IEEEmembership{Member,~IEEE,}
+        John~Doe,~\IEEEmembership{Fellow,~OSA,}
+        and~Jane~Doe,~\IEEEmembership{Life~Fellow,~IEEE}% <-this % stops a space
+\IEEEcompsocitemizethanks{\IEEEcompsocthanksitem M. Shell is with the Department
+of Electrical and Computer Engineering, Georgia Institute of Technology, Atlanta,
+GA, 30332.\protect\\
+% note need leading \protect in front of \\ to get a newline within \thanks as
+% \\ is fragile and will error, could use \hfil\break instead.
+E-mail: see http://www.michaelshell.org/contact.html
+\IEEEcompsocthanksitem J. Doe and J. Doe are with Anonymous University.}% <-this % stops a space
+\thanks{Manuscript received April 19, 2005; revised January 11, 2007.}}
+
+% note the % following the last \IEEEmembership and also \thanks - 
+% these prevent an unwanted space from occurring between the last author name
+% and the end of the author line. i.e., if you had this:
+% 
+% \author{....lastname \thanks{...} \thanks{...} }
+%                     ^------------^------------^----Do not want these spaces!
+%
+% a space would be appended to the last name and could cause every name on that
+% line to be shifted left slightly. This is one of those "LaTeX things". For
+% instance, "\textbf{A} \textbf{B}" will typeset as "A B" not "AB". To get
+% "AB" then you have to do: "\textbf{A}\textbf{B}"
+% \thanks is no different in this regard, so shield the last } of each \thanks
+% that ends a line with a % and do not let a space in before the next \thanks.
+% Spaces after \IEEEmembership other than the last one are OK (and needed) as
+% you are supposed to have spaces between the names. For what it is worth,
+% this is a minor point as most people would not even notice if the said evil
+% space somehow managed to creep in.
+
+
+
+% The paper headers
+\markboth{Journal of \LaTeX\ Class Files,~Vol.~6, No.~1, January~2007}%
+{Shell \MakeLowercase{\textit{et al.}}: Bare Demo of IEEEtran.cls for Computer Society Journals}
+% The only time the second header will appear is for the odd numbered pages
+% after the title page when using the twoside option.
+% 
+% *** Note that you probably will NOT want to include the author's ***
+% *** name in the headers of peer review papers.                   ***
+% You can use \ifCLASSOPTIONpeerreview for conditional compilation here if
+% you desire.
+
+
+
+% The publisher's ID mark at the bottom of the page is less important with
+% Computer Society journal papers as those publications place the marks
+% outside of the main text columns and, therefore, unlike regular IEEE
+% journals, the available text space is not reduced by their presence.
+% If you want to put a publisher's ID mark on the page you can do it like
+% this:
+%\IEEEpubid{0000--0000/00\$00.00~\copyright~2007 IEEE}
+% or like this to get the Computer Society new two part style.
+%\IEEEpubid{\makebox[\columnwidth]{\hfill 0000--0000/00/\$00.00~\copyright~2007 IEEE}%
+%\hspace{\columnsep}\makebox[\columnwidth]{Published by the IEEE Computer Society\hfill}}
+% Remember, if you use this you must call \IEEEpubidadjcol in the second
+% column for its text to clear the IEEEpubid mark (Computer Society jorunal
+% papers don't need this extra clearance.)
+
+
+
+% use for special paper notices
+%\IEEEspecialpapernotice{(Invited Paper)}
+
+
+
+% for Computer Society papers, we must declare the abstract and index terms
+% PRIOR to the title within the \IEEEcompsoctitleabstractindextext IEEEtran
+% command as these need to go into the title area created by \maketitle.
+\IEEEcompsoctitleabstractindextext{%
+\begin{abstract}
+%\boldmath
+The abstract goes here.
+\end{abstract}
+% IEEEtran.cls defaults to using nonbold math in the Abstract.
+% This preserves the distinction between vectors and scalars. However,
+% if the journal you are submitting to favors bold math in the abstract,
+% then you can use LaTeX's standard command \boldmath at the very start
+% of the abstract to achieve this. Many IEEE journals frown on math
+% in the abstract anyway. In particular, the Computer Society does
+% not want either math or citations to appear in the abstract.
+
+% Note that keywords are not normally used for peerreview papers.
+\begin{IEEEkeywords}
+Computer Society, IEEEtran, journal, \LaTeX, paper, template.
+\end{IEEEkeywords}}
+
+
+% make the title area
+\maketitle
+
+
+% To allow for easy dual compilation without having to reenter the
+% abstract/keywords data, the \IEEEcompsoctitleabstractindextext text will
+% not be used in maketitle, but will appear (i.e., to be "transported")
+% here as \IEEEdisplaynotcompsoctitleabstractindextext when compsoc mode
+% is not selected <OR> if conference mode is selected - because compsoc
+% conference papers position the abstract like regular (non-compsoc)
+% papers do!
+\IEEEdisplaynotcompsoctitleabstractindextext
+% \IEEEdisplaynotcompsoctitleabstractindextext has no effect when using
+% compsoc under a non-conference mode.
+
+
+% For peer review papers, you can put extra information on the cover
+% page as needed:
+% \ifCLASSOPTIONpeerreview
+% \begin{center} \bfseries EDICS Category: 3-BBND \end{center}
+% \fi
+%
+% For peerreview papers, this IEEEtran command inserts a page break and
+% creates the second title. It will be ignored for other modes.
+\IEEEpeerreviewmaketitle
+
+
+
+\section{Introduction}
+% Computer Society journal papers do something a tad strange with the very
+% first section heading (almost always called "Introduction"). They place it
+% ABOVE the main text! IEEEtran.cls currently does not do this for you.
+% However, You can achieve this effect by making LaTeX jump through some
+% hoops via something like:
+%
+%\ifCLASSOPTIONcompsoc
+%  \noindent\raisebox{2\baselineskip}[0pt][0pt]%
+%  {\parbox{\columnwidth}{\section{Introduction}\label{sec:introduction}%
+%  \global\everypar=\everypar}}%
+%  \vspace{-1\baselineskip}\vspace{-\parskip}\par
+%\else
+%  \section{Introduction}\label{sec:introduction}\par
+%\fi
+%
+% Admittedly, this is a hack and may well be fragile, but seems to do the
+% trick for me. Note the need to keep any \label that may be used right
+% after \section in the above as the hack puts \section within a raised box.
+
+
+
+% The very first letter is a 2 line initial drop letter followed
+% by the rest of the first word in caps (small caps for compsoc).
+% 
+% form to use if the first word consists of a single letter:
+% \IEEEPARstart{A}{demo} file is ....
+% 
+% form to use if you need the single drop letter followed by
+% normal text (unknown if ever used by IEEE):
+% \IEEEPARstart{A}{}demo file is ....
+% 
+% Some journals put the first two words in caps:
+% \IEEEPARstart{T}{his demo} file is ....
+% 
+% Here we have the typical use of a "T" for an initial drop letter
+% and "HIS" in caps to complete the first word.
+\IEEEPARstart{T}{his} demo file is intended to serve as a ``starter file''
+for IEEE Computer Society journal papers produced under \LaTeX\ using
+IEEEtran.cls version 1.7 and later.
+% You must have at least 2 lines in the paragraph with the drop letter
+% (should never be an issue)
+I wish you the best of success.
+
+\hfill mds
+ 
+\hfill January 11, 2007
+
+\subsection{Subsection Heading Here}
+Subsection text here.
+
+% needed in second column of first page if using \IEEEpubid
+%\IEEEpubidadjcol
+
+\subsubsection{Subsubsection Heading Here}
+Subsubsection text here.
+
+
+% An example of a floating figure using the graphicx package.
+% Note that \label must occur AFTER (or within) \caption.
+% For figures, \caption should occur after the \includegraphics.
+% Note that IEEEtran v1.7 and later has special internal code that
+% is designed to preserve the operation of \label within \caption
+% even when the captionsoff option is in effect. However, because
+% of issues like this, it may be the safest practice to put all your
+% \label just after \caption rather than within \caption{}.
+%
+% Reminder: the "draftcls" or "draftclsnofoot", not "draft", class
+% option should be used if it is desired that the figures are to be
+% displayed while in draft mode.
+%
+%\begin{figure}[!t]
+%\centering
+%\includegraphics[width=2.5in]{myfigure}
+% where an .eps filename suffix will be assumed under latex, 
+% and a .pdf suffix will be assumed for pdflatex; or what has been declared
+% via \DeclareGraphicsExtensions.
+%\caption{Simulation Results}
+%\label{fig_sim}
+%\end{figure}
+
+% Note that IEEE typically puts floats only at the top, even when this
+% results in a large percentage of a column being occupied by floats.
+% However, the Computer Society has been known to put floats at the bottom.
+
+
+% An example of a double column floating figure using two subfigures.
+% (The subfig.sty package must be loaded for this to work.)
+% The subfigure \label commands are set within each subfloat command, the
+% \label for the overall figure must come after \caption.
+% \hfil must be used as a separator to get equal spacing.
+% The subfigure.sty package works much the same way, except \subfigure is
+% used instead of \subfloat.
+%
+%\begin{figure*}[!t]
+%\centerline{\subfloat[Case I]\includegraphics[width=2.5in]{subfigcase1}%
+%\label{fig_first_case}}
+%\hfil
+%\subfloat[Case II]{\includegraphics[width=2.5in]{subfigcase2}%
+%\label{fig_second_case}}}
+%\caption{Simulation results}
+%\label{fig_sim}
+%\end{figure*}
+%
+% Note that often IEEE papers with subfigures do not employ subfigure
+% captions (using the optional argument to \subfloat), but instead will
+% reference/describe all of them (a), (b), etc., within the main caption.
+
+
+% An example of a floating table. Note that, for IEEE style tables, the 
+% \caption command should come BEFORE the table. Table text will default to
+% \footnotesize as IEEE normally uses this smaller font for tables.
+% The \label must come after \caption as always.
+%
+%\begin{table}[!t]
+%% increase table row spacing, adjust to taste
+%\renewcommand{\arraystretch}{1.3}
+% if using array.sty, it might be a good idea to tweak the value of
+% \extrarowheight as needed to properly center the text within the cells
+%\caption{An Example of a Table}
+%\label{table_example}
+%\centering
+%% Some packages, such as MDW tools, offer better commands for making tables
+%% than the plain LaTeX2e tabular which is used here.
+%\begin{tabular}{|c||c|}
+%\hline
+%One & Two\\
+%\hline
+%Three & Four\\
+%\hline
+%\end{tabular}
+%\end{table}
+
+
+% Note that IEEE does not put floats in the very first column - or typically
+% anywhere on the first page for that matter. Also, in-text middle ("here")
+% positioning is not used. Most IEEE journals use top floats exclusively.
+% However, Computer Society journals sometimes do use bottom floats - bear
+% this in mind when choosing appropriate optional arguments for the
+% figure/table environments.
+% Note that, LaTeX2e, unlike IEEE journals, places footnotes above bottom
+% floats. This can be corrected via the \fnbelowfloat command of the
+% stfloats package.
+
+
+
+\section{Conclusion}
+The conclusion goes here.
+
+
+
+
+
+% if have a single appendix:
+%\appendix[Proof of the Zonklar Equations]
+% or
+%\appendix  % for no appendix heading
+% do not use \section anymore after \appendix, only \section*
+% is possibly needed
+
+% use appendices with more than one appendix
+% then use \section to start each appendix
+% you must declare a \section before using any
+% \subsection or using \label (\appendices by itself
+% starts a section numbered zero.)
+%
+
+
+\appendices
+\section{Proof of the First Zonklar Equation}
+Appendix one text goes here.
+
+% you can choose not to have a title for an appendix
+% if you want by leaving the argument blank
+\section{}
+Appendix two text goes here.
+
+
+% use section* for acknowledgement
+\ifCLASSOPTIONcompsoc
+  % The Computer Society usually uses the plural form
+  \section*{Acknowledgments}
+\else
+  % regular IEEE prefers the singular form
+  \section*{Acknowledgment}
+\fi
+
+
+The authors would like to thank...
+
+
+% Can use something like this to put references on a page
+% by themselves when using endfloat and the captionsoff option.
+\ifCLASSOPTIONcaptionsoff
+  \newpage
+\fi
+
+
+
+% trigger a \newpage just before the given reference
+% number - used to balance the columns on the last page
+% adjust value as needed - may need to be readjusted if
+% the document is modified later
+%\IEEEtriggeratref{8}
+% The "triggered" command can be changed if desired:
+%\IEEEtriggercmd{\enlargethispage{-5in}}
+
+% references section
+
+% can use a bibliography generated by BibTeX as a .bbl file
+% BibTeX documentation can be easily obtained at:
+% http://www.ctan.org/tex-archive/biblio/bibtex/contrib/doc/
+% The IEEEtran BibTeX style support page is at:
+% http://www.michaelshell.org/tex/ieeetran/bibtex/
+%\bibliographystyle{IEEEtran}
+% argument is your BibTeX string definitions and bibliography database(s)
+%\bibliography{IEEEabrv,../bib/paper}
+%
+% <OR> manually copy in the resultant .bbl file
+% set second argument of \begin to the number of references
+% (used to reserve space for the reference number labels box)
+\begin{thebibliography}{1}
+
+\bibitem{IEEEhowto:kopka}
+H.~Kopka and P.~W. Daly, \emph{A Guide to \LaTeX}, 3rd~ed.\hskip 1em plus
+  0.5em minus 0.4em\relax Harlow, England: Addison-Wesley, 1999.
+
+\end{thebibliography}
+
+% biography section
+% 
+% If you have an EPS/PDF photo (graphicx package needed) extra braces are
+% needed around the contents of the optional argument to biography to prevent
+% the LaTeX parser from getting confused when it sees the complicated
+% \includegraphics command within an optional argument. (You could create
+% your own custom macro containing the \includegraphics command to make things
+% simpler here.)
+%\begin{biography}[{\includegraphics[width=1in,height=1.25in,clip,keepaspectratio]{mshell}}]{Michael Shell}
+% or if you just want to reserve a space for a photo:
+
+\begin{IEEEbiography}{Michael Shell}
+Biography text here.
+\end{IEEEbiography}
+
+% if you will not have a photo at all:
+\begin{IEEEbiographynophoto}{John Doe}
+Biography text here.
+\end{IEEEbiographynophoto}
+
+% insert where needed to balance the two columns on the last page with
+% biographies
+%\newpage
+
+\begin{IEEEbiographynophoto}{Jane Doe}
+Biography text here.
+\end{IEEEbiographynophoto}
+
+% You can push biographies down or up by placing
+% a \vfill before or after them. The appropriate
+% use of \vfill depends on what kind of text is
+% on the last page and whether or not the columns
+% are being equalized.
+
+%\vfill
+
+% Can be used to pull up biographies so that the bottom of the last one
+% is flush with the other column.
+%\enlargethispage{-5in}
+
+
+
+% that's all folks
+\end{document}
+
+

--- a/ieee/changelog.txt
+++ b/ieee/changelog.txt
@@ -1,0 +1,762 @@
+
+
+ Changelog history of the IEEEtran LaTeX class.
+ 
+
+ v1.8 -- 2012/11/21
+ by Harald Hanche-Olsen and Anders Christensen (IEEE Computational Intelligence Society)
+
+*******
+11/2012 v1.8 changes:
+
+1335c1335
+<                 \itemindent 0em%
+---
+>                 \itemindent 0.3em%
+1386c1386
+<                 \itemindent 0em%
+---
+>                 \itemindent .3em%
+1436c1436
+<                 \itemindent 0em%
+---
+>                 \itemindent .3em%
+1524c1524
+< \def\unnumberedfootnote{\gdef\@thefnmark{}\@footnotetext}
+---
+> \def\unnumberedfootnote{\gdef\@thefnmark{\quad}\@footnotetext}
+1526c1526
+< \skip\@mpfootins = \skip\footins
+---
+> \skip\@mpfootins 0.3\baselineskip
+1531a1532
+> %\long\def\@makefnmark{\scriptsize\normalfont\@thefnmark}
+1541c1542
+< \def\footnoterule{\vskip-2pt \hrule height 0.4pt depth \z@ \vskip1.6pt\relax}
+---
+> \def\footnoterule{\vskip-2pt \hrule height 0.6pt depth \z@ \vskip1.6pt\relax}
+1652c1653
+< \def\figurename{Figure}
+---
+> \def\figurename{Fig.}
+1740c1741
+< \setlength\abovecaptionskip{0.25\baselineskip}
+---
+> \setlength\abovecaptionskip{0.65\baselineskip}
+1799c1800
+< \footnotesize{\centering\normalfont\footnotesize#1.\quad\scshape #2\par}%
+---
+> \footnotesize{\centering\normalfont\footnotesize#1.\qquad\scshape #2\par}%
+1812c1813
+< \ifCLASSOPTIONconference \hbox to\hsize{\normalfont\footnotesize\hfil\box\@tempboxa\hfil}%
+---
+> \ifCLASSOPTIONconference \hbox to\hsize{\normalfont\footnotesize\box\@tempboxa\hfil}%
+1856c1857
+< \def\table{\def\@floatboxreset{\reset@font\footnotesize\@setminipage}%
+---
+> \def\table{\def\@floatboxreset{\reset@font\scriptsize\@setminipage}%
+1861c1862
+< \@namedef{table*}{\def\@floatboxreset{\reset@font\footnotesize\@setminipage}\@dblfloat{table}}
+---
+> \@namedef{table*}{\def\@floatboxreset{\reset@font\scriptsize\@setminipage}\@dblfloat{table}}
+3747c3748
+< \def\endIEEEkeywords{\relax\ifCLASSOPTIONtechnote\vspace{1.34ex}\else\vspace{1.67ex}\fi
+---
+> \def\endIEEEkeywords{\relax\ifCLASSOPTIONtechnote\vspace{1.34ex}\else\vspace{0.5ex}\fi
+3826,3827c3827,3829
+< 
+< \def\@seccntformat#1{\csname the#1dis\endcsname\hskip 1em\relax}
+---
+> \def\@seccntformat#1{\hb@xt@ 1.4em{\csname the#1dis\endcsname\hss\relax}}
+> \def\@seccntformatinl#1{\hb@xt@ 1.1em{\csname the#1dis\endcsname\hss\relax}}
+> \def\@seccntformatch#1{\csname the#1dis\endcsname\hskip 1em\relax}
+3843c3845,3853
+<      \protected@edef\@svsec{\@seccntformat{#1}\relax}%
+---
+>      \ifnum #2=1
+>         \protected@edef\@svsec{\@seccntformatch{#1}\relax}%
+>      \else
+>         \ifnum #2>2
+>            \protected@edef\@svsec{\@seccntformatinl{#1}\relax}%
+>         \else
+>            \protected@edef\@svsec{\@seccntformat{#1}\relax}%
+>         \fi
+>      \fi
+
+
+
+
+
+
+*****************************************
+
+2007/03/05
+ by Michael Shell (MDS)
+ http://www.michaelshell.org/
+
+*******
+ 3/2007 V1.7a (MDS) changes:
+
+ 1) Corrected problem of unwanted two column peer review title page format.
+    Thanks to Virgilio Rodriguez for reporting this bug.
+
+ 2) "depreciated" -> "deprecated". Thanks to Virgilio Rodriguez for
+    suggesting this change.
+
+*******
+ 1/2007 V1.7 (MDS) changes:
+
+ 1) New class option compsoc to support the IEEE Computer Society format.
+
+ 2) New class option captionsoff disables the display of figure/table
+    captions. endfloat.sty is now mentioned in the docs. Thanks to Geoff
+    Walker for suggesting these changes.
+
+ 3) Fixed compatibility issues with subfig.sty and caption.sty. Thanks to
+    Steven Douglas Cochran and Axel Sommerfeldt for suggesting this change.
+
+ 4) New \CLASSINPUT, \CLASSOPTION and \CLASSINFO interface allows for more
+    user control and conditional compilation.
+
+ 5) \ifcenterfigcaptions (\centerfigcaptionstrue, \centerfigcaptionsfalse),
+    \CMPARstart and \overrideIEEEmargins have been removed and no are
+    longer supported. The effect of \overrideIEEEmargins can be mimicked
+    via the more general \CLASSINPUT interface:
+    % US letter paper:
+    \newcommand{\CLASSINPUTinnersidemargin}{0.775in}
+    \newcommand{\CLASSINPUToutersidemargin}{0.585in}
+    % A4 paper:
+    \newcommand{\CLASSINPUTinnersidemargin}{17mm}
+    \newcommand{\CLASSINPUToutersidemargin}{11.647mm}
+
+ 6) Several commands and environments have been deprecated in favor of
+    replacements with IEEE prefixes to better avoid potential future name
+    clashes with other packages. Legacy code retained to allow the use of
+    the obsolete forms (for now), but with a warning message to the console
+    during compilation:
+    \IEEEauthorblockA, \IEEEauthorblockN, \IEEEauthorrefmark,
+    \IEEEbiography, \IEEEbiographynophoto, \IEEEkeywords, \IEEEPARstart,
+    \IEEEproof, \IEEEpubid, \IEEEpubidadjcol, \IEEEQED, \IEEEQEDclosed,
+    \IEEEQEDopen, \IEEEspecialpapernotice. IEEEtran.cls now redefines
+    \proof in way to avoid problems with the amsthm.sty package.
+    For IED lists:
+    \IEEEiedlabeljustifyc, \IEEEiedlabeljustifyl, \IEEEiedlabeljustifyr,
+    \IEEEnocalcleftmargin, \IEEElabelindent, \IEEEsetlabelwidth,
+    \IEEEusemathlabelsep
+
+ 7) These commands/lengths now require the IEEE prefix and do not have
+    legacy support: \IEEEnormaljot.
+    For IED lists: \ifIEEEnocalcleftmargin, \ifIEEEnolabelindentfactor,
+    \IEEEiedlistdecl, \IEEElabelindentfactor
+
+ 8) \normalsizebaselineskip skip replaced by
+    \CLASSINFOnormalsizebaselineskip (nonrubber dimen) length.
+    Also, new \CLASSINFOnormalsizeunitybaselineskip (nonrubber dimen)
+    provided.
+
+ 9) Now defaults to using Alpha numbering rather than Roman for appendices
+    numbering. This is because Alpha numbering is more common and avoids
+    problems with theorem numbering. \ifuseRomanappendices
+    (\useRomanappendicestrue, \useRomanappendicesfalse) is no longer
+    supported. Instead, use the new class option romanappendices if Roman
+    appendices numbering is desired. Thanks to Leonid Mirkin for reporting
+    the problem with theorems in appendices and suggesting changes.
+
+10) Improved paper size setting code for pdflatex.
+
+11) Better handling of theorem numbering when using the section counter
+    within the appendix(cies). Thanks to Leonid Mirkin for suggesting
+    this change.
+
+12) Fixed bug that caused equations at the end of theorems to be too
+    close to the line below them.
+
+13) Provided hook to conference mode console notice and changed notice to
+    better support conferences that use A4 paper. Thanks to Volker Kuhlmann
+    for suggesting this change.
+
+14) \IEEEauthorrefmark made robust to allow it to be used in \thanks
+    without a leading \protect
+
+15) Improved \textunderscore to provide a much better fake _ when used with
+    OT1 encoding. Under OT1, detect use of pcr or cmtt \ttfamily and use
+    available true _ glyph for those two typewriter fonts.
+
+16) Revised internal \@sect command to be more robust for users who employ
+    modified section heading formats. Thanks to Zarko F. Cucej for
+    suggesting this change.
+
+17) Improved \thesubsubsection definition to prevent breaks at the hyphen.
+    Thanks to Moritz Borgmann for suggesting this change. Thanks to
+    Dan Luecking and Heiko Oberdiek for explaining some of the various
+    alternatives and techniques to fix it.
+
+18) No longer provide \NAT@parse hack to get cite.sty to play (somewhat)
+    with hyperref.sty as this is already included in cite.sty version
+    4.0 (2003-05-27) and later.
+
+19) At the beginning of document, set the default style of url.sty to be
+    the same as the current text font - as is done in IEEE journals.
+
+20) Corrected excessive line spacing in journal table captions. Thanks to
+    Moritz Borgmann for suggesting this change.
+
+21) Corrected \thesubsubsection to use the "I-A1" format IEEE uses rather
+    than "I-A.1" as was done before. Ditto for \theparagraph. Thanks to
+    Moritz Borgmann for suggesting this change.
+
+22) Enclose papersize specials within \AtBeginDvi in case someone wants
+    to make a format with IEEEtran. Thanks to Moritz Borgmann for
+    suggesting this change.
+
+23) Eliminated the small space after abstract and keywords dash as IEEE
+    now does. Thanks to Moritz Borgmann for suggesting this change.
+
+24) IEEEkeywords is no longer locked out in conference mode
+
+25) Increase defaults of \binoppenalty and \relpenalty to discourage
+    breaks within equations. Thanks to Moritz Borgmann for suggesting
+    this change.
+
+26) Support optional argument for IEEEproof. Thanks to Ingo Steinwart for
+    suggesting this change. Also, start a new \par with \IEEEproof.
+
+27) Add support for an optional argument to \bstctlcite.
+
+28) Changed \topfraction and \dbltopfraction from 1.0 to 0.9. Thanks to
+    Donald Arseneau for suggesting this change.
+
+
+*******
+ 09/2005 V1.6c (MDS) changes:
+
+ 1) Changed endfigure/endfloat definitions so as not to cause problems with
+    preview-LaTeX and other packages. Thanks to Stephan Heuel and David
+    Kastrup for reporting this problem.
+
+
+
+*******
+ 11/2002 V1.6b (MDS) changes:
+
+ 1) Fixed problem with figure captions when using hyperref. Thanks to 
+    Leandro Barajas and Michael Bassetti for reporting this bug.
+
+ 2) Provide a fake nabib command \NAT@parse so that hyperref will not
+    interfere with the operation of cite.sty. However, as a result citation
+    numbers will not be hyperlinked. Also, natbib will not be able to work
+    with IEEEtran. However, this is perhaps the best solution until
+    cite.sty and hyperref.sty are able to co-exist with each other.
+    It easy enough to override the fake command via:
+    \makeatletter
+    \let\NAT@parse\undefined
+    \makeatother
+
+ 3) Revised font selection method so as not to have problems when used
+    with setspace.sty. Thanks to Zhang Yan for reporting this bug.
+
+ 4) Added \special to feed papersize to dvips. Thanks to Moritz Borgmann 
+    for suggesting this feature.
+
+ 5) In addition to the IEEE IED lists, the original IED style list
+    environments (as is done in article.cls) are now provided as
+    LaTeXitemize, LaTeXenumerate, and LaTeXdescription. Also, users can
+    now redefine \makelabel within IEEE IED list controls. There may be
+    some use for this in specialized applications. Thanks to Eli Barzilay
+    for suggesting this feature.
+
+ 6) \table* now defaults to \footnotesize text like \table.
+
+ 7) The draft modes now no longer force a pagebreak after the title.
+    Thanks to Christian Peel for suggesting this change.
+
+ 8) New draftclsnofoot mode is like draftcls, but does not display the
+    date and the word "DRAFT" at the foot of the page. Thanks to
+    Christian Peel for suggesting this feature.
+
+ 9) New peerreview and peerreviewca modes with \IEEEpeerreviewmaketitle
+    command allows for a "cover" titlepage for anonymous peer review.
+    Except for the cover titlepage, peerreview is much like journal mode.
+    peerreviewca is like peerreview, but allows the author names to be
+    entered and formatted as under conference mode so that author
+    affiliations and contact information can be easily seen on the cover
+    page. Thanks to Eric Benedict for suggesting this feature.
+
+
+
+*******
+ 7/2002 V1.6 (MDS) changes:
+ 
+ 1) Added conference mode via conference option. Defaults to the
+    traditional journal mode. e.g., \documentclass[conference]{IEEEtran}
+ 
+ 2) Added support for A4 paper via new a4paper option. Pdflatex's paper
+    size lengths are now automatically set to the proper paper size being
+    used.
+ 
+ 3) Revised margins again. Page text is now horizontally centered.
+    Conference mode increases the top and bottom margins with the bottom
+    margin being slightly larger. For A4 paper, the top margin and text
+    typesetting will not change from those of US letter paper, but the side
+    margins will be smaller and the bottom margin will be larger than that
+    of US letter. All per IEEE specs.
+
+ 4) Fixed footnote line spacing anomaly in draft mode. 
+    Thanks to Alberto Rodriguez for reporting this bug.
+    
+    Also, slightly revised footnote and \thanks note spacing.
+    Set \interfootnotelinepenalty=10000 to prevent LaTeX
+    from breaking footnotes across multiple pages or columns.
+
+ 5) Fixed bug that caused overwritten photo areas and sometimes anomalous
+    spacing when a new paragraph was started within a biography. Also,
+    the presence of \par's, new lines or spaces at the beginning of
+    abstract, keywords, biography, or biographynophoto will no longer
+    affect the first word spacing.
+    Thanks to Eric Durant for reporting this bug.
+    
+    The biography environment now does a better job in preventing
+    a biography photo area from being broken across pages or columns.
+
+ 6) Fixed whitespace between \cite entries bug. i.e.,
+    both \cite{einstein24, knuth84} and \cite{einstein24,knuth84}
+    are now valid. \cite is now a robust command as it should be.
+    IEEEtran now no longer defines the old non-standard \shortcite or 
+    \citename.
+    
+    The base IEEEtran.cls does not sort citation numbers or produce ranges
+    for three or more consecutive numbers. However, V1.6 of IEEEtran.cls 
+    now pre-defines the following format control macros to facilitate easy
+    use with Donald Arseneau's cite.sty package (tested with cite.sty V3.9):  
+
+    \def\citepunct{], [}
+    \def\citedash{]--[}
+    
+    cite.sty is standard on most LaTeX sytems and can be obtained from
+    www.ctan.org. Thanks to Donald Arseneau for creating cite.sty,
+    providing the required format arguments to produce the IEEE style
+    and designing a cite interface capable of handling the IEEE citation
+    style.
+    
+    Note: Historically, IEEE has wanted authors to "hardcode" symbolics.
+    (i.e., replace all \cite{} with fixed [x]). However, it now seems that
+    most electronic manuscript submissions to IEEE are in .pdf format, and 
+    as such, do not require the LaTeX document reference numbers to be hard
+    coded. If an author is required to submit actual LaTeX files, I do
+    recommend that the bibliography file (.bbl) be copied into the .tex
+    document and the \bibliographystyle{} and \bibliography{} commands be
+    commented out so that the .tex file does not depend on (potentially
+    lengthy and/or confidential) external bibliography database files
+
+ 7) Adjusted some spacing parameters. The spacing above and below equations
+    has been revised (to a typical IEEE value). \jot now has a decent value.
+    The title text is now exactly 24pt. (On a related note, \fontsubfuzz has
+    been increased to 0.9pt to prevent annoying font substitution warnings
+    when using the Computer Modern fonts that use the 24.88pt size.)
+    In V1.6, \small is now 8.5pt in 9pt docs because \footnotesize is 8pt.
+    For 9pt docs, you should probably go ahead and use \footnotesize when
+    you need text a little smaller than \normalsize.
+    The interword spacing has been adjusted to be extremely close to that
+    which IEEE uses. You can use a new class option, nofonttune, if you need
+    to disable the adjusting of the interword spacing. This adjustment and
+    an increase to \hyphenpenalty have greatly reduced the amount of
+    hyphenation in a typical paper.
+       The baselineskip for the normalsize fonts has been tweaked to reduce
+    underfull vboxes on journal paper columns with only paragraphs. 
+    Conference mode does the same thing but by also tweaking the \textheight
+    slightly off 9.25in (IEEE spec) to ensure an integer number of lines per
+    page. Draft (also draftcls) mode has also been revised to reduce
+    underfull vbox warnings. However, draft mode can still produce underfull
+    vboxes (a direct result of the increase in line spacing and margins) if:
+    A non-normalsize font occupies an entire column (abstract and index
+    terms take up a whole column by themselves); or the beginning of a
+    section occurs near the end of a column and cannot be squeezed into the
+    bottom, etc. This is normal as draft mode's liberal spacings cannot
+    guarantee perfect formatting.
+
+ 8) New biographynophoto environment for biographies without photos.
+    Usage: 
+    
+    \begin{biographynophoto}{author name}
+    biography text here 
+    \end{biographynophoto}
+    
+ 9) Fixed bug that produced multiple table of contents entries for papers
+    with more than one biography. Also, biography now works better with
+    hyperref.
+ 
+10) New \sublargesize font size command provides for 11pt text in a 10pt
+    document. (Needed for things like author names.) For documents not
+    using 10pt normal size text, \sublargesize is currently identical 
+    to \large.
+
+11) New \IEEEmembership command to provide correct font to indicate IEEE
+    membership for journal papers.
+
+12) Fixed author name line overflow problem when in journal mode. This
+    problem had been introduced in V1.5 in my rush to get \and to work for
+    conferences. \and is unneeded (and invalid) in journal mode. For 
+    conference mode, \and will work as expected and features an optional
+    spacing argument. i.e., \and[\hspace{5ex}] 
+    \and will default (recommended) to using \hfill which will result in
+    equal spacing between author blocks.
+ 
+13) New \authorblockN, \authorblockA and \authorrefmark commands to 
+    facilitate easy formatting of author names, affiliations and cross
+    reference symbols, respectively, when in conference mode. These 
+    three commands are to be used only for conference papers.
+    In conference mode, \author text is placed within a modified tabular
+    environment (somewhat like article.cls). So, within \author in
+    conference mode, you should not try to enclose multiple \\ within an
+    environment or command (other than the argument braces of
+    \authorblockX{}). For example:
+    
+    \author{\authorblockN{{John Doe \\ Jane Doe}}} % WRONG!
+    
+    will generate an error. 
+  
+    Note that font size/attribute changes will now persists across \\
+    within \author. (But, not across author blocks nor across \and.)
+    However, with the new commands, there should be no need to alter any
+    font attributes within \author. All text sizing and spacing within 
+    \author{} and the author block commands is per IEEE specs for both 
+    conference and journal modes. (In conference mode, the author names
+    are only very slightly larger than the affiliations which are in normal
+    size.) For specialized applications you can alter the justification of
+    author lines by placing \hfill at the beginning or at the end of a line.
+    The interline spacing within \author is determined by the font
+    attributes that are in effect at the end of each line within author.
+ 
+14) Because the titles and author name blocks use different font
+    sizes/styles from the main text, it was possible that two column papers
+    with titles that span both columns (standard journal and conference
+    papers, but not technotes) with certain numbers of lines for the title
+    and authors' name/affiliations can cause underfull vbox problems
+    (paragraphs with large spacings between them) in the second column of
+    the main text on the title page - if there were no new sections,
+    equations or figures in this column (they would provide some needed
+    rubber spacing). The use of things like special paper notices and
+    publisher ID marks also affected this issue. The problem could not
+    happen in the first column because the first column has a rubber length
+    around the heading of the first section. Furthermore, problems seldom
+    occurred on pages after the first as the margins had been chosen not to
+    cause it with the popular font sizes. Rubber lengths after the author
+    names would not fix this problem.
+       Auto-calculating a "good" spacing after the title is a tad difficult
+    to do in LaTeX. However, I am pleased to report that V1.6 has this new
+    capability - "dynamically determined title spacing". IEEEtran will now
+    measure the height of all the title and author text in \maketitle
+    and then calculate a rigid (non-rubber) spacer to follow that meets
+    IEEE specs and also produces a \textheight on the title page that
+    ensures an integer number of normalsized lines on the rest of the page.
+    Single column  papers, and two column papers with the title entirely in
+    column one (technotes) do not need dynamic rigid spacing and therefore
+    use standard rubber spacers.
+    
+    Note: This problem can still crop up if you use floats that span both
+    columns (i.e., figure*). It has been a decade+ long limitation with
+    LaTeX that the stretchable portion of \dbltextfloatsep is ignored. 
+    If you get a problem with underful vbox warnings and paragraphs that
+    "are pulled apart" on page with a float that spans both columns, tweak
+    the space between the figure and the main text a little:
+    
+    \vskip 5pt
+    \end{figure*}
+    
+    If you can't find a value that fixes both columns, you are going to
+    have to put a rubber spacer somewhere in one or both of the columns.
+15) Because of change #14 above, those of you using \pubid will, as of V1.6,
+    have to place it *before* \maketitle in order for it have the intended 
+    affect. The dynamic spacer algorithm must see if you are using \pubid
+    when \maketitle is called. \pubidadjcol works as before except that it
+    now has additional logic to prevent it from doing anything if \pubid
+    was never called.
+    
+16) In some unusual, non-standard circumstances, an author may desire to
+    alter the spacing after the title area or put some unusual text above
+    the main text. For instance, to stop a bad break when a new section
+    occurs right at the start of the second page. This is difficult to do
+    when the title spans both columns of two column text since LaTeX treats
+    such title text as a type of float. A new command,
+    \IEEEaftertitletext{}, gives access to the end of that produced by
+    \maketitle. The types of things that can go into \IEEEaftertitletext
+    are the same as those into \twocolumn[] - no \par, but \\ are OK. There
+    is no restriction on the range of spacings that can be used. e.g.,
+    \IEEEaftertitletext{\vspace{-100pt}} will push the main text well into
+    the title and \IEEEaftertitletext{\vspace{100pt}} will push it far down
+    the page. You will have complete control. If used, place
+    \IEEEaftertitletext{} before \maketitle like \title and \author.
+    IEEEtran's dynamic title spacing intentionally does not take into
+    consideration the contents of \IEEEaftertitletext{} when determining
+    the spacer after the title area (otherwise it would try to second
+    guess you), so the user will have manually adjust the height of the
+    contents in \IEEEaftertitletext{} if the problem discussed in #14 above
+    should develop. A safe bet is to keep the height of contents of
+    \IEEEaftertitletext{} to integer multiples of \baselineskip, e.g.,
+    \IEEEaftertitletext{\vspace{-1\baselineskip}} 
+    
+    Because it can result in an IEEE nonstandard format, the use of
+    \IEEEaftertitletext{} is discouraged. Possible uses include (1) the use
+    of IEEEtran for non-IEEE work with different title spacing requirements,
+    or (2) as an emergency manual override if a problem should develop in 
+    IEEEtran's automatic spacing algorithm.
+ 
+17) completely rewritten \PARstart to:
+    a. no longer have problems when the user begins an environment
+       within the paragraph that uses \PARstart.
+    b. auto-detect and use the current font family
+    c. revise handling of the space at the end of the first word so that
+       interword glue will now work as normal.
+    d. produce correctly aligned edges for the (two) indented lines.
+
+    Because the current font family is now auto-detected, there is no
+    longer any need for \CMPARstart - it is now the same as \PARstart.
+   
+18) There is now a new "open box" Q.E.D. symbol (\QEDopen) as well as the
+    original default (\QED) closed one (\QEDclosed). Some journals use
+    the open form. To make \proof use the open form, just do:
+    \renewcommand{\QED}{\QEDopen}
+
+19) Additional \typeout{} notices added to warn the user when unusual 
+    settings/commands are detected or as reminders to avoid common errors
+    when in conference mode.
+
+20) IEEEtran now provides \abovecaptionskip and \belowcaptionskip skip
+    registers because article class provides them and some packages
+    may error if they are missing. However, IEEEtran only uses 
+    \abovecaptionskip for actual caption spacing.
+
+21) Fixed bug that prevented users from redefining the section headings
+    to use arabic digits. Thanks to Richardt H. Wilkinson for reporting
+    this bug.
+
+22) Code cleaned up to be more efficient with the use of TeX registers;
+    removed some old LaTeX 2.09 code; revised option processing to 
+    LaTeX2e standard; eliminated unwanted "phantom" spaces in some
+    environments.
+
+23) Added new \IEEEeqnarray, \IEEEeqnarraybox, \IEEEeqnarrayboxm and 
+    \IEEEeqnarrayboxt environments to provide superior alternatives to the
+    standard LaTeX \eqnarray, \array and \tabular. Additional new support
+    commands include \IEEEeqnarraydecl, \IEEEeqnarrayboxdecl,
+    \IEEEeqnarraymathstyle, \IEEEeqnarraytextstyle, \yesnumber.
+    \IEEEnonumber, \IEEEyesnumber, \IEEEyessubnumber, \IEEEeqnarraynumspace,
+    \IEEEeqnarraymulticol, \IEEEeqnarrayomit, \IEEEeqnarraydefcol,
+    \IEEEeqnarraydefcolsep, \IEEEeqnarrayseprow, \IEEEeqnarrayseprowcut,
+    \IEEEeqnarrayrulerow, \IEEEeqnarraydblrulerowcut,
+    \IEEEeqnarraystrutmode, \IEEEeqnarraystrutsize,
+    \IEEEeqnarraystrutsizeadd, \IEEEvisiblestrutstrue,
+    \IEEEvisiblestrutsfalse and \IEEEstrut.
+    These are documented in the user's guide.
+    
+24) V1.6 changed back to using () around theorem names (which are also now
+    in italics) as this is what IEEE is using now. Thanks to Christian Peel
+    for reporting this. Also, when section numbers are used as the first
+    part of theorem numbers, display them in arabic, not Roman.
+    
+25) New \IEEEtriggeratref{X} command allows a page break to be triggered
+    just before the given reference number "X". This is most useful when
+    balancing the columns on the last page and a \newpage between references
+    is desired. \IEEEtriggercmd{X} allows a different command to be executed
+    at trigger.
+
+
+
+*******
+ 7/2001 V1.5 (MDS) changes:
+
+
+ 1) Fixed \and within \author bug: (! Misplaced \crcr. \endtabular ->\crcr)
+    Thanks to Rainer Dorsch for discovering and reporting that \and 
+    did not work.
+    
+ 2) Fixed the biography environment so that if a biography's text is shorter
+    than the area allocated for the photo, a collision with the next
+    biography does not occur. You can now put real graphics (using the
+    graphicx package) into the biography photo box with a new optional 
+    argument of the biography command! For example:
+    
+    \begin{biography}[{\includegraphics[width=1in,height=1.25in,clip,
+                      keepaspectratio]{./tux.eps}}]{Linux Penguin}
+    
+    will use the specified graphic as the author's photo. The photo area is
+    exactly 1in wide by 1.25in high - as is done in IEEE Transactions. Try
+    to keep the same 4:5 aspect ratio if scanning/cropping your photos. 
+    Note the need for the extra set of enclosing braces around the
+    \includegraphics. Without it, The LaTeX parser may get confused when it
+    sees the \includegraphics's brackets within the biography's optional
+    argument. Due to the length of the \includegraphics command, you may
+    wish to define your own shorthand form of it. I have not done so with
+    IEEEtran to prevent dependence on the graphicx package. If you do not
+    use the optional argument, or leave it empty, a standard frame box
+    with the words "Place Photo Here" will be used. If you want the space
+    to remain completely empty, you can do:
+    
+    \begin{biography}[\mbox{}]{The Invisible Man} 
+    
+    The interface to biography's optional argument is into a
+    1in X 1.25in minipage in which the argument text is centered both 
+    horizontally and vertically:
+    
+    \begin{minipage}[b][1.25in][c]{1in}%
+    \centering
+    #1%
+    \end{minipage}
+    
+    Within the biography environment, \unitlength is set to 1in.
+    With this in mind, you can even design your own custom frameboxes.
+    For instance:
+    
+    \begin{biography}[\framebox(1,1.25){\parbox[][\height
+                     ][c]{0.9in}{\centering PLACE\\ PHOTO\\
+                                  HERE}}]{Author Name}
+    
+    will yield the same type of result as the default photo box.
+    
+    Thanks to Herbert Voss for discovering the collision bug, suggesting
+    the ability to handle graphics and providing some prototype code.
+
+
+
+*******
+ 3/2001 V1.4 (MDS) changes:
+
+
+ 1) New "draftcls" and "final" options have been added.
+    Thanks to Dragan Cvetkovic for suggesting an option like draftcls.
+    
+ 2) Documentation changes to reflect the fact that this IEEEtran.cls 
+    is no longer beta test.
+
+ 3) Slightly revised caption sizes. Figure and table captions are now 
+    in \footnotesize, not \small as before.
+
+ 4) Allow user to control figure caption justification. IEEEtran.cls 
+    normally defaults to left justified as is done in Transactions.
+    However, for conferences, you may wish to issue the command:
+    \centerfigcaptionstrue
+    in the preamble. Short (less than one line long) figure captions
+    will then be centered. Multi-line figure captions will always be 
+    properly left justified. V1.6: This is already done for you when
+    using the conference mode.
+
+
+
+*******
+ 1/2001 V1.3 
+ Michael Shell (MDS) made extensive changes and additions:
+
+
+ BUGS FIXED (and many others too numerous to mention!):
+ 1) Fixed improper alignment with itemized, enumerated and
+    description lists. Added new controls to these three
+    environments so that it is easy to get the alignment IEEE
+    uses. Furthermore, the itemize, enumerate and description lists
+    no longer force a new paragraph to begin at the end the list
+    (\par). (Sometimes lists are used within paragraphs.) 
+ 
+ 2) JVH's fixes now allow things like $\mathbf{N}(0,P(0))$
+    to work properly without needing the extra braces:
+    ${\mathbf{N}}(0,P(0))$. There is no longer any dependence
+    on the "rawfonts" and "oldlfont" packages. Thanks Juergen! 
+ 
+ 3) Fixed underfull hbox errors and incorrect reference number
+    alignment when the number of references in the bibliography
+    exceeded 9 entries (which is almost every paper!).
+  
+ 4) Removed dependence on the LaTeX sizexx.clo files.
+    Now, 9pt documents should work correctly even on systems that
+    lack a size9.clo file. This is most often used in conjunction
+    with the option "technote" for "correspondence" papers like those
+    in IEEE Transactions on Information Theory. For virtually all
+    other papers, 10pt is used and so it is the default.
+    Some improper font sizes have been corrected. \footnotesize is
+    now 8pt in 9pt docs, so footnotes in technotes should be the
+    correct size now. 
+ 
+ 5) Added \interlinepenalty within the bibliography section to discourage
+    LaTeX from breaking within a reference. IEEE almost never breaks within
+    a reference and when they do it is usually in technotes
+    (correspondence papers). You may get an underfull vbox warning in the
+    bibliography indicating that the spacing just before the "REFERENCES" 
+    section is larger than normal, but the final result will be more like 
+    what IEEE will publish. See the comments in the BIBLIOGRAPHY section
+    around line 2034 below if you want to change this behavior.
+
+ 6) No longer "blows up" when you use \paragraph and have a table
+    of contents.
+ 
+ 7) Theorem environment changed, (but for V1.6, back to the old way, sigh).
+ 
+ 8) Figure captions adjusted: IEEE left (not center) justifies
+    figure captions (for journals) and does not indent figure caption text.
+ 
+ 9) Adjusted some spacings in the table of contents(TOC))/list-of-figures/
+    list-of-tables so that section/table numbers will not so easily 
+    collide with the titles. Section VIII was usually the worst offender.
+    Still doesn't right justify the section numbers, but neither does 
+    article.cls (This must be why LaTeX likes the x.y.z section numbering
+    scheme unlike I, II, III, etc. of IEEE. )
+    It may be "normal" as it is (left justified). sigh.
+ 
+10) Now uses "index terms" now as a heading instead of "keywords".
+    Furthermore, the "index terms" and "abstract" headings are in bold
+    italic. This is how IEEE does things.
+
+11) \thebibliography and \biography now put entries into
+    the table of contents for you.
+
+*******
+
+
+
+
+
+
+ *******
+ 9/2000 (JVH) changes: (now designated as V1.2)
+ 
+ made some corrections to get closer to LaTeX2e
+ 20000906 Juergen v.Hagen
+ vonhagen@ihefiji.etec.uni-karlsruhe.de
+
+ Permission to redistribute granted as of December 2000.
+ *******
+
+
+
+
+
+ *******
+ 
+ 1996 (JWD) LaTeX2e version: (now designated as V1.1)
+  
+ In the most recent TeXhax digest, there was a request for a copy of
+ IEEEtrans.sty modified to work with LaTeX2e.  I have a version I
+ modified to make it IEEEtrans.cls, which I have sent to the person
+ making the request and am now sending to you to consider posting to
+ the archives.
+ --
+ Jon Dixon
+ dixonj@colorado.edu
+ http://spot.colorado.edu/~dixonj/
+
+*******
+
+
+
+
+
+*******
+
+ 30-August-1993 original LaTeX 2.09 version (IEEEtran.sty),
+ (now designated as V1.0):
+
+ by Gerry Murray and Silvano Balemi
+ Automatic Control Lab, ETH Zurich, Switzerland
+ balemi@aut.ee.ethz.ch
+
+*******
+
+
+

--- a/ieee/footer.tex
+++ b/ieee/footer.tex
@@ -1,0 +1,12 @@
+% Bibliography
+
+\ifx\bibliostyle\undefined
+  \bibliographystyle{IEEEtran}
+\else
+  \bibliographystyle{\bibliostyle}
+\fi
+
+\ifx\bibliocommand\undefined
+\else
+  \bibliocommand
+\fi

--- a/ieee/setup.tex
+++ b/ieee/setup.tex
@@ -1,0 +1,439 @@
+
+%% bare_conf.tex
+%% V1.3
+%% 2007/01/11
+%% by Michael Shell
+%% See:
+%% http://www.michaelshell.org/
+%% for current contact information.
+%%
+%% This is a skeleton file demonstrating the use of IEEEtran.cls
+%% (requires IEEEtran.cls version 1.7 or later) with an IEEE conference paper.
+%%
+%% Support sites:
+%% http://www.michaelshell.org/tex/ieeetran/
+%% http://www.ctan.org/tex-archive/macros/latex/contrib/IEEEtran/
+%% and
+%% http://www.ieee.org/
+
+%%*************************************************************************
+%% Legal Notice:
+%% This code is offered as-is without any warranty either expressed or
+%% implied; without even the implied warranty of MERCHANTABILITY or
+%% FITNESS FOR A PARTICULAR PURPOSE!
+%% User assumes all risk.
+%% In no event shall IEEE or any contributor to this code be liable for
+%% any damages or losses, including, but not limited to, incidental,
+%% consequential, or any other damages, resulting from the use or misuse
+%% of any information contained here.
+%%
+%% All comments are the opinions of their respective authors and are not
+%% necessarily endorsed by the IEEE.
+%%
+%% This work is distributed under the LaTeX Project Public License (LPPL)
+%% ( http://www.latex-project.org/ ) version 1.3, and may be freely used,
+%% distributed and modified. A copy of the LPPL, version 1.3, is included
+%% in the base LaTeX documentation of all distributions of LaTeX released
+%% 2003/12/01 or later.
+%% Retain all contribution notices and credits.
+%% ** Modified files should be clearly indicated as such, including  **
+%% ** renaming them and changing author support contact information. **
+%%
+%% File list of work: IEEEtran.cls, IEEEtran_HOWTO.pdf, bare_adv.tex,
+%%                    bare_conf.tex, bare_jrnl.tex, bare_jrnl_compsoc.tex
+%%*************************************************************************
+
+% *** Authors should verify (and, if needed, correct) their LaTeX system  ***
+% *** with the testflow diagnostic prior to trusting their LaTeX platform ***
+% *** with production work. IEEE's font choices can trigger bugs that do  ***
+% *** not appear when using other class files.                            ***
+% The testflow support page is at:
+% http://www.michaelshell.org/tex/testflow/
+
+
+
+% Note that the a4paper option is mainly intended so that authors in
+% countries using A4 can easily print to A4 and see how their papers will
+% look in print - the typesetting of the document will not typically be
+% affected with changes in paper size (but the bottom and side margins will).
+% Use the testflow package mentioned above to verify correct handling of
+% both paper sizes by the user's LaTeX system.
+%
+% Also note that the "draftcls" or "draftclsnofoot", not "draft", option
+% should be used if it is desired that the figures are to be displayed in
+% draft mode.
+%
+\documentclass[conference]{IEEEtran}
+% Add the compsoc option for Computer Society conferences.
+%
+% If IEEEtran.cls has not been installed into the LaTeX system files,
+% manually specify the path to it like:
+% \documentclass[conference]{../sty/IEEEtran}
+
+
+
+
+
+% Some very useful LaTeX packages include:
+% (uncomment the ones you want to load)
+
+
+% *** MISC UTILITY PACKAGES ***
+%
+%\usepackage{ifpdf}
+% Heiko Oberdiek's ifpdf.sty is very useful if you need conditional
+% compilation based on whether the output is pdf or dvi.
+% usage:
+% \ifpdf
+%   % pdf code
+% \else
+%   % dvi code
+% \fi
+% The latest version of ifpdf.sty can be obtained from:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/oberdiek/
+% Also, note that IEEEtran.cls V1.7 and later provides a builtin
+% \ifCLASSINFOpdf conditional that works the same way.
+% When switching from latex to pdflatex and vice-versa, the compiler may
+% have to be run twice to clear warning/error messages.
+
+
+
+
+
+
+% *** CITATION PACKAGES ***
+%
+%\usepackage{cite}
+% cite.sty was written by Donald Arseneau
+% V1.6 and later of IEEEtran pre-defines the format of the cite.sty package
+% \cite{} output to follow that of IEEE. Loading the cite package will
+% result in citation numbers being automatically sorted and properly
+% "compressed/ranged". e.g., [1], [9], [2], [7], [5], [6] without using
+% cite.sty will become [1], [2], [5]--[7], [9] using cite.sty. cite.sty's
+% \cite will automatically add leading space, if needed. Use cite.sty's
+% noadjust option (cite.sty V3.8 and later) if you want to turn this off.
+% cite.sty is already installed on most LaTeX systems. Be sure and use
+% version 4.0 (2003-05-27) and later if using hyperref.sty. cite.sty does
+% not currently provide for hyperlinked citations.
+% The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/cite/
+% The documentation is contained in the cite.sty file itself.
+
+
+
+
+
+
+% *** GRAPHICS RELATED PACKAGES ***
+%
+\ifCLASSINFOpdf
+  % \usepackage[pdftex]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../pdf/}{../jpeg/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.pdf,.jpeg,.png}
+\else
+  % or other class option (dvipsone, dvipdf, if not using dvips). graphicx
+  % will default to the driver specified in the system graphics.cfg if no
+  % driver is specified.
+  % \usepackage[dvips]{graphicx}
+  % declare the path(s) where your graphic files are
+  % \graphicspath{{../eps/}}
+  % and their extensions so you won't have to specify these with
+  % every instance of \includegraphics
+  % \DeclareGraphicsExtensions{.eps}
+\fi
+% graphicx was written by David Carlisle and Sebastian Rahtz. It is
+% required if you want graphics, photos, etc. graphicx.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/graphics/
+% Another good source of documentation is "Using Imported Graphics in
+% LaTeX2e" by Keith Reckdahl which can be found as epslatex.ps or
+% epslatex.pdf at: http://www.ctan.org/tex-archive/info/
+%
+% latex, and pdflatex in dvi mode, support graphics in encapsulated
+% postscript (.eps) format. pdflatex in pdf mode supports graphics
+% in .pdf, .jpeg, .png and .mps (metapost) formats. Users should ensure
+% that all non-photo figures use a vector format (.eps, .pdf, .mps) and
+% not a bitmapped formats (.jpeg, .png). IEEE frowns on bitmapped formats
+% which can result in "jaggedy"/blurry rendering of lines and letters as
+% well as large increases in file sizes.
+%
+% You can find documentation about the pdfTeX application at:
+% http://www.tug.org/applications/pdftex
+
+
+
+
+
+% *** MATH PACKAGES ***
+%
+%\usepackage[cmex10]{amsmath}
+% A popular package from the American Mathematical Society that provides
+% many useful and powerful commands for dealing with mathematics. If using
+% it, be sure to load this package with the cmex10 option to ensure that
+% only type 1 fonts will utilized at all point sizes. Without this option,
+% it is possible that some math symbols, particularly those within
+% footnotes, will be rendered in bitmap form which will result in a
+% document that can not be IEEE Xplore compliant!
+%
+% Also, note that the amsmath package sets \interdisplaylinepenalty to 10000
+% thus preventing page breaks from occurring within multiline equations. Use:
+%\interdisplaylinepenalty=2500
+% after loading amsmath to restore such page breaks as IEEEtran.cls normally
+% does. amsmath.sty is already installed on most LaTeX systems. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/amslatex/math/
+
+
+
+
+
+% *** SPECIALIZED LIST PACKAGES ***
+%
+%\usepackage{algorithmic}
+% algorithmic.sty was written by Peter Williams and Rogerio Brito.
+% This package provides an algorithmic environment fo describing algorithms.
+% You can use the algorithmic environment in-text or within a figure
+% environment to provide for a floating algorithm. Do NOT use the algorithm
+% floating environment provided by algorithm.sty (by the same authors) or
+% algorithm2e.sty (by Christophe Fiorio) as IEEE does not use dedicated
+% algorithm float types and packages that provide these will not provide
+% correct IEEE style captions. The latest version and documentation of
+% algorithmic.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithms/
+% There is also a support site at:
+% http://algorithms.berlios.de/index.html
+% Also of interest may be the (relatively newer and more customizable)
+% algorithmicx.sty package by Szasz Janos:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/algorithmicx/
+
+
+
+
+% *** ALIGNMENT PACKAGES ***
+%
+%\usepackage{array}
+% Frank Mittelbach's and David Carlisle's array.sty patches and improves
+% the standard LaTeX2e array and tabular environments to provide better
+% appearance and additional user controls. As the default LaTeX2e table
+% generation code is lacking to the point of almost being broken with
+% respect to the quality of the end results, all users are strongly
+% advised to use an enhanced (at the very least that provided by array.sty)
+% set of table tools. array.sty is already installed on most systems. The
+% latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/required/tools/
+
+
+%\usepackage{mdwmath}
+%\usepackage{mdwtab}
+% Also highly recommended is Mark Wooding's extremely powerful MDW tools,
+% especially mdwmath.sty and mdwtab.sty which are used to format equations
+% and tables, respectively. The MDWtools set is already installed on most
+% LaTeX systems. The lastest version and documentation is available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/mdwtools/
+
+
+% IEEEtran contains the IEEEeqnarray family of commands that can be used to
+% generate multiline equations as well as matrices, tables, etc., of high
+% quality.
+
+
+%\usepackage{eqparbox}
+% Also of notable interest is Scott Pakin's eqparbox package for creating
+% (automatically sized) equal width boxes - aka "natural width parboxes".
+% Available at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/eqparbox/
+
+
+
+
+
+% *** SUBFIGURE PACKAGES ***
+%\usepackage[tight,footnotesize]{subfigure}
+% subfigure.sty was written by Steven Douglas Cochran. This package makes it
+% easy to put subfigures in your figures. e.g., "Figure 1a and 1b". For IEEE
+% work, it is a good idea to load it with the tight package option to reduce
+% the amount of white space around the subfigures. subfigure.sty is already
+% installed on most LaTeX systems. The latest version and documentation can
+% be obtained at:
+% http://www.ctan.org/tex-archive/obsolete/macros/latex/contrib/subfigure/
+% subfigure.sty has been superceeded by subfig.sty.
+
+
+
+%\usepackage[caption=false]{caption}
+%\usepackage[font=footnotesize]{subfig}
+% subfig.sty, also written by Steven Douglas Cochran, is the modern
+% replacement for subfigure.sty. However, subfig.sty requires and
+% automatically loads Axel Sommerfeldt's caption.sty which will override
+% IEEEtran.cls handling of captions and this will result in nonIEEE style
+% figure/table captions. To prevent this problem, be sure and preload
+% caption.sty with its "caption=false" package option. This is will preserve
+% IEEEtran.cls handing of captions. Version 1.3 (2005/06/28) and later
+% (recommended due to many improvements over 1.2) of subfig.sty supports
+% the caption=false option directly:
+%\usepackage[caption=false,font=footnotesize]{subfig}
+%
+% The latest version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/subfig/
+% The latest version and documentation of caption.sty can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/caption/
+
+
+
+
+% *** FLOAT PACKAGES ***
+%
+%\usepackage{fixltx2e}
+% fixltx2e, the successor to the earlier fix2col.sty, was written by
+% Frank Mittelbach and David Carlisle. This package corrects a few problems
+% in the LaTeX2e kernel, the most notable of which is that in current
+% LaTeX2e releases, the ordering of single and double column floats is not
+% guaranteed to be preserved. Thus, an unpatched LaTeX2e can allow a
+% single column figure to be placed prior to an earlier double column
+% figure. The latest version and documentation can be found at:
+% http://www.ctan.org/tex-archive/macros/latex/base/
+
+
+
+%\usepackage{stfloats}
+% stfloats.sty was written by Sigitas Tolusis. This package gives LaTeX2e
+% the ability to do double column floats at the bottom of the page as well
+% as the top. (e.g., "\begin{figure*}[!b]" is not normally possible in
+% LaTeX2e). It also provides a command:
+%\fnbelowfloat
+% to enable the placement of footnotes below bottom floats (the standard
+% LaTeX2e kernel puts them above bottom floats). This is an invasive package
+% which rewrites many portions of the LaTeX2e float routines. It may not work
+% with other packages that modify the LaTeX2e float routines. The latest
+% version and documentation can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/sttools/
+% Documentation is contained in the stfloats.sty comments as well as in the
+% presfull.pdf file. Do not use the stfloats baselinefloat ability as IEEE
+% does not allow \baselineskip to stretch. Authors submitting work to the
+% IEEE should note that IEEE rarely uses double column equations and
+% that authors should try to avoid such use. Do not be tempted to use the
+% cuted.sty or midfloat.sty packages (also by Sigitas Tolusis) as IEEE does
+% not format its papers in such ways.
+
+
+
+
+
+% *** PDF, URL AND HYPERLINK PACKAGES ***
+%
+%\usepackage{url}
+% url.sty was written by Donald Arseneau. It provides better support for
+% handling and breaking URLs. url.sty is already installed on most LaTeX
+% systems. The latest version can be obtained at:
+% http://www.ctan.org/tex-archive/macros/latex/contrib/misc/
+% Read the url.sty source comments for usage information. Basically,
+% \url{my_url_here}.
+
+
+
+
+
+% *** Do not adjust lengths that control margins, column widths, etc. ***
+% *** Do not use packages that alter fonts (such as pslatex).         ***
+% There should be no need to do such things with IEEEtran.cls V1.6 and later.
+% (Unless specifically asked to do so by the journal or conference you plan
+% to submit to, of course. )
+
+
+% correct bad hyphenation here
+\hyphenation{op-tical net-works semi-conduc-tor}
+
+
+\begin{document}
+%
+% paper title
+% can use linebreaks \\ within to get better formatting as desired
+\title{\mytitle}
+
+
+% author names and affiliations
+% use a multiple column layout for up to three different
+% affiliations
+\author{\myauthor}
+
+% conference papers do not typically use \thanks and this command
+% is locked out in conference mode. If really needed, such as for
+% the acknowledgment of grants, issue a \IEEEoverridecommandlockouts
+% after \documentclass
+
+% for over three affiliations, or if they all won't fit within the width
+% of the page, use this alternative format:
+%
+%\author{\IEEEauthorblockN{Michael Shell\IEEEauthorrefmark{1},
+%Homer Simpson\IEEEauthorrefmark{2},
+%James Kirk\IEEEauthorrefmark{3},
+%Montgomery Scott\IEEEauthorrefmark{3} and
+%Eldon Tyrell\IEEEauthorrefmark{4}}
+%\IEEEauthorblockA{\IEEEauthorrefmark{1}School of Electrical and Computer Engineering\\
+%Georgia Institute of Technology,
+%Atlanta, Georgia 30332--0250\\ Email: see http://www.michaelshell.org/contact.html}
+%\IEEEauthorblockA{\IEEEauthorrefmark{2}Twentieth Century Fox, Springfield, USA\\
+%Email: homer@thesimpsons.com}
+%\IEEEauthorblockA{\IEEEauthorrefmark{3}Starfleet Academy, San Francisco, California 96678-2391\\
+%Telephone: (800) 555--1212, Fax: (888) 555--1212}
+%\IEEEauthorblockA{\IEEEauthorrefmark{4}Tyrell Inc., 123 Replicant Street, Los Angeles, California 90210--4321}}
+
+
+
+
+% use for special paper notices
+%\IEEEspecialpapernotice{(Invited Paper)}
+
+
+
+
+% make the title area
+\maketitle
+
+
+\begin{abstract}
+%\boldmath
+\myabstract
+\end{abstract}
+% IEEEtran.cls defaults to using nonbold math in the Abstract.
+% This preserves the distinction between vectors and scalars. However,
+% if the conference you are submitting to favors bold math in the abstract,
+% then you can use LaTeX's standard command \boldmath at the very start
+% of the abstract to achieve this. Many IEEE journals/conferences frown on
+% math in the abstract anyway.
+
+% no keywords
+
+
+
+
+% For peer review papers, you can put extra information on the cover
+% page as needed:
+% \ifCLASSOPTIONpeerreview
+% \begin{center} \bfseries EDICS Category: 3-BBND \end{center}
+% \fi
+%
+% For peerreview papers, this IEEEtran command inserts a page break and
+% creates the second title. It will be ignored for other modes.
+\IEEEpeerreviewmaketitle
+
+
+
+
+% conference papers do not normally have an appendix
+
+
+\ifx\myacknowledgment\undefined
+\else
+% use section* for acknowledgement
+\section*{Acknowledgment}
+
+
+\myacknowledgement
+
+
+\fi

--- a/mmd-latex-template-footer.tex
+++ b/mmd-latex-template-footer.tex
@@ -1,0 +1,7 @@
+% Back Matter
+\if@mainmatter
+  we're in main
+  \backmatter
+\fi
+
+\input{\latextemplate/footer}

--- a/mmd-latex-template.tex
+++ b/mmd-latex-template.tex
@@ -1,0 +1,17 @@
+% This template provides basic hooks for integrating a pre-existing
+% LaTeX template into a MultiMarkdown framework. This allows
+% writing academic papers which often provide strict style
+% guidelines to be easily written in MultiMarkdown. In order to
+% to accomplish this, three lines of metadata must be used in the
+% MultiMarkdown file:
+% latex template: foo - which specifies which subfolder contains
+% the latex template
+% latex input: mmd-latex-template - uses the template name to load
+% the desired template
+% latex footer: mmd-latex-template-footer - adds the template
+% specified footer
+
+% Author: Jason Ziglar <jpz@vt.edu>
+
+
+\input{\latextemplate/setup}


### PR DESCRIPTION
This adds a method for taking pre-defined LaTeX templates such as those for academic papers, and allows it to be easily used with MultiMarkdown. This includes one such template (the IEEE conference template) as an example, but more can be added by adding subfolders with the appropriate material.

To use a template, the MultiMarkdown metadata simply has to include:
```
latex template: $template
latex input: mmd-latex-template
latex footer: mmd-latex-template-footer
```

where $template is a directory which includes a `setup.tex` for the body of the template, and a `footer.tex` for the footer.